### PR TITLE
Add smus-upgrade-agent

### DIFF
--- a/spark-troubleshooting-agent/POWER.md
+++ b/spark-troubleshooting-agent/POWER.md
@@ -34,7 +34,7 @@ Before proceeding, ensure the following are installed:
 
 ## Step 2: Deploy CloudFormation Stack
 
-**Note**: If you already have a role configured with `sagemaker-unified-studio-mcp` permissions, please ignore. However, it is recommended to deploy the stack as will contain latest updatest for permissions and role policies
+**Note**: If the customer already has a role configured with `sagemaker-unified-studio-mcp` permissions, please ignore this step, get the AWS CLI profile for that role from the customer and configure your (Kiro's) mcp.json file (typically located at `~/.kiro/settings/mcp.json`) with that profile. However, it is recommended to deploy the stack as will contain latest updates for permissions and role policies
 
 1. Log into the AWS Console with the role your AWS CLI is configured with - this role must have permissions to deploy Cloud Formation stacks.
 1. Navigate to [troubleshooting agent setup page](https://docs.aws.amazon.com/emr/latest/ReleaseGuide/spark-troubleshooting-agent-setup.html#spark-troubleshooting-agent-setup-resources).

--- a/spark-upgrade-agent/POWER.md
+++ b/spark-upgrade-agent/POWER.md
@@ -1,0 +1,260 @@
+---
+name: "spark-upgrade-agent"
+displayName: "Upgrade Spark applications on Amazon EMR"
+description: "Accelerate Apache Spark version upgrades with conversational AI that automates code transformation, dependency resolution, and validation testing. Supports PySpark and Scala on EMR EC2 and EMR Serverless."
+keywords: ["spark", "emr", "upgrade", "migration", "automation", "code-transformation", "pyspark", "scala", "aws"]
+author: "AWS"
+---
+
+# [Onboarding](https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-spark-upgrade-agent-setup.html)
+
+## Step 1: Validate Prerequisites
+
+Before proceeding, ensure the following are installed:
+
+- **AWS CLI**: Required for AWS authentication
+  - Verify with: `aws --version`
+  - Install: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
+
+- **Python 3.10+**: Required for MCP proxy
+  - Verify with: `python3 --version`
+  - Install: https://www.python.org/downloads/release/python-3100/
+
+- **uv package manager**: Required for MCP Proxy for AWS
+  - Verify with: `uv --version`
+  - Install: https://docs.astral.sh/uv/getting-started/installation/
+
+- **AWS Credentials**: Must be configured
+  - Verify with: `aws sts get-caller-identity`
+  - Configure via AWS CLI, environment variables, or IAM roles
+  - Identify the AWS Profile that the creds are configured for
+    - You can do this with `echo ${AWS_PROFILE}`. No response likely means they are using the `default` profile
+    - use this profile later when configuring the `spark-upgrade-profile`
+
+**CRITICAL**: If any prerequisites are missing, DO NOT proceed. Install missing components first.
+
+## Step 2: Deploy CloudFormation Stack
+
+**Note**: If the customer already has a role configured with `sagemaker-unified-studio-mcp` permissions, please ignore this step, get the AWS CLI profile for that role from the customer and configure your (Kiro's) mcp.json file (typically located at `~/.kiro/settings/mcp.json`) with that profile. However, it is recommended to deploy the stack as will contain latest updates for permissions and role policies
+
+1. Log into the AWS Console with the role your AWS CLI is configured with - this role must have permissions to deploy Cloud Formation stacks.
+1. Navigate to [upgrade agent setup page](https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-spark-upgrade-agent-setup.html).
+1. Deploy Cfn stack / resources to desired region
+1. **Configure parameters** on the "Specify stack details" page:
+   - **SparkUpgradeIAMRoleName**: Name of the IAM role for Spark upgrade process
+   - **EnableEMREC2**: Enable EMR-EC2 upgrade permissions (default: true)
+   - **EnableEMRServerless**: Enable EMR-Serverless upgrade permissions (default: true)
+   - **StagingBucketPath**: S3 path for staging artifacts (e.g., `s3://my-bucket/spark-upgrade` or leave empty to auto-generate)
+   - **UseS3Encryption**: Enable KMS encryption for S3 staging bucket (default: false)
+   - **S3KmsKeyArn**: (Optional) ARN of existing KMS key for S3 bucket encryption
+   - **CloudWatchKmsKeyArn**: (Optional) ARN of existing KMS key for CloudWatch Logs encryption
+   - **EMRServerlessS3LogPath**: (Optional) S3 path where EMR-Serverless application logs are stored
+   - **ExecutionRoleToGrantS3Access**: (Optional) IAM Role Name or ARN of existing EMR execution role
+1. **Wait for deployment** to complete successfully.
+
+## Step 3: Configure the AWS CLI with the MCP role and Kiro's mcp.json
+
+1. Prompt the user to provide the region and role ARN from the Cfn stack deployment
+1. Configure the CLI with the `spark-upgrade-profile`
+    ```bash
+    # run these as a single command so the use doesn't have to approve multiple times
+    aws configure set profile.spark-upgrade-profile.source_profile <profile with Cloud Formation deployment permissions from earlier>
+    aws configure set profile.spark-upgrade-profile.role_arn <role arn from Cloud Formation stack, provided by customer>
+    aws configure set profile.spark-upgrade-profile.region <region from Cloud Formation stack, provided by customer>
+    ```
+1. then update your MCP json configuration file (typically located at `~/.kiro/settings/mcp.json`) with the region. Only edit your mcp.json, no other local copies, just the one that configures your mcp settings.
+
+# [Overview](https://docs.aws.amazon.com/emr/latest/ReleaseGuide/spark-upgrades.html)
+
+A fully managed remote MCP server that provides specialized tools and guidance for upgrading Apache Spark applications on Amazon EMR. This server accelerates Spark version upgrades through automated analysis, code transformation, and validation capabilities.
+
+**Important Note**: Not all MCP clients today support remote servers. Please make sure that your client supports remote MCP servers or that you have a suitable proxy setup to use this server.
+
+## [Key Features & Capabilities](https://github.com/awslabs/mcp/blob/main/src/sagemaker-unified-studio-spark-upgrade-mcp-server/README.md#key-features--capabilities)
+
+- **Project Analysis & Planning**: Deep analysis of Spark application structure, dependencies, and API usage to generate comprehensive step-by-step upgrade plans with risk assessment
+- **Automated Code Transformation**: Automated PySpark and Scala code updates for version compatibility, handling API changes and deprecations
+- **Dependency & Build Management**: Update and manage Maven/SBT/pip dependencies and build environments for target Spark versions with iterative error resolution
+- **Comprehensive Testing & Validation**: Execute unit tests, integration tests and EMR validation jobs and validates the upgraded application against target spark version
+- **Data Quality Validation**: Ensure data integrity throughout the upgrade process with validation rules
+- **EMR Integration & Monitoring**: Submit and monitor EMR jobs for upgrade validation across Amazon EMR on EC2 and Amazon EMR Serverless
+- **Observability & Progress Tracking**: Track upgrade progress, analyze results, and provide detailed insights throughout the upgrade process
+
+## [Architecture](https://docs.aws.amazon.com/emr/latest/ReleaseGuide/spark-upgrades.html#emr-spark-upgrade-agent-architecture)
+
+The upgrade agent has three main components: any MCP-compatible AI Assistant in your development environment for interaction, the [MCP Proxy for AWS](https://github.com/aws/mcp-proxy-for-aws) that handles secure communication between your client and the MCP server, and the Amazon SageMaker Unified Studio Managed MCP Server (in preview) that provides specialized Spark upgrade tools for Amazon EMR. This diagram illustrates how you interact with the Amazon SageMaker Unified Studio Managed MCP Server through your AI Assistant.
+
+![img](https://docs.aws.amazon.com/images/emr/latest/ReleaseGuide/images/SparkUpgradeIntroduction.png)
+
+
+The AI assistant will orchestrate the upgrade using specialized tools provided by the MCP server following these steps:
+
+- **Planning**: The agent analyzes your project structure and generates or revises an upgrade plan that guides the end-to-end Spark upgrade process.
+
+- **Compile & Build**: Agent updates the build environment and dependencies, compiles the project, and iteratively fixes build and test failures.
+
+- **Spark code edit tool**: Applies targeted code updates to resolve Spark version incompatibilities, fixing both build-time and runtime errors.
+
+- **Execution & Validation**: Submits remote validation jobs to EMR (on EC2 or Serverless), monitors execution and logs, and iteratively fixes runtime and data-quality issues.
+
+- **Observability**: Tracks upgrade progress using EMR observability tools and allows users to view upgrade analyses and status at any time.
+
+Please refer to [Using Spark Upgrade Tools](https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-spark-upgrade-agent-tools.html) for a list of major tools for each steps.
+
+### [Supported Upgrade Paths](https://docs.aws.amazon.com/emr/latest/ReleaseGuide/spark-upgrades.html#emr-spark-upgrade-agent-architecture)
+- We support Apache Spark upgrades from version 2.4 to 3.5. The corresponding deployment mode mappings are as follows
+- **EMR Release Upgrades**:
+    - For EMR-EC2
+        - Source Version: EMR 5.20.0 and later
+        - Target Version: EMR 7.12.0 and earlier, should be newer than EMR 5.20.0
+
+    - For EMR-Serverless
+        - Source Version: EMR Serverless 6.6.0 and later
+        - Target Version: EMR Serverless 7.12.0 and earlier
+
+## Available MCP Server
+
+### spark-upgrade
+**Connection:** MCP Proxy for AWS
+**Authentication:** AWS IAM role assumption via spark-upgrade-profile
+**Timeout:** 180 seconds
+
+Provides comprehensive Spark upgrade tools including:
+- Project Analysis & Planning
+- Automated Code Transformation
+- Dependency & Build Management
+- Comprehensive Testing & Validation
+- Data Quality Validation
+- EMR Integration & Monitoring
+- Observability & Progress Tracking
+
+## [Usage Examples](https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-spark-upgrade-agent-prompt-examples.html)
+
+1. **Run the spark upgrade analysis**:
+  - EMR-S
+    ```
+    Help me upgrade my spark application in <project-path> from EMR-EC2 version 6.0.0 to 7.12.0. you can use EMR-S Application id xxg017hmd2agxxxx and execution role <role name> to run the validation and s3 paths s3://s3-staging-path to store updated application artifacts.
+    ```
+  - EMR-EC2
+    ```
+    Upgrade my Spark application <local-project-path> from EMR-S version 6.6.0 to 7.12.0. Use EMR-EC2 Cluster j-PPXXXXTG09XX to run the validation and s3 paths s3://s3-staging-path to store updated application artifacts.
+    ```
+
+2. **List the analyses**:
+   ```
+   Provide me a list of analyses performed by the spark agent
+   ```
+
+3. **Describe Analysis**:
+   ```
+   can you explain the analysis 439715b3-xxxx-42a6-xxxx-3bf7f1fxxxx
+   ```
+4. **Reuse Plan for other analysis**:
+    ```
+    Use my upgrade_plan spark_upgrade_plan_xxx.json to upgrade my project in <project-path>
+    ```
+
+## [Full Features and Capabilities](https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-spark-upgrade-agent-features.html)
+
+### Supported Technologies
+
+* Languages: Python and Scala applications
+* Build Systems: Maven and SBT for Scala projects; requirements.txt, Pipfile, and Setuptools for Python projects
+* Target Platforms: Amazon EMR and EMR Serverless
+* Supported Versions: We support Apache Spark upgrades from version 2.4 to 3.5. The corresponding deployment mode mappings are as follows
+  * For EMR-EC2
+    * Source Version: EMR 5.20.0 and later
+    * Target Version: EMR 7.12.0 and earlier, should be newer than EMR 5.20.0
+  * For EMR Serverless
+    * Source Version: EMR Serverless 6.6.0 and later
+    * Target Version: EMR Serverless 7.12.0 and earlier
+
+### What We Upgrade
+
+The upgrade agent provide comprehensive Spark application upgrades:
+
+* Build Configuration: Automatically updates dependency management files (pom.xml, requirements.txt, etc.)
+* Source Code: Fixes API compatibility issues and deprecated method usage
+* Test Code: Ensures unit and integration tests work with the target Spark version
+* Dependencies: Upgrades packaged dependencies to versions compatible with target EMR version
+* Validation: Compiles and validates applications on target EMR clusters
+* Data Quality Analysis: Detects schema differences, value-level statistical drifts (min/max/mean), and aggregate row-count mismatches, with detailed impact reporting.
+
+### Scope of Upgrades and User Requirements
+
+* Cluster Management: Spark Upgrade Agent focuses on application code upgrades. Target EMR clusters for new versions must be created and managed by users.
+* Bootstrap Actions: Spark Upgrade Agent does not upgrade custom bootstrap scripts outside of Spark application code. They need to be upgraded by the user.
+* Upgrade for Build and Tests: The upgrade agent will perform build and run your unit and integration tests on your development environment locally to validate that applications compile successfully with the target Spark version. If you have restrictions (security policies, resource limitations, network restrictions, or corporate guidelines) for Spark application code for local execution, consider using Amazon SageMaker Unified Studio VSCode IDE Spaces or EC2 to run the upgrade agent. The upgrade agent uses your target EMR-EC2 cluster or EMR-S applications to validate and upgrade end-to-end.
+* Error-Driven Approach: The upgrade agent uses an error-driven methodology, making one fix at a time based on compilation or runtime errors rather than multiple fixes at once. This iterative approach ensures each issue is properly addressed before proceeding to the next.
+* Private Dependencies: Dependencies installed from private artifact repositories cannot be automatically upgraded as part of this process. They must be upgraded by the user.
+* Regional resources: Spark upgrade agent is regional and uses the underlying EMR resources in that region for the upgrade process. Cross-region upgrades are not supported.
+
+## [Data Usage](https://github.com/awslabs/mcp/blob/main/src/sagemaker-unified-studio-spark-upgrade-mcp-server/README.md#data-usage)
+
+This server processes your code and configuration files to provide upgrade recommendations. No sensitive data is stored permanently, and all processing follows AWS data protection standards.
+
+## FAQs ([1](https://github.com/awslabs/mcp/blob/main/src/sagemaker-unified-studio-spark-upgrade-mcp-server/README.md#data-usage), [2](https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-spark-upgrade-agent-troubleshooting.html#spark-upgrade-agent-qa))
+
+### 1. Which Spark versions are supported?
+- For EMR-EC2
+    - Source Version: EMR 5.20.0 and later
+    - Target Version: EMR 7.12.0 and earlier, should be newer than EMR 5.20.0
+
+- For EMR-Serverless
+    - Source Version: EMR Serverless 6.6.0 and later
+    - Target Version: EMR Serverless 7.12.0 and earlier
+
+### 2. Can I use this for Scala applications?
+
+Yes, the agent supports both PySpark and Scala Spark applications, including Maven and SBT build system
+
+### 3. What about custom libraries and UDFs?
+
+The agent analyzes custom dependencies and provides guidance for updating user-defined functions and third-party libraries.
+
+### 4. How does data quality validation work?
+
+The agent compares output data between old and new Spark versions using validation rules and statistical analysis.
+
+### 5. Can I customize the upgrade process?
+
+Yes, you can modify upgrade plans, exclude specific transformations, and customize validation criteria based on your requirements.
+
+### 6. What if the automated upgrade fails?
+
+The agent provides detailed error analysis, suggested fixes, and fallback strategies. You maintain full control over all changes.
+
+### 7. Should I enable "trust" setting for the tools by default?
+
+Do not turn on "trust" setting by default for all tool calls initially and operate on git-versioned build environment. Review each tool execution to understand what changes are being made, for example review the upgrade plan before providing consent. Never trust the Kiro or your Agent's fs_write tool - this tool modifies your project files and you should always review changes before they are saved/committed. In general, examine all proposed file changes before allowing them to be written. Use git to version changes and create checkpoints throughout the upgrade process. Build confidence gradually - If you are repeatedly using the system for multiple upgrades and have gained confidence in the tools, you can selectively trust certain tools.
+
+## [Troubleshooting Access to the Remote MCP Server](https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-spark-upgrade-agent-troubleshooting.html)
+
+The error message from the upgrade process is available in different ways for different MCP clients. In this page, we list some general guidance for common issues you may see using Apache Spark Upgrade Agent for Amazon EMR.
+
+### Topics
+
+### Error: SMUS Managed MCP server failed to load
+* Verify your MCP configuration are properly configured.
+* Validate JSON syntax:
+* Ensure your JSON is valid with no syntax errors
+* Check for missing commas, quotes, or brackets
+* Verify your local AWS credentials and verify the policy for the MCP IAM role are properly configured.
+
+### Observation : Slow Tool Loading
+* Tools may take a few seconds to be loaded on first attempt of launching the server.
+* If tools don't appear, try restarting the chat,
+* Run /tools command to verify tool availability.
+* Run /mcp if the server is launched without error.
+
+### Error: Tool Invocation Failed with Throttling Error
+If you hit your service limit, please wait for a few seconds to issue a tool invocation if you see the throttling exception.
+
+### Error: Tool Responds With User Error
+* AccessDeniedException - check the error message and fix the permission issue.
+* InvalidInputException - check the error message and correct the tool input parameters.
+* ResourceNotFoundException - check the error message and fix the input parameter for resource reference.
+
+### Error: Tool Responds With Internal Error
+* If you see The service is handling high-volume requests please retry the tool invocation in a few seconds.
+* If you see INTERNAL SERVICE EXCEPTION please document the analysis id, tool name, any error message available from the mcp log or tool response and optional sanitized conversation history and reach out to the AWS support.

--- a/spark-upgrade-agent/mcp.json
+++ b/spark-upgrade-agent/mcp.json
@@ -1,0 +1,22 @@
+{
+  "mcpServers": {
+    "spark-upgrade": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "mcp-proxy-for-aws@latest",
+        "https://sagemaker-unified-studio-mcp.{AWS_REGION}.api.aws/spark-upgrade/mcp",
+        "--service",
+        "sagemaker-unified-studio-mcp",
+        "--profile",
+        "spark-upgrade-profile",
+        "--region",
+        "{AWS_REGION}",
+        "--read-timeout",
+        "180"
+      ],
+      "timeout": 180000,
+      "disabled": false
+    }
+  }
+}


### PR DESCRIPTION
This change adds a Kiro Power for the [Apache Spark upgrade agent](https://docs.aws.amazon.com/emr/latest/ReleaseGuide/spark-upgrades.html) - an MCP server with tools that assist customers with Spark application upgrades in AWS EMR on EC2 and EMR Serverless

I tested this PR by:

navigating to the Power tab in the Kiro IDE
clicking "Add Custom Power"
selecting the "spark-upgrade-agent" directory
clicking the power in the "installed" powers list to open the power's landing page
clicking "Try power", which opens a dialogue with Kiro to configure and enable the power

here is the dialogue
```md
I just installed the spark-upgrade-agent power and want to use it.

Kiro
I'll help you get started with the spark-upgrade-agent power! Let me activate it first to understand its capabilities.


Activated Kiro power spark-upgrade-agent
Great! I've activated the spark-upgrade-agent power. Let me give you an overview and walk through the onboarding process.

What This Power Does
The Spark Upgrade Agent accelerates Apache Spark version upgrades for EMR applications. Instead of spending months manually updating code, it uses AI to:

Automatically transform code for Spark version compatibility (PySpark & Scala)
Resolve dependency conflicts and update build configurations
Submit validation jobs to EMR to test your upgraded code
Validate data quality to ensure output correctness
Support EMR EC2 and EMR Serverless platforms
It's a conversational tool - you describe what you want to upgrade, and it handles the heavy lifting.

Let's Go Through Onboarding
Step 1: Validate Prerequisites
Let me check what you have installed:

Command
aws --version && echo "---" && python3 --version && echo "---" && uv --version && echo "---" && aws sts get-caller-identity && echo "---" && echo "AWS_PROFILE: ${AWS_PROFILE:-default}"
aws-cli/2.28.4 Python/3.13.4 Linux/5.10.245-243.979.amzn2int.x86_64 exe/x86_64.amzn.2
---
Python 3.12.6
---
uv 0.6.17
---

An error occurred (InvalidClientTokenId) when calling the GetCallerIdentity operation: The security token included in the req
uest is invalid                                                                                                              
Good news - you have AWS CLI, Python 3.12, and uv installed! However, your AWS credentials aren't configured properly. Let me help you set that up.

Current Status:

✅ AWS CLI: v2.28.4
✅ Python: 3.12.6 (meets 3.10+ requirement)
✅ uv: 0.6.17
❌ AWS Credentials: Not configured
Step 2: Configure AWS Credentials
Before we can deploy the CloudFormation stack, you need to configure your AWS credentials. You have a few options:

Configure AWS CLI credentials:

aws configure
You'll need your AWS Access Key ID, Secret Access Key, and preferred region.

Or use environment variables:

export AWS_ACCESS_KEY_ID=your_access_key
export AWS_SECRET_ACCESS_KEY=your_secret_key
export AWS_DEFAULT_REGION=us-east-1
Or if you're using IAM roles (on EC2/ECS), they should be automatically available.

Once you've configured your credentials, run:

aws sts get-caller-identity
This should return your AWS account details.

Step 3: Deploy CloudFormation Stack
After your credentials are working, you'll need to:

Log into the AWS Console

Navigate to the Spark Troubleshooting Agent Setup Page

Deploy the CloudFormation stack with these key parameters:

SparkUpgradeIAMRoleName: Name for the IAM role
EnableEMREC2: true (if using EMR on EC2)
EnableEMRServerless: true (if using EMR Serverless)
StagingBucketPath: S3 path for artifacts (or leave empty to auto-generate)
After deployment completes, note the Role ARN and Region from the stack outputs.

Step 4: Configure AWS CLI Profile
Once you have the Role ARN from the CloudFormation stack, let me know and I'll help you configure the spark-upgrade-profile and update your MCP configuration.

Simple Example (After Setup)
Once everything is configured, here's how you'd use it:

"I want to upgrade my PySpark application from Spark 3.3 to 3.5. 
The project is located at /home/myuser/spark-projects/etl-pipeline.
Can you help me create an upgrade plan?"
The agent would then:

Analyze your project structure
Identify compatibility issues
Generate an upgrade plan
Apply automated transformations (with your approval)
Update dependencies
Submit validation jobs to EMR
Validate data quality
Next Steps:

Configure your AWS credentials
Deploy the CloudFormation stack
Share the Role ARN and Region with me
I'll configure the MCP profile for you
Let me know when you're ready to proceed or if you need help with any of these steps!

Checkpoint
Restore
please try the aws creds call again

Kiro
I'll check your AWS credentials now.

Command
aws sts get-caller-identity
{
    "UserId": "AROA2PY2DM4KYKVBOBDYA:arusignu-Isengard",
    "Account": "721072383765",
    "Arn": "arn:aws:sts::721072383765:assumed-role/Admin/arusignu-Isengard"
}
Great! Your AWS credentials are configured and working. You're authenticated as an Admin role in account 721072383765.

Now let me check your current AWS profile:

Command
echo ${AWS_PROFILE:-default}
arusignu
Perfect! You're using the arusignu profile.

Here's what we've confirmed so far:

Prerequisites Status:

✅ AWS CLI: Installed and configured
✅ AWS Credentials: Working (profile: arusignu, account: 721072383765)
✅ Python 3.10+: Need to verify
✅ uv package manager: Need to verify
Let me check the remaining prerequisites:

Command
python3 --version && uv --version
Python 3.12.6
uv 0.6.17
Excellent! All prerequisites are met:

Prerequisites Status:

✅ AWS CLI: Installed
✅ AWS Credentials: Configured (profile: arusignu)
✅ Python 3.12.6: Installed
✅ uv 0.6.17: Installed
Next Steps:

You now need to deploy the CloudFormation stack to create the IAM role with proper permissions for the Spark Upgrade Agent. Here's what to do:

Deploy the CloudFormation Stack:

Log into the AWS Console with your current role
Navigate to: https://docs.aws.amazon.com/emr/latest/ReleaseGuide/spark-troubleshooting-agent-setup.html#spark-troubleshooting-agent-setup-resources
Deploy the stack to your desired region
Configure the parameters (especially SparkUpgradeIAMRoleName, EnableEMREC2, EnableEMRServerless)
Wait for deployment to complete
After deployment, provide me with:

The region where you deployed the stack
The IAM role ARN from the CloudFormation outputs
Once you have those, I'll configure the AWS CLI profile and update your MCP configuration automatically.

Would you like to proceed with the CloudFormation deployment, or do you already have a role configured with sagemaker-unified-studio-mcp permissions?

Checkpoint
Restore
I deployed the stack. The role is `arn:aws:iam::721072383765:role/spark_upgrade_role` and the region is `us-east-1`

Kiro
Perfect! Let me configure everything for you now.

Step 3: Configure AWS CLI Profile
I'll set up the spark-upgrade-profile with your role:

Command
aws configure set profile.spark-upgrade-profile.source_profile arusignu && aws configure set profile.spark-upgrade-profile.role_arn arn:aws:iam::721072383765:role/spark_upgrade_role && aws configure set profile.spark-upgrade-profile.region us-east-1 && echo "Profile configured successfully"
Profile configured successfully
Great! Now let me verify the profile works:

Command
AWS_PROFILE=spark-upgrade-profile aws sts get-caller-identity
{
    "UserId": "AROA2PY2DM4KT7OFDXN33:botocore-session-1765998498",
    "Account": "721072383765",
    "Arn": "arn:aws:sts::721072383765:assumed-role/spark_upgrade_role/botocore-session-1765998498"
}
Excellent! The profile is working correctly. Now let me update your MCP configuration:

Command
cat ~/.kiro/settings/mcp.json
{
  "mcpServers": {
    "builder-mcp": {
      "command": "/home/arusignu/.toolbox/bin/builder-mcp",
      "args": [],
      "env": {},
      "disabled": false,
      "autoApprove": []
    }
  },
  "powers": {
    "mcpServers": {
      "power-postman-postman": {
        "url": "https://mcp.postman.com/minimal",
        "headers": {
          "Authorization": "Bearer ${POSTMAN_API_KEY}"
        }
      },
      "power-spark-troubleshooting-agent-sagemaker-unified-studio-mcp-troubleshooting": {
        "type": "stdio",
        "command": "uvx",
        "args": [
          "mcp-proxy-for-aws@latest",
          "https://sagemaker-unified-studio-mcp.us-east-1.api.aws/spark-troubleshooting/mcp",
          "--service",
          "sagemaker-unified-studio-mcp",
          "--profile",
          "smus-mcp-profile",
          "--region",
          "us-east-1",
          "--read-timeout",
          "180"
        ],
        "timeout": 180000,
        "disabled": false
      },
      "power-spark-troubleshooting-agent-sagemaker-unified-studio-mcp-code-rec": {
        "type": "stdio",
        "command": "uvx",
        "args": [
          "mcp-proxy-for-aws@latest",
          "https://sagemaker-unified-studio-mcp.us-east-1.api.aws/spark-code-recommendation/mcp",
          "--service",
          "sagemaker-unified-studio-mcp",
          "--profile",
          "smus-mcp-profile",
          "--region",
          "us-east-1",
          "--read-timeout",
          "180"
        ],
        "timeout": 180000,
        "disabled": false
      },
      "power-spark-upgrade-agent-spark-upgrade": {
        "type": "stdio",
        "command": "uvx",
        "args": [
          "mcp-proxy-for-aws@latest",
          "https://sagemaker-unified-studio-mcp.{AWS_REGION}.api.aws/spark-upgrade/mcp",
          "--service",
          "sagemaker-unified-studio-mcp",
          "--profile",
          "spark-upgrade-profile",
          "--region",
          "{AWS_REGION}",
          "--read-timeout",
          "180"
        ],
        "timeout": 180000,
        "disabled": false
      }
    }
  }
}%                                                                                                                           
I can see the spark-upgrade-agent is already configured in your MCP settings, but it has placeholder values {AWS_REGION}. Let me update it with the correct region:

Command
cat ~/.kiro/settings/mcp.json | python3 -c "import sys, json; data = json.load(sys.stdin); data['powers']['mcpServers']['power-spark-upgrade-agent-spark-upgrade']['args'] = [arg.replace('{AWS_REGION}', 'us-east-1') for arg in data['powers']['mcpServers']['power-spark-upgrade-agent-spark-upgrade']['args']]; print(json.dumps(data, indent=2))" > ~/.kiro/settings/mcp.json.tmp && mv ~/.kiro/settings/mcp.json.tmp ~/.kiro/settings/mcp.json && echo "MCP configuration updated successfully"
MCP configuration updated successfully
Perfect! Let me verify the configuration:

Command




cat ~/.kiro/settings/mcp.json | grep -
```