### PR TITLE
ci(workflows): Update new-power-check to use pull_request_target

### DIFF
--- a/.github/workflows/new-power-check.yml
+++ b/.github/workflows/new-power-check.yml
@@ -6,55 +6,35 @@ on:
 
 permissions:
   pull-requests: write
-  contents: read
+
+concurrency:
+  group: new-power-check-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   check-new-power:
     runs-on: ubuntu-latest
     steps:
-      - name: Detect new power folders and comment
+      - name: Check for new power and comment
         uses: actions/github-script@v7
         with:
           script: |
-            const SKIP_DIRS = new Set(['.git', '.github', '.kiro', 'checkout']);
-
-            // Get files changed in this PR
             const files = await github.paginate(github.rest.pulls.listFiles, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.issue.number,
             });
 
-            // Extract unique top-level folders from changed files
-            const touchedFolders = new Set(
+            const newPowerDirs = new Set(
               files
+                .filter(f => f.status === 'added' && /^[^/]+\/POWER\.md$/.test(f.filename))
                 .map(f => f.filename.split('/')[0])
-                .filter(f => f.includes('/') === false)
             );
 
-            // Get top-level directories on the base branch
-            const { data: baseTree } = await github.rest.git.getTree({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              tree_sha: context.payload.pull_request.base.sha,
-            });
-            const baseFolders = new Set(
-              baseTree.tree
-                .filter(item => item.type === 'tree')
-                .map(item => item.path)
-            );
-
-            // Find new folders: in PR diff, not on base, not in skip list
-            const newFolders = [...touchedFolders].filter(
-              f => !baseFolders.has(f) && !SKIP_DIRS.has(f)
-            );
-
-            if (newFolders.length === 0) {
-              console.log('No new power folders detected.');
+            if (newPowerDirs.size === 0) {
+              console.log('No new POWER.md found at a top-level folder — skipping comment.');
               return;
             }
-
-            console.log(`New power folders detected: ${newFolders.join(', ')}`);
 
             const user = context.payload.pull_request.user.login;
             const body = [

--- a/.github/workflows/new-power-check.yml
+++ b/.github/workflows/new-power-check.yml
@@ -12,61 +12,50 @@ jobs:
   check-new-power:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout base branch
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Fetch PR head
-        run: git fetch origin "pull/${{ github.event.pull_request.number }}/head:pr-head"
-
-      - name: Detect new power folders
-        id: detect
-        run: |
-          SKIP_DIRS=".git .github .kiro checkout"
-
-          # Get folders that exist on the base branch
-          BASE_FOLDERS=$(git ls-tree --name-only -d "${{ github.event.pull_request.base.sha }}" 2>/dev/null || true)
-
-          # Get top-level folders touched in this PR
-          PR_FOLDERS=$(git diff --name-only "${{ github.event.pull_request.base.sha }}...pr-head" \
-            | cut -d'/' -f1 \
-            | sort -u)
-
-          # Get directories present in the PR head tree
-          PR_HEAD_DIRS=$(git ls-tree --name-only -d pr-head 2>/dev/null || true)
-
-          NEW_FOLDERS=""
-          for folder in $PR_FOLDERS; do
-            # Skip if not a directory in the PR head
-            echo "$PR_HEAD_DIRS" | grep -qx "$folder" || continue
-
-            # Skip meta directories
-            skip=false
-            for s in $SKIP_DIRS; do
-              [ "$folder" = "$s" ] && skip=true && break
-            done
-            $skip && continue
-
-            # Check if folder existed on base branch
-            if ! echo "$BASE_FOLDERS" | grep -qx "$folder"; then
-              NEW_FOLDERS="$NEW_FOLDERS $folder"
-            fi
-          done
-
-          NEW_FOLDERS=$(echo "$NEW_FOLDERS" | xargs)
-          echo "new_folders=$NEW_FOLDERS" >> "$GITHUB_OUTPUT"
-          if [ -n "$NEW_FOLDERS" ]; then
-            echo "has_new=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_new=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Comment on PR
-        if: steps.detect.outputs.has_new == 'true'
+      - name: Detect new power folders and comment
         uses: actions/github-script@v7
         with:
           script: |
+            const SKIP_DIRS = new Set(['.git', '.github', '.kiro', 'checkout']);
+
+            // Get files changed in this PR
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+
+            // Extract unique top-level folders from changed files
+            const touchedFolders = new Set(
+              files
+                .map(f => f.filename.split('/')[0])
+                .filter(f => f.includes('/') === false)
+            );
+
+            // Get top-level directories on the base branch
+            const { data: baseTree } = await github.rest.git.getTree({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tree_sha: context.payload.pull_request.base.sha,
+            });
+            const baseFolders = new Set(
+              baseTree.tree
+                .filter(item => item.type === 'tree')
+                .map(item => item.path)
+            );
+
+            // Find new folders: in PR diff, not on base, not in skip list
+            const newFolders = [...touchedFolders].filter(
+              f => !baseFolders.has(f) && !SKIP_DIRS.has(f)
+            );
+
+            if (newFolders.length === 0) {
+              console.log('No new power folders detected.');
+              return;
+            }
+
+            console.log(`New power folders detected: ${newFolders.join(', ')}`);
+
             const user = context.payload.pull_request.user.login;
             const body = [
               `Hi @${user}, thank you for your contribution!`,

--- a/.github/workflows/new-power-check.yml
+++ b/.github/workflows/new-power-check.yml
@@ -1,7 +1,7 @@
 name: New Power PR Check
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 permissions:
@@ -12,10 +12,13 @@ jobs:
   check-new-power:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout base branch
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Fetch PR head
+        run: git fetch origin "pull/${{ github.event.pull_request.number }}/head:pr-head"
 
       - name: Detect new power folders
         id: detect
@@ -23,17 +26,20 @@ jobs:
           SKIP_DIRS=".git .github .kiro checkout"
 
           # Get folders that exist on the base branch
-          BASE_FOLDERS=$(git ls-tree --name-only -d "origin/${{ github.event.pull_request.base.ref }}" 2>/dev/null || true)
+          BASE_FOLDERS=$(git ls-tree --name-only -d "${{ github.event.pull_request.base.sha }}" 2>/dev/null || true)
 
           # Get top-level folders touched in this PR
-          PR_FOLDERS=$(git diff --name-only "origin/${{ github.event.pull_request.base.ref }}...HEAD" \
+          PR_FOLDERS=$(git diff --name-only "${{ github.event.pull_request.base.sha }}...pr-head" \
             | cut -d'/' -f1 \
             | sort -u)
 
+          # Get directories present in the PR head tree
+          PR_HEAD_DIRS=$(git ls-tree --name-only -d pr-head 2>/dev/null || true)
+
           NEW_FOLDERS=""
           for folder in $PR_FOLDERS; do
-            # Skip files (no directory in diff)
-            [ -d "$folder" ] || continue
+            # Skip if not a directory in the PR head
+            echo "$PR_HEAD_DIRS" | grep -qx "$folder" || continue
 
             # Skip meta directories
             skip=false


### PR DESCRIPTION
- Change trigger from pull_request to pull_request_target for improved security
- Fetch PR head explicitly using git fetch to ensure correct ref is available
- Replace branch references with commit SHAs for more reliable comparisons
- Add PR_HEAD_DIRS variable to validate directories exist in PR head tree
- Improve directory detection logic to check against actual PR tree state
- Ensures workflow operates on correct commit context and prevents potential security issues with untrusted code

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
