### PR TITLE
chore(mcp): Remove pre-configured autoApprove and disabledTools from powers

### DIFF
--- a/aws-agentcore/mcp.json
+++ b/aws-agentcore/mcp.json
@@ -3,14 +3,7 @@
     "agentcore-mcp-server": {
       "command": "uvx",
       "args": ["awslabs.amazon-bedrock-agentcore-mcp-server@latest"],
-      "disabled": false,
-      "autoApprove": [
-        "search_agentcore_docs",
-        "fetch_agentcore_doc",
-        "manage_agentcore_runtime",
-        "manage_agentcore_memory",
-        "manage_agentcore_gateway"
-      ]
+      "disabled": false
     }
- }
+  }
 }

--- a/aws-infrastructure-as-code/mcp.json
+++ b/aws-infrastructure-as-code/mcp.json
@@ -7,14 +7,7 @@
         "AWS_PROFILE": "your-named-profile",
         "FASTMCP_LOG_LEVEL": "ERROR"
       },
-      "disabled": false,
-      "autoApprove": [
-        "read_iac_documentation_page",
-        "search_cdk_documentation",
-        "search_cdk_samples_and_constructs",
-        "cdk_best_practices",
-        "search_cloudformation_documentation"
-      ]
+      "disabled": false
     }
   }
 }

--- a/cloud-architect/mcp.json
+++ b/cloud-architect/mcp.json
@@ -20,8 +20,7 @@
       "env": {
         "AWS_REGION": "us-east-2"
       },
-      "disabled": false,
-      "autoApprove": []
+      "disabled": false
     },
     "context7": {
       "type": "stdio",

--- a/dynatrace/mcp.json
+++ b/dynatrace/mcp.json
@@ -5,12 +5,7 @@
       "headers": {
         "Authorization": "Bearer YOUR_BEARER_TOKEN"
       },
-      "disabled": false,
-      "autoApprove": [
-        "create-dql",
-        "execute-dql"
-      ],
-      "disabledTools": []
+      "disabled": false
     }
   }
 }

--- a/figma/mcp.json
+++ b/figma/mcp.json
@@ -2,8 +2,7 @@
   "mcpServers": {
     "figma": {
       "url": "https://mcp.figma.com/mcp",
-      "disabled": false,
-      "disabledTools": []
+      "disabled": false
     }
   }
 }

--- a/neon/mcp.json
+++ b/neon/mcp.json
@@ -2,10 +2,7 @@
   "mcpServers": {
     "Neon": {
       "url": "https://mcp.neon.tech/mcp",
-      "disabled": false,
-      "disabledTools": [
-        "compare_database_schema"
-      ]
+      "disabled": false
     }
   }
 }

--- a/saas-builder/mcp.json
+++ b/saas-builder/mcp.json
@@ -6,8 +6,7 @@
         "mcp-server-fetch"
       ],
       "env": {},
-      "disabled": false,
-      "autoApprove": []
+      "disabled": false
     },
     "stripe": {
       "url": "https://mcp.stripe.com",
@@ -25,8 +24,7 @@
       "env": {
         "FASTMCP_LOG_LEVEL": "ERROR"
       },
-      "disabled": false,
-      "autoApprove": []
+      "disabled": false
     },
     "awslabs.aws-serverless-mcp": {
       "command": "uvx",


### PR DESCRIPTION
*Description of changes:*
Removes all autoApprove and disabledTools configurations from power mcp.json files to improve security posture.

Pre-populating approved tools can lead to unexpected behavior when users first install powers, as tools execute without explicit user consent. Users should decide their own approval preferences after installation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
