### PR TITLE
adds file use instructions to best practices

### DIFF
--- a/terraform/steering/terraform-best-practices.md
+++ b/terraform/steering/terraform-best-practices.md
@@ -24,13 +24,17 @@ module/
 └── README.md        # Docs
 ```
 
+Add new resources to the `main.tf` file. Once this file contains more than 15 resources, put additional resources into their own separate .tf files. For example, if adding OpenSearch resources, put them in a file named, `opensearch.tf`.
+
+Always add new outputs to the `outputs.tf` file.
+
 ## Variables
 
 ```hcl
 variable "environment" {
   description = "Deployment environment"
   type        = string
-  
+
   validation {
     condition     = contains(["dev", "staging", "prod"], var.environment)
     error_message = "Must be dev, staging, or prod."
@@ -51,7 +55,7 @@ variable "database_password" {
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "5.1.0"
-  
+
   name = "my-vpc"
   cidr = "10.0.0.0/16"
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In my testing, the current Power adds new resources and outputs to separate files. This change adds a prompt to use the `main.tf` and `outputs.tf` by default.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
