### PR TITLE
fix(postman): always pass environmentId to runCollection for remote APIs

### DIFF
--- a/postman/steering/steering.md
+++ b/postman/steering/steering.md
@@ -20,7 +20,7 @@ inclusion: always
 - You are not allowed to use curl or any other API clients except Postman.
 - A Collection ID is required
 - Read the .postman.json file if it exists.
-- Use the environment for local testing if it exists. An Environment ID is required
-- The server must be running first
+- Always pass the environment ID to `runCollection` if one is available, regardless of whether the target API is local or remote. Environment variables must be resolved for tests to work correctly.
+- If the target API is a local server, ensure it is running before executing the collection. For remote APIs (e.g. staging, production, cloud endpoints), skip this check.
 - After running, display a summary of the results and a breakdown by endpoint
 - If any endpoint is failing, offer to investigate and fix the error


### PR DESCRIPTION
## Problem

The steering instruction in `# Test/Run Collections` read:

> _"Use the environment for local testing if it exists."_

The qualifier **"for local testing"** caused the agent to skip passing `environmentId` to `runCollection` when the target API was remote (e.g. AWS API Gateway, staging, or production endpoints). Environment variables like `{{base_url}}` were left unresolved, causing all requests to fail.

A secondary instruction — _"The server must be running first"_ — compounded the issue by being scoped to local servers only, creating ambiguity for remote API targets.

This was reported in [postmanlabs/postman-mcp-server#130](https://github.com/postmanlabs/postman-mcp-server/issues/130).

## Fix

- Replace the ambiguous "for local testing" phrasing with an explicit instruction to **always** pass `environmentId` when available, regardless of whether the API is local or remote.
- Clarify the "server must be running" check so it only applies to local servers and is skipped for remote APIs.

## Changes

`postman/steering/steering.md` — two lines in `# Test/Run Collections`:

```diff
- Use the environment for local testing if it exists. An Environment ID is required
- The server must be running first
+ Always pass the environment ID to `runCollection` if one is available, regardless of whether the target API is local or remote. Environment variables must be resolved for tests to work correctly.
+ If the target API is a local server, ensure it is running before executing the collection. For remote APIs (e.g. staging, production, cloud endpoints), skip this check.
```