### PR TITLE
feat(checkout): upgrade checkout-api-reference power to v2.0.0

### DIFF
--- a/checkout/POWER.md
+++ b/checkout/POWER.md
@@ -2,7 +2,7 @@
 name: "checkout-api-reference"
 displayName: "Checkout.com Global Payments"
 description: "Access Checkout.com's comprehensive API documentation with intelligent search and detailed operation information for payments, customers, disputes, and more."
-version: "1.0.0"
+version: "2.0.0"
 author: "Checkout.com"
 keywords:
   - "checkout"
@@ -21,26 +21,58 @@ keywords:
   - "reference"
 ---
 
-# Checkout.com Developer Experience MCP
+# Checkout.com Global Payments
 
-This power provides access to Checkout.com's comprehensive API documentation through a Model Context Protocol (MCP) server. It enables AI assistants to search, explore, and understand Checkout.com's payment processing APIs with over 189 operations covering payments, customers, disputes, issuing, platforms, workflows, and identity verification.
+This power provides access to Checkout.com's comprehensive API documentation. It enables AI assistants to search, explore, and understand Checkout.com's payment processing APIs covering payments, customers, disputes, issuing, platforms, workflows, and identity verification.
 
 ## What This Power Does
 
-The Checkout.com Developer Experience MCP acts as an intelligent documentation assistant that can:
+This power acts as an intelligent documentation assistant that can:
 
-- **Search API Operations**: Find relevant endpoints by keywords, functionality, or business domain
+- **Search API Operations**: Find relevant endpoints using Lucene full-text search with fuzzy matching and typo tolerance
+- **Search Documentation**: Find relevant guides, tutorials, and conceptual content
 - **Explore API Structure**: Browse operations by tags and categories
-- **Get Detailed Documentation**: Retrieve comprehensive information about specific endpoints including parameters, responses, and examples
+- **Get Operation Details**: Retrieve simplified, token-efficient information about specific endpoints
 - **Access Schema Definitions**: Get detailed schema information for request/response objects
-- **Understand API Relationships**: Discover how different endpoints work together
+
+## Important: Understand the Integration Path First
+
+Before diving into API operations, determine which integration path the user needs:
+
+### Flow (Prebuilt Payment UI)
+If the user wants to accept payments with minimal effort, steer them towards **Flow** - Checkout.com's prebuilt payment interface. Flow handles:
+- Tokenizing sensitive payment details (PCI compliant out of the box)
+- Displaying available payment methods
+- Capturing additional customer data
+- 3D Secure authentication and redirects
+
+**Flow is the right choice when:**
+- The user wants a drop-in payment form on their website
+- They want to get up and running quickly
+- They don't need deep customization of the payment UI
+- They want Checkout.com to manage the end-to-end payment experience
+
+**Key resources for Flow:**
+- [Get started with Flow](https://www.checkout.com/docs/get-started)
+- [Customize Flow](https://www.checkout.com/docs/payments/accept-payments/accept-a-payment-on-your-website/customize-your-flow-integration)
+- npm package: `@checkout.com/checkout-web-components`
+- The main API call creates a Payment Session - use `ApiSearch` for "payment session" then `GetOperation` and `GetSchema` to explore it
+
+### API-to-API (Direct Integration)
+If the user needs full control over the payment experience, they should use the payment API endpoints directly. This is for:
+- Server-to-server payment processing
+- Custom payment UIs
+- Complex payment flows (split payments, marketplace payouts, recurring billing)
+- Backend-only integrations with no frontend
+
+**Start with:** `ApiSearch` for "payment" or `ListOperations` with tag "Payments" to explore available endpoints.
 
 ## Key Features
 
 ### Comprehensive API Coverage
 Access to all Checkout.com API operations including:
 - **Payments**: Process payments, refunds, captures, and voids
-- **Customers**: Manage customer profiles and payment instruments  
+- **Customers**: Manage customer profiles and payment instruments
 - **Disputes**: Handle chargebacks and dispute management
 - **Issuing**: Card issuing and management capabilities
 - **Platforms**: Multi-entity and marketplace functionality
@@ -48,15 +80,16 @@ Access to all Checkout.com API operations including:
 - **Identity Verification**: KYC and identity checking services
 
 ### Intelligent Search
-- Keyword-based search across operation IDs, paths, summaries, and descriptions
+- Lucene full-text search with fuzzy matching and typo tolerance
+- Handles 1-character typos (e.g. "paymnt" finds "payment")
+- Relevance-ranked results with scoring
 - Tag-based filtering for specific API domains
-- Fuzzy matching to find relevant operations even with partial information
 
-### Detailed Documentation Access
-- Complete operation details including HTTP methods, paths, and parameters
-- Request/response schema definitions with examples
-- Error codes and handling information
-- Authentication and authorization requirements
+### Token-Efficient Responses
+- `GetOperation` returns simplified responses (~300 tokens vs ~1,200 previously)
+- Parameters show only essential info: name, location, required, type
+- Request bodies show schema names with hints to use `GetSchema()` for details
+- Responses grouped into success/error categories
 
 ## When to Use This Power
 
@@ -66,86 +99,85 @@ This power is ideal for:
 - **Development Support**: Getting detailed parameter and response information during coding
 - **API Exploration**: Discovering new functionality and understanding API structure
 - **Troubleshooting**: Finding relevant endpoints for specific use cases
-- **Documentation Generation**: Creating comprehensive API documentation and guides
 
 ## Available Tools
 
-### docssearch
-Search through Checkout.com's API documentation for operations matching specific keywords.
+### Guide
+Get integration guidance for Checkout.com's payment APIs. Call this first to understand the two integration paths: Flow (prebuilt payment UI with minimal code) or API-to-API (direct REST integration with full control). Returns structured recommendations, getting-started steps, and links to relevant documentation for each path.
+
+**Use Cases:**
+- Determine which integration approach fits the user's needs
+- Get step-by-step onboarding for Flow or direct API integration
+- Discover the key operations and npm packages for each path
+
+**When to use:** At the start of any conversation about integrating with Checkout.com, before exploring specific endpoints.
+
+### ApiSearch
+Search the Checkout.com OpenAPI specification using Lucene full-text search with fuzzy matching, typo tolerance, and relevance ranking. Searches across operationId, path, summary, description, and tags.
 
 **Use Cases:**
 - Find payment-related endpoints: "payment", "charge", "transaction"
 - Discover customer management APIs: "customer", "profile", "account"
 - Locate dispute handling operations: "dispute", "chargeback", "refund"
+- Search for schema definitions: "PaymentRequest", "Customer"
 
-### openapilistOperations  
-List and filter API operations with advanced filtering capabilities.
+**When to use:** You need to find specific API endpoints, operation IDs, HTTP methods, paths, or schema definitions.
+
+### DocsSearch
+Search through Checkout.com documentation using Lucene full-text search with fuzzy matching, typo tolerance, and relevance ranking. Returns relevant sections with context.
+
+**Use Cases:**
+- Find implementation guides: "Flow integration", "3D Secure setup"
+- Locate best practices: "payment security", "error handling"
+- Discover integration patterns: "webhook configuration", "authentication"
+
+**When to use:** You need to understand how to implement features, follow tutorials, or learn about concepts and best practices.
+
+### ListOperations
+List all API operations from the Checkout.com OpenAPI specification, with optional filtering by tag or text.
 
 **Use Cases:**
 - Browse all operations in a specific domain (e.g., "Payments", "Customers")
 - Find operations containing specific terms
 - Get an overview of available functionality
 
-### openapigetOperation
-Get comprehensive details about a specific API operation.
+### GetOperation
+Get detailed information about a specific API operation by operationId. Returns a simplified, token-efficient response with parameters, request body schema names, grouped response codes, and required scopes.
 
 **Use Cases:**
-- Understand exact parameters required for an endpoint
-- Get response schema and example data
+- Understand parameters required for an endpoint
+- See which schemas are used in request bodies (use `GetSchema` for full details)
+- Check success/error response codes
 - Learn about authentication requirements
-- Find related operations and workflows
 
-### openapigetSchema
-Retrieve detailed schema definitions for request/response objects.
+### GetSchema
+Get a schema definition by name from the Checkout.com OpenAPI specification (components/schemas).
 
 **Use Cases:**
 - Understand data structures for API requests
 - Validate request/response formats
 - Generate client code with proper type definitions
-- Create comprehensive API documentation
-
-### markdownsearch
-Search through additional markdown documentation for contextual information.
-
-**Use Cases:**
-- Find implementation guides and best practices
-- Locate troubleshooting information
-- Discover integration patterns and examples
 
 ## Example Workflows
 
+### Starting a New Integration
+1. Call `Guide` to understand the two integration paths (Flow vs API-to-API)
+2. Based on the user's needs, follow the recommended path
+
 ### Finding Payment Processing Endpoints
-1. Use `docssearch` with query "payment process" to find relevant operations
-2. Use `openapigetOperation` to get detailed information about specific endpoints
-3. Use `openapigetSchema` to understand request/response structures
+1. Use `ApiSearch` with query "payment process" to find relevant API operations
+2. Use `GetOperation` to get information about specific endpoints
+3. Use `GetSchema` to understand request/response structures
 
 ### Understanding Customer Management
-1. Use `openapilistOperations` with tag "Customers" to see all customer-related endpoints
+1. Use `ListOperations` with tag "Customers" to see all customer-related endpoints
 2. Explore specific operations like customer creation, updates, and retrieval
 3. Get schema definitions for customer objects and related data structures
 
-### Exploring Dispute Handling
-1. Search for dispute-related operations using `docssearch`
-2. Get detailed operation information to understand the dispute lifecycle
-3. Access schema definitions for dispute objects and status updates
-
-## Integration Benefits
-
-- **Faster Development**: Quickly find and understand the right APIs for your use case
-- **Reduced Documentation Overhead**: Get answers without manually browsing extensive documentation
-- **Better API Understanding**: Discover relationships between different endpoints and workflows
-- **Improved Code Quality**: Access to complete schema definitions ensures proper implementation
-- **Enhanced Troubleshooting**: Quickly find relevant endpoints and understand their behavior
-
-## Technical Architecture
-
-This power runs as an MCP server that:
-- Loads and parses Checkout.com's OpenAPI specification
-- Provides intelligent search and filtering capabilities
-- Serves detailed documentation through standardized MCP tools
-- Maintains up-to-date API information through bundled documentation
-
-The power is built with .NET 9.0 and follows clean architecture principles with comprehensive test coverage.
+### Learning About Integration Patterns
+1. Use `DocsSearch` with query "Flow integration" to find implementation guides
+2. Search for "webhook" to understand event notification setup
+3. Look for "3D Secure" to learn about authentication flows
 
 ---
 
@@ -155,7 +187,7 @@ The power is built with .NET 9.0 and follows clean architecture principles with 
 For information about how Checkout.com collects, stores, and processes user data, please review our [Privacy Policy](https://www.checkout.com/legal/privacy-policy).
 
 ### Service Information
-This power connects to Checkout.com's Developer Experience MCP service, which provides access to our API documentation and developer resources. The service is hosted and maintained by Checkout.com.
+This power connects to Checkout.com's MCP service at `https://docs.mcp.checkout.com/rpc`, which provides access to our API documentation and developer resources.
 
 ### Support
 For technical support, questions, or to report issues with this power, please contact our support team:

--- a/checkout/mcp.json
+++ b/checkout/mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "checkout-dx": {
-      "url": "https://dx-mcp.checkout.com/rpc",
+      "url": "https://docs.mcp.checkout.com/rpc",
       "disabled": false
     }
   }

--- a/checkout/steering/advanced-usage.md
+++ b/checkout/steering/advanced-usage.md
@@ -19,24 +19,24 @@ For complex integrations, use a systematic approach to discover and understand r
 
 1. **Domain Exploration**
    ```
-   List all operations with tag "Payments"
-   List all operations with tag "Workflows" 
-   Search for operations containing "webhook"
+   ListOperations with tag "Payments"
+   ListOperations with tag "Workflows"
+   ApiSearch for "webhook"
    ```
 
 2. **Relationship Mapping**
    ```
-   Get details for createPayment operation
-   Get schema for PaymentRequest
-   Get schema for PaymentResponse
-   Search for operations containing "payment" and "capture"
+   GetOperation for createPayment
+   GetSchema for PaymentRequest
+   GetSchema for PaymentResponse
+   ApiSearch for "payment capture"
    ```
 
 3. **Error Scenario Planning**
    ```
-   Search for operations containing "void"
-   Search for operations containing "refund"
-   Get details for disputePayment operation
+   ApiSearch for "void"
+   ApiSearch for "refund"
+   GetOperation for disputePayment
    ```
 
 ### Schema Deep Diving
@@ -45,14 +45,14 @@ Understanding complex data structures requires systematic schema exploration:
 
 1. **Identify Core Schemas**
    ```
-   Get schema for PaymentRequest
-   Get schema for CustomerRequest
-   Get schema for WebhookEvent
+   GetSchema for PaymentRequest
+   GetSchema for CustomerRequest
+   GetSchema for WebhookEvent
    ```
 
 2. **Explore Nested Objects**
-   - Look for `$ref` references in schemas
-   - Follow object hierarchies to understand data relationships
+   - `GetOperation` shows schema names referenced in request bodies
+   - Use `GetSchema` to follow those references and understand full structures
    - Map required vs optional fields across related schemas
 
 3. **Validate Data Flow**
@@ -68,24 +68,24 @@ For sophisticated payment processing:
 
 1. **Authorization and Capture Pattern**
    ```
-   Get details for authorizePayment operation
-   Get details for capturePayment operation
-   Get schema for AuthorizationRequest
-   Get schema for CaptureRequest
+   GetOperation for authorizePayment
+   GetOperation for capturePayment
+   GetSchema for AuthorizationRequest
+   GetSchema for CaptureRequest
    ```
 
 2. **Payment Instrument Management**
    ```
-   Search for operations containing "instrument"
-   Get details for createPaymentInstrument operation
-   Get details for updatePaymentInstrument operation
+   ApiSearch for "instrument"
+   GetOperation for createPaymentInstrument
+   GetOperation for updatePaymentInstrument
    ```
 
 3. **Recurring Payment Setup**
    ```
-   Search for operations containing "recurring"
-   Search for operations containing "subscription"
-   Get schema for RecurringPaymentRequest
+   ApiSearch for "recurring"
+   ApiSearch for "subscription"
+   GetSchema for RecurringPaymentRequest
    ```
 
 ### Platform and Marketplace Integrations
@@ -94,23 +94,23 @@ For multi-entity scenarios:
 
 1. **Sub-Entity Management**
    ```
-   List operations with tag "Platforms"
-   Get details for createSubEntity operation
-   Get schema for SubEntityRequest
+   ListOperations with tag "Platforms"
+   GetOperation for createSubEntity
+   GetSchema for SubEntityRequest
    ```
 
 2. **Split Payment Scenarios**
    ```
-   Search for operations containing "split"
-   Search for operations containing "marketplace"
-   Get schema for SplitPaymentRequest
+   ApiSearch for "split"
+   ApiSearch for "marketplace"
+   GetSchema for SplitPaymentRequest
    ```
 
 3. **Onboarding Workflows**
    ```
-   Search for operations containing "onboard"
-   Get details for uploadDocument operation
-   Get schema for OnboardingRequest
+   ApiSearch for "onboard"
+   GetOperation for uploadDocument
+   GetSchema for OnboardingRequest
    ```
 
 ### Advanced Dispute Management
@@ -119,17 +119,17 @@ For comprehensive dispute handling:
 
 1. **Dispute Lifecycle Management**
    ```
-   Get details for getDispute operation
-   Get details for acceptDispute operation
-   Get details for provideDisputeEvidence operation
-   Get schema for DisputeEvidence
+   GetOperation for getDispute
+   GetOperation for acceptDispute
+   GetOperation for provideDisputeEvidence
+   GetSchema for DisputeEvidence
    ```
 
 2. **Chargeback Prevention**
    ```
-   Search for operations containing "alert"
-   Search for operations containing "prevention"
-   Get details for getDisputeAlert operation
+   ApiSearch for "alert"
+   ApiSearch for "prevention"
+   GetOperation for getDisputeAlert
    ```
 
 ## Workflow Automation Patterns
@@ -140,23 +140,16 @@ Understanding webhook and event patterns:
 
 1. **Event Type Discovery**
    ```
-   Search documentation for "webhook events"
-   Get schema for WebhookEvent
-   Search for operations containing "event"
+   DocsSearch for "webhook events"
+   GetSchema for WebhookEvent
+   ApiSearch for "event"
    ```
 
 2. **Workflow Configuration**
    ```
-   List operations with tag "Workflows"
-   Get details for createWorkflow operation
-   Get schema for WorkflowRequest
-   ```
-
-3. **Event Processing Patterns**
-   ```
-   Search documentation for "event handling"
-   Search for operations containing "retry"
-   Get details for getWorkflowExecution operation
+   ListOperations with tag "Workflows"
+   GetOperation for createWorkflow
+   GetSchema for WorkflowRequest
    ```
 
 ### Identity Verification Workflows
@@ -165,56 +158,36 @@ For KYC and compliance:
 
 1. **Verification Process Discovery**
    ```
-   List operations with tag "Identity Verification"
-   Get details for createIdentityVerification operation
-   Get schema for IdentityVerificationRequest
+   ListOperations with tag "Identity Verification"
+   GetOperation for createIdentityVerification
+   GetSchema for IdentityVerificationRequest
    ```
 
 2. **Document Management**
    ```
-   Search for operations containing "document"
-   Get details for uploadDocument operation
-   Get schema for DocumentRequest
+   ApiSearch for "document"
+   GetOperation for uploadDocument
+   GetSchema for DocumentRequest
    ```
 
 ## Performance and Optimization
 
-### Efficient API Usage Patterns
+### Efficient Tool Usage
 
-1. **Batch Operations Discovery**
-   ```
-   Search for operations containing "batch"
-   Search for operations containing "bulk"
-   Get details for batchPayments operation
-   ```
+1. **Start with Search** - Use `ApiSearch` or `DocsSearch` to find relevant operations first
+2. **Get Simplified Details** - `GetOperation` returns token-efficient responses (~300 tokens)
+3. **Drill into Schemas** - Only call `GetSchema` when you need full data structure details
+4. **Use Tag Filtering** - `ListOperations` with a tag is more efficient than broad searches
 
-2. **Pagination Understanding**
-   ```
-   Search documentation for "pagination"
-   Get schema for PaginatedResponse
-   Look for limit/offset parameters in list operations
-   ```
+### Token-Efficient Workflows
 
-3. **Rate Limit Management**
-   ```
-   Search documentation for "rate limits"
-   Search documentation for "throttling"
-   Look for rate limit headers in operation responses
-   ```
+The `GetOperation` tool returns simplified responses by default:
+- Parameters show only name, location, required status, and type
+- Request bodies show schema names with hints to use `GetSchema()`
+- Responses are grouped into success/error code arrays
+- Security shows only required scopes
 
-### Caching and Data Management
-
-1. **Cacheable Resource Identification**
-   - Identify GET operations that return stable data
-   - Look for ETags and cache headers in responses
-   - Understand data freshness requirements
-
-2. **Idempotency Patterns**
-   ```
-   Search documentation for "idempotency"
-   Look for idempotency key parameters
-   Understand retry-safe operations
-   ```
+This means a typical workflow uses ~300 tokens per operation lookup instead of ~1,200.
 
 ## Security and Compliance
 
@@ -222,66 +195,29 @@ For KYC and compliance:
 
 1. **Auth Method Discovery**
    ```
-   Search documentation for "authentication"
-   Search documentation for "authorization"
-   Look for security requirements in operation details
+   DocsSearch for "authentication"
+   DocsSearch for "authorization"
    ```
 
 2. **Token Management**
    ```
-   Search for operations containing "token"
-   Get details for createToken operation
-   Get schema for TokenRequest
+   ApiSearch for "token"
+   GetOperation for createToken
+   GetSchema for TokenRequest
    ```
 
 ### PCI and Compliance
 
 1. **Secure Data Handling**
    ```
-   Search documentation for "PCI compliance"
-   Search documentation for "sensitive data"
-   Identify operations that handle card data
+   DocsSearch for "PCI compliance"
+   DocsSearch for "sensitive data"
    ```
 
 2. **Audit and Logging**
    ```
-   Search for operations containing "audit"
-   Search for operations containing "log"
-   Get details for getAuditLog operation
-   ```
-
-## Troubleshooting Advanced Scenarios
-
-### Error Analysis Patterns
-
-1. **Error Code Mapping**
-   ```
-   Search documentation for "error codes"
-   Look for error responses in operation details
-   Get schema for ErrorResponse
-   ```
-
-2. **Diagnostic Operations**
-   ```
-   Search for operations containing "status"
-   Search for operations containing "health"
-   Get details for getSystemStatus operation
-   ```
-
-### Integration Testing
-
-1. **Test Environment Setup**
-   ```
-   Search documentation for "sandbox"
-   Search documentation for "testing"
-   Look for test-specific operations and endpoints
-   ```
-
-2. **Mock Data Discovery**
-   ```
-   Search documentation for "test data"
-   Search documentation for "examples"
-   Look for example values in schema definitions
+   ApiSearch for "audit"
+   ApiSearch for "log"
    ```
 
 ## Best Practices for Power Usage
@@ -291,17 +227,10 @@ For KYC and compliance:
 - Use schema exploration to understand data relationships
 - Map complete workflows before implementation
 
-### Documentation Strategy
-- Save important operation IDs and schema names for quick reference
-- Document discovered patterns and relationships
-- Create integration checklists based on discovered operations
-
 ### Continuous Learning
 - Regularly explore new API areas as your integration grows
 - Stay updated with new operations and schema changes
 - Use the power to understand deprecation notices and migration paths
-
-This advanced usage guide helps you leverage the full potential of the Checkout.com Developer Experience MCP for sophisticated payment processing integrations.
 
 ## Additional Resources
 

--- a/checkout/steering/getting-started.md
+++ b/checkout/steering/getting-started.md
@@ -12,22 +12,58 @@ For comprehensive information about Checkout.com's APIs, refer to the official d
 
 ## Quick Start
 
-Once the power is activated, you have access to five main tools for exploring Checkout.com's API documentation:
+### First: Determine the Integration Path
 
-### 1. Search for API Operations (`docssearch`)
+The most important question to ask is: **what kind of payment integration does the user need?**
 
-The fastest way to find relevant endpoints is through keyword search:
+#### Flow (Prebuilt Payment UI)
+If the user wants to accept payments on their website with minimal effort, guide them to **Flow** - Checkout.com's prebuilt payment interface.
+
+Flow manages the entire payment experience: tokenization, payment method display, customer data capture, 3D Secure authentication, and redirects. The user creates a Payment Session server-side, then mounts Flow client-side using the `@checkout.com/checkout-web-components` npm package.
+
+**Key steps for Flow:**
+1. Create a Payment Session (`CreatePaymentSession` endpoint)
+2. Install `@checkout.com/checkout-web-components`
+3. Initialize `CheckoutWebComponents` with the payment session and public key
+4. Mount Flow onto the page with `checkout.create('flow').mount('#container')`
+5. Handle payment response via webhooks or `onPaymentCompleted` callback
+
+**Resources:**
+- [Get started with Flow](https://www.checkout.com/docs/get-started)
+- [Customize Flow](https://www.checkout.com/docs/payments/accept-payments/accept-a-payment-on-your-website/customize-your-flow-integration)
+- [Add localization](https://www.checkout.com/docs/payments/accept-payments/accept-a-payment-on-your-website/add-localization-to-your-flow-integration)
+
+Use `ApiSearch` with "payment session" to find the relevant operationId, then `GetOperation` and `GetSchema` for `PaymentSessionRequest` to explore the server-side setup.
+
+#### API-to-API (Direct Integration)
+If the user needs full control, custom UI, or server-to-server processing, they should use the payment API endpoints directly. Start exploring with `ApiSearch` for "payment" or `ListOperations` with tag "Payments".
+
+---
+
+Once the integration path is clear, you have access to six tools for exploring the API:
+
+### 1. Get Integration Guidance (`Guide`)
+
+Start here. The `Guide` tool returns structured guidance on the two integration paths (Flow vs API-to-API), including getting-started steps, relevant documentation links, and suggested next tools to call.
+
+```
+Call Guide to understand integration options
+```
+
+### 2. Search for API Operations (`ApiSearch`)
+
+The fastest way to find relevant API endpoints is through keyword search:
 
 ```
 Search for payment processing endpoints
 ```
 
-This will use the `docssearch` tool to find operations related to payments. You can search for:
+This will use the `ApiSearch` tool to find operations related to payments. Supports fuzzy matching so typos like "paymnt" still find results. You can search for:
 - **Business functions**: "payment", "refund", "customer", "dispute"
 - **Technical terms**: "webhook", "authentication", "token"
 - **Specific operations**: "create", "update", "delete", "list"
 
-### 2. Browse Operations by Category (`openapilistOperations`)
+### 3. Browse Operations by Category (`ListOperations`)
 
 To explore operations in a specific domain:
 
@@ -37,22 +73,22 @@ List all customer-related operations
 
 This helps you understand the full scope of functionality available in each API domain.
 
-### 3. Get Detailed Operation Information (`openapigetOperation`)
+### 4. Get Operation Information (`GetOperation`)
 
-Once you find an interesting operation, get comprehensive details:
+Once you find an interesting operation, get its details:
 
 ```
 Get details for the createPayment operation
 ```
 
-This provides complete information including:
+This provides a simplified, token-efficient response including:
 - HTTP method and path
-- Required and optional parameters
-- Request/response schemas
-- Authentication requirements
-- Example requests and responses
+- Parameter names, locations, and types
+- Request body schema names (with hints to use `GetSchema` for full details)
+- Success and error response codes
+- Required authentication scopes
 
-### 4. Understand Data Structures (`openapigetSchema`)
+### 5. Understand Data Structures (`GetSchema`)
 
 To understand the data structures used in requests and responses:
 
@@ -66,7 +102,7 @@ This is essential for:
 - Generating client code
 - Creating proper API requests
 
-### 5. Search Documentation (`markdownsearch`)
+### 6. Search Documentation (`DocsSearch`)
 
 For additional context and implementation guidance:
 
@@ -146,33 +182,18 @@ Search for webhook implementation examples
 
 ### Search Strategy
 - Start with broad terms like "payment" or "customer"
+- Fuzzy matching handles 1-character typos automatically
 - Use specific operation names when you know them
-- Try different variations: "create", "add", "new" might find the same operations
 
 ### Understanding Relationships
 - Operations often work together in workflows
-- Use schema definitions to understand data flow between operations
+- Use `GetSchema` to understand data flow between operations
 - Look for common parameters that link operations
 
 ### Schema Exploration
-- Always check schema definitions for complex operations
+- `GetOperation` shows schema names in request bodies - use `GetSchema` to get full details
 - Pay attention to required vs optional fields
 - Look for nested objects and their schemas
-
-### Documentation Context
-- Use markdown search for implementation guidance
-- Look for best practices and common patterns
-- Find troubleshooting information for complex scenarios
-
-## Next Steps
-
-After getting familiar with the basic tools:
-
-1. **Explore Specific Domains**: Focus on the API areas most relevant to your use case
-2. **Understand Authentication**: Learn about API keys, OAuth, and other auth methods
-3. **Review Error Handling**: Understand error codes and proper error handling
-4. **Check Rate Limits**: Learn about API usage limits and best practices
-5. **Explore Advanced Features**: Discover webhooks, workflows, and platform features
 
 ## Getting Help
 
@@ -181,8 +202,6 @@ If you need assistance:
 - Check schema definitions for data structure questions
 - Search documentation for implementation guidance
 - Explore related operations to understand complete workflows
-
-The power provides access to comprehensive, up-to-date API documentation, making it easy to find exactly what you need for your Checkout.com integration.
 
 For additional resources and detailed implementation guides, visit:
 - [Checkout.com Developer Portal](https://www.checkout.com/docs/)


### PR DESCRIPTION
## Summary

Upgrades the `checkout-api-reference` power from v1.0.0 to v2.0.0 with improved tooling, token efficiency, and clearer integration guidance.

## Changes

### New tools and renamed tools
- Added `Guide` tool — call this first to determine the right integration path (Flow vs API-to-API)
- Added `DocsSearch` — replaces `markdownsearch` for documentation search
- Renamed `docssearch` → `ApiSearch` with Lucene full-text search, fuzzy matching, and relevance ranking
- Renamed `openapilistOperations` → `ListOperations`
- Renamed `openapigetOperation` → `GetOperation` (now returns token-efficient ~300 token responses)
- Renamed `openapigetSchema` → `GetSchema`

### MCP endpoint update
- Updated MCP server URL from `https://dx-mcp.checkout.com/rpc` to `https://docs.mcp.checkout.com/rpc`

### Documentation improvements
- Added integration path guidance (Flow vs API-to-API) to POWER.md and getting-started.md
- Updated advanced-usage.md to use new tool names throughout
- Streamlined content to remove outdated sections

## Testing
Verify the MCP server is reachable at the new endpoint and that all renamed tools resolve correctly.
