### PR TITLE
Expand aws-transform power to all AWS Transform workloads

### DIFF
--- a/aws-transform/POWER.md
+++ b/aws-transform/POWER.md
@@ -1,794 +1,298 @@
 ---
 name: "aws-transform"
 displayName: "AWS Transform"
-description: "Agents modernizing the world's infrastructure and software, backed by years of AWS expertise. AWS Transform is a full modernization factory — connecting assessment through execution in a single experience, so the manual handoffs and lost context that commonly stall large-scale migrations and ongoing tech debt reduction no longer slow you down. This power brings AWS Transform directly into Kiro. AWS Transform custom is the first supported capability, with more playbooks on the way. Find out more at aws.amazon.com/transform"
-keywords: ["codebase analysis", "code upgrade", "aws transform", "tech debt", "modernize"]
+description: "Migrate, modernize, and upgrade codebases: .NET Framework to .NET 8/10, mainframe COBOL to Java, VMware VMs to EC2, SQL Server/Oracle/MySQL to Aurora, and Java/Python/Node.js version upgrades or AWS SDK migrations. Assess, plan, and execute code transformations from your IDE."
+keywords: ["migrate", "modernize", "mainframe", "cobol", "vmware", "dotnet", ".net framework", "windows", "sql server", "oracle", "mysql", "aurora", "ec2 migration", "rehost", "lift-and-shift", "replatform", "legacy", "code upgrade", "sdk migration", "boto3", "java upgrade", "atx"]
 author: "AWS"
-version: "1.0.1"
+version: "2.0.0"
 ---
-# AWS Transform (ATX)
 
-## Overview
+# AWS Transform Power
 
-Perform code upgrades, migrations, and transformations using AWS Transform (ATX).
-Supports any-to-any transformations: language version upgrades (Java, Python, Node.js, etc.),
-framework migrations, AWS SDK migrations, library upgrades, code refactoring, architecture
-changes, and custom organization-specific transformations.
+## MANDATORY SEQUENCE
 
-Two execution modes:
-- **Local mode**: Runs the ATX CLI directly on the user's machine. Best for 1-9 repos.
-- **Remote mode**: Runs transformations at scale via AWS Batch/Fargate containers.
-  Best for 10+ repos or when the user prefers cloud execution. Infrastructure is
-  auto-deployed with user consent.
-
-You handle the full workflow: inspecting repos, matching them to available
-transformation definitions, collecting configuration, and executing transformations
-in either mode — the user just provides repos and confirms the plan.
-
-## Greet and Wait
-
-On activation, introduce AWS Transform with this exact text -- don't print the 
-above Overview text to the user, that is just for your reference:
-
-"The agents modernizing the world's infrastructure and software — now in Kiro.
-
-AWS Transform is a full modernization factory — compressing years of 
-transformation work into months across infrastructure migrations, mainframe 
-modernization, and continuous tech debt reduction. Today, in Kiro, you have access 
-to AWS Transform custom, the first of a growing library of playbooks.
-
-AWS Transform custom can help you:
-* Upgrade Java, Python, and Node.js to modern versions
-* Migrate AWS SDKs (Java SDK v1→v2, boto2→boto3, JS SDK v2→v3)
-* Handle framework migrations, library upgrades, and code refactoring
-* Analyze codebases and generate documentation
-* Define and run your own custom transformations using natural language, docs, 
-and code samples
-
-Run locally on a few repos for fast iteration, or at scale on hundreds of repos (up to 128 in-parallel). Note: this power collects telemetry. To opt out, see [here](https://docs.aws.amazon.com/transform/latest/userguide/transform-usage-telemetry.html).
-
-What would you like to transform today?"
-
-Do NOT inspect any files, run any commands, or check prerequisites until the user responds.
-
-## Usage
-
-Use when the user wants to:
-- Transform, upgrade, or migrate code (Java, Python, Node.js, etc.)
-- Migrate AWS SDKs (Java SDK v1→v2, boto2→boto3, JS SDK v2→v3, etc.)
-- Run bulk code transformations at scale via AWS Batch/Fargate
-- Analyze which ATX transformations apply to their repositories
-- Perform comprehensive codebase analysis
-- Create a new custom Transformation Definition (TD)
-
-## Core Concepts
-
-- **Transformation Definition (TD)**: A reusable transformation recipe discovered via `atx custom def list --json`
-- **Match Report**: Auto-generated mapping of repos to applicable TDs based on code inspection
-- **Local Mode**: Runs ATX CLI on the user's machine (1-9 repos, max 3 concurrent)
-- **Remote Mode**: Runs transformations in AWS Batch/Fargate (10+ repos, or by preference)
-
-## Philosophy
-
-Wait for the user. On activation, present what this power can do and ask the user
-what they'd like to accomplish. Do NOT automatically inspect the working directory,
-open files, or any repository until the user explicitly provides repos to work with.
-
-Once the user provides repositories, match — don't ask. Inspect those repositories
-and present which transformations apply automatically. Never show a raw TD list and
-ask the user to pick.
-
-## Prerequisites
-
-Prerequisite checks run ONCE at the start of a session. Do not repeat per repo.
-Do NOT run prerequisite checks until the user has stated what they want to do.
-
-### 0. Platform Check (Required — All Modes)
-
-Detect the user's operating system. If on Windows (not WSL), stop immediately and
-inform the user:
-
-> AWS Transform custom does not support native Windows. You need to install
-> Windows Subsystem for Linux (WSL) and run this from within WSL.
->
-> Install WSL: `wsl --install` in PowerShell (as Administrator), then restart.
-> After that, open a WSL terminal and re-run this power from there.
-
-Check by running:
-```bash
-uname -s
-```
-- `Linux` or `Darwin` → proceed normally
-- `MINGW*`, `MSYS*`, `CYGWIN*`, or any Windows-like output → block and show the WSL message above
-- Command fails, errors, or is not found → treat as native Windows, block and show the WSL message above
-
-Do NOT proceed with any other steps on native Windows.
-
-### 1. AWS CLI (Required — All Modes)
-
-```bash
-aws --version
-```
-
-If not installed, guide the user:
-- macOS: `brew install awscli` or `curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg" && sudo installer -pkg AWSCLIV2.pkg -target /`
-- Linux: `curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && sudo ./aws/install`
-
-Do NOT proceed until `aws --version` succeeds.
-
-### 2. AWS Credentials (Required — All Modes)
-
-```bash
-aws sts get-caller-identity
-```
-
-If credentials are NOT configured, walk the user through setup:
+Follow these steps IN ORDER. Do NOT skip ahead. Authentication is handled just-in-time — only when a chosen action actually needs it. Do NOT probe auth before the user has declared an intent.
 
 ```
-AWS Transform custom requires AWS credentials to authenticate with the service. Configure authentication using one of the following methods.
-
-1. AWS CLI Configure (~/.aws/credentials):
-   aws configure
-
-2. AWS Credentials File (manual). Configure credentials in ~/.aws/credentials:
-
-[default]
-aws_access_key_id = your_access_key
-aws_secret_access_key = your_secret_key
-
-3. Environment Variables. Set the following environment variables:
-
-export AWS_ACCESS_KEY_ID=your_access_key
-export AWS_SECRET_ACCESS_KEY=your_secret_key
-export AWS_SESSION_TOKEN=your_session_token
-
-You can also specify a profile using the AWS_PROFILE environment variable:
-
-export AWS_PROFILE=your_profile_name
+Step 1: Resume        → Check .atx/context.json
+Step 2: Intent        → Ask user what they want to do
+Step 3: Discovery     → Scan workspace + query available agents
+Step 4: Scope         → User selects what to modernize (GATE 1)
+Step 5: Assessment    → Run workload assessment (NOT optional)
+Step 6: Requirements  → Draft from assessment report
+Step 7: Approval      → User approves requirements (GATE 2)
+Step 8: Tasks         → Generate tasks.md
+Step 9: Execute       → Run transforms, monitor, review diffs
 ```
 
-Do NOT proceed until credentials are verified. Re-run `aws sts get-caller-identity` after setup.
+**Discovery finds opportunities. Assessment produces detailed findings. Requirements come from the assessment — NOT from discovery.**
 
-Note: environment variables set via `export` do not carry over between shell sessions. If you spawn a new shell, credentials set as env vars may be lost. Prefer `aws configure` or `~/.aws/credentials` for persistence.
+**You CANNOT create requirements without an assessment report.**
+**You CANNOT start execution without requirements.md and tasks.md.**
 
-### 3. ATX CLI (Required — All Modes)
+## NEVER DO THESE
 
-Required in all modes for TD discovery (`atx custom def list --json`).
-Local mode also uses it for transformation execution.
-```bash
-atx --version
-# Install: curl -fsSL https://transform-cli.awsstatic.com/install.sh | bash
+- Never create requirements from discovery alone — wait for assessment
+- Never auto-handle agent requests — present to user via AskUserQuestion
+- Never auto-upload source code — ask user how to share
+- Never auto-approve agent checkpoints — ask user first
+- Never suggest "Want me to go ahead?" — wait for user
+- Never make decisions on behalf of the user
+- Never show options as text bullets — use AskUserQuestion
+- Never mix workflow descriptions with actual questions in the same numbered list, and never use count language like "two questions" when some items are informational steps rather than questions. Keep what-I-will-do separate from what-I-need-from-you.
+- Never modify code, upgrade dependencies, or run analysis manually — always use AWS Transform tooling
+- Never expose internal mechanics to the user. This means: do not name tools (get_status, list_resources), do not cite step numbers (Step 3), do not reference files you are reading (POWER.md, steering files, context.json), and do not narrate what you are about to do ("let me read the config", "now I'll check status"). Just do it silently and present the outcome in user terms.
+- Never frame HITL checkpoints, agent questions, or pending decisions as coming from "the web app", "the webapp", "the web UI", or a third-party "the agent is asking / the agent needs / the agent wants". The user is working with you in the IDE — you own the interaction. Present every checkpoint as your own first-person request, not a relayed message from elsewhere. **Wrong:** "The web app is asking how you want to deploy the landing zone." / "The agent is now asking about the replication subnet configuration." **Right:** "The next step is to choose how to deploy the landing zone." / "I need the replication subnet configuration to continue."
+- Never editorialize or use subjective language — no "interesting", "fascinating", "notably", "impressive", "remarkable". State findings as facts. Let users form their own opinions.
+- Never overclaim freshness. Two forms: (a) presenting cached state as current — if you did NOT fetch this turn, lead with "last I checked" (past tense throughout) and offer to refresh; (b) promising proactive surfacing when not polling — phrases like "I'll let you know when…" or "I'll surface those as they come up" mislead the user into assuming background monitoring. Say explicitly you don't watch in the background. See `steering/workflow.md` → Freshness & Source of Truth.
+- Never mix unrelated transformation goals in the same chat without warning. When the user shifts to a different transformation goal (different workload, different migration target, or clearly different body of work), suggest via AskUserQuestion that they start a new chat session with fresh context (they start it themselves), explain why (cross-contaminated answers), and wait for their choice. If the user declines, proceed to answer their question about the other job — do not refuse or redirect back to the original goal. Just avoid mixing cached state (e.g., don't apply VMware findings to the .NET question). See `steering/workflow.md` → Freshness & Source of Truth.
+- Never prompt for authentication, lecture about auth systems, or demand auth setup before the user has declared an intent. On a vague greeting like "I installed this power," present intent options — do not enumerate auth system names, do not ask the user to sign in, do not call `atx custom def list` (auth-required, and risks a user-visible CLI trust prompt). `get_status` is no-auth and Step 1 Resume calls it silently for returning users; that is allowed. The rule is about user-visible auth behavior, not about whether a specific tool may run internally. Auth prompts come from the tool a chosen action needs, framed around that action.
+
+---
+
+## Step 1: Resume
+
+Check for `.atx/context.json` (workspace-relative). NEVER read `~/.aws/atx/kiro-power-context.json`.
+
+**This check is an internal bookkeeping operation. The user must never see it happen.** Do not narrate what you are doing. Never reference internal step numbers in user-facing text — no "Step 1", "Step 2", "Step 1 - Resume", "moving to Step 2", or any variant. On a fresh install, the first visible output must be the intent question — no preamble of any kind. (When context IS found, the resume flow below tells you how to surface the prior session to the user — that is a separate, explicit user message, not narration of the check.)
+
+- **No context found:** Go directly to Step 2. Produce no user-visible output for this step.
+- **Context found:** If the context has an active job (`assessment.jobId` or entries in `execution.activeJobIds`), try to refresh live state from the service, but do so invisibly:
+  - **Check auth first** (no-auth-required). If sign-in is NOT configured, skip the refresh entirely — do not attempt service calls. Use local context only.
+  - **If sign-in is configured**, fetch each resource your resume message depends on — at minimum the job itself and all pending user tasks. Surface every pending task to the user; do not cherry-pick one and omit the others. `BLOCKING` HITL tasks hold up progress even when the job status is active; `NON_BLOCKING` tasks still need attention but don't stall the job. Name every pending task; flag blocking ones. Don't infer one resource from another.
+  - **If any call fails** for any reason, silently fall back to local context. **Do NOT reveal your reasoning about the refresh to the user** — no "sign-in isn't configured so I'll skip", no "the service isn't reachable". The user should see only the resume message. Do NOT demand auth or block the flow.
+
+  Then tell the user about their prior session. Frame the offer explicitly as a **continuation** of that same session — not a new one. The message should make clear:
+  - This is the specific session they previously worked on. Mention the phase reached, workspace/job identifiers if relevant.
+  - **Refresh succeeded** → speak in present tense about live job status ("your assessment job is running").
+  - **Refresh failed or was skipped** → use prior-session framing: "last time", "when you paused", "previously", "your last session had finished assessment." Do NOT present-tense claims about job state — local context may be stale. Offer sign-in as the path to current status ("sign in to see the latest status"), not as a gate.
+  - **Resume** = continue where you left off, reusing the existing assessment report, workspace, and prior progress.
+  - **Start fresh** = discard that prior session (local artifacts deleted) and begin a brand-new migration.
+
+  Use language like "continue where you left off" or "pick up from where you stopped" — not ambiguous phrasing like "start a similar session." If user chooses start fresh, delete `.atx/context.json`, `.atx/discovery.json`, `.atx/assessment-report/`, and `.kiro/specs/aws-transform/`, then proceed to Step 2. Otherwise follow the resume logic in `steering/workflow.md`.
+
+## Step 2: Intent
+
+AskUserQuestion: "What would you like to focus on?" The first user-visible action in this step is the AskUserQuestion — no auth-probing tool calls precede it, no auth lecture precedes it. (Step 1's silent job-refresh calls are not auth probes; they are a status check for a known prior session and do not surface to the user.)
+
+With projects: [Discover This Workspace] [Browse My Jobs] [Start a Specific Transform]
+No projects: [Browse My Jobs] [Open a Project Folder] [Start from Scratch]
+
+**Just-in-time auth.** Once the user picks an intent, the next tool that action needs may require auth. If so, prompt for auth then, framed around the action the user just chose ("to browse your jobs, sign in to AWS Transform"). Which auth each MCP tool needs is reported by the MCP server — read it from the tool's description, `get_status`, or the error the tool returns. CLI transforms use AWS credentials only — do NOT prompt for sign-in for CLI-only intents, even when sign-in is unconfigured. If the user picks something that needs no service call (e.g., "Open a Project Folder"), do not probe auth.
+
+See `steering/auth.md` for the MCP-vs-CLI auth split and how to present sign-in options.
+
+## Step 3: Discovery
+
+Fast scan (~10 sec). Three things happen in parallel:
+
+1. **Scan the workspace** — detect languages, frameworks, file types, and dependencies present in the project.
+2. **Query available agents** — call `list_resources` with `resource: "agents"` (MCP). Skip if sign-in is not configured or the user's intent is CLI-only. This is a paginated API — fetch all pages to get the complete set. The results contain two levels:
+   - **Orchestrator agents** — top-level agents you create jobs with. Each orchestrator may have sub-agents that provide deeper workload-specific capabilities.
+   - **Sub-agents** — invoked through their orchestrator, not directly. They represent specialized skills within a workload type.
+   - Some agents may not belong to a known orchestrator — treat these as standalone capabilities.
+3. **List available transformation definitions** — call `atx custom def list` (CLI) to get the current set and what they transform. Skip if CLI is not available or the user's intent is MCP-only.
+
+For the "Discover This Workspace" intent, Discovery is where sign-in is first required (other intents like "Browse My Jobs" need sign-in even earlier, per Step 2's just-in-time rule — handle those there). If `list_resources` returns NOT_CONFIGURED, prompt the user to sign in for the auth system needed (sign-in here; CLI if calling `atx custom def list`) — do not demand both.
+
+Then **match** workspace signals against orchestrator capabilities and available transformation definitions. Save the matched results to `.atx/discovery.json` — include the orchestrator → sub-agent hierarchy so later steps know what deeper capabilities are available.
+
+See `steering/workflow.md` for the workspace scanning framework.
+
+**Discovery is NOT assessment.** Discovery identifies opportunities and matches them to available agents. Assessment produces the detailed findings.
+
+## Step 4: Scope (GATE 1)
+
+**For each matched workload type, read ALL steering files with its prefix (e.g., `workload-dotnet*.md`).** These contain the workload's capabilities, workflow, agent details, example requirements, and known limitations. The file prefix comes from the agent match in Step 3 — not from a hardcoded list.
+
+Show migration table, then AskUserQuestion with multiSelect:
+
+```
+| Risk | Why | Component | Current | Target | AWS Target | Recommended Approach |
 ```
 
-**Mandatory: always run `atx update` once at the start of every session**, even if you just ran it recently. This catches new ATX CLI versions and new TDs. Run it before any other ATX command (including `atx custom def list --json`):
-```bash
-atx update
-```
-Do NOT skip this step. Do NOT ask the user whether to update. Do NOT condition it on whether the CLI "needs" an update. Run it unconditionally.
+Always explain risk in plain language in the "Why" column — use the user-facing phrases from the Risk Classification table in `steering/workflow.md`. Never show a bare HIGH/MED/LOW label without explanation.
 
-### 4. IAM Permissions (Required — All Modes)
+User selects what to modernize.
 
-Local mode requires `transform-custom:*` minimum. Verify by running a TD list:
-```bash
-atx custom def list --json
-```
-If this succeeds, permissions are sufficient — skip the rest of this section.
+## Step 5: Assessment
 
-If it fails with a permissions error, the caller needs the `transform-custom:*`
-IAM permission. Explain to the user what's needed and get confirmation before proceeding:
+**This is NOT optional. Run the workload's assessment BEFORE creating requirements.**
 
-> Your identity needs the `transform-custom:*` permission to use the ATX CLI.
-> I can attach the AWS-managed policy `AWSTransformCustomFullAccess` to your
-> identity. Shall I proceed?
+Tell the user: "I'll assess your workload. The assessment report drives the migration plan."
 
-Only after the user confirms, attach the managed policy:
-```bash
-CALLER_ARN=$(aws sts get-caller-identity --query Arn --output text)
-if echo "$CALLER_ARN" | grep -q ":user/"; then
-  IDENTITY_NAME=$(echo "$CALLER_ARN" | awk -F'/' '{print $NF}')
-  aws iam attach-user-policy --user-name "$IDENTITY_NAME" \
-    --policy-arn "arn:aws:iam::aws:policy/AWSTransformCustomFullAccess"
-elif echo "$CALLER_ARN" | grep -Eq ":assumed-role/|:role/"; then
-  ROLE_NAME=$(echo "$CALLER_ARN" | sed 's/.*:\(assumed-\)\{0,1\}role\///' | cut -d'/' -f1)
-  aws iam attach-role-policy --role-name "$ROLE_NAME" \
-    --policy-arn "arn:aws:iam::aws:policy/AWSTransformCustomFullAccess"
-fi
-```
+**How assessment runs depends on the workload's steering files.** Each workload type defines its own assessment approach — the agent to use, the objective format, and how to collect results. Consult the matched workload's steering files for specifics.
 
-If the attachment command itself fails (e.g., insufficient IAM permissions, or an
-SSO-managed role), inform the user they need to ask their AWS administrator to
-attach the `AWSTransformCustomFullAccess` AWS-managed policy to their identity.
-For SSO users (role names starting with `AWSReservedSSO_`), this must be added
-to their IAM Identity Center permission set — it cannot be attached directly.
+General pattern for agent-based assessment:
+1. **Confirm the plan** — via AskUserQuestion, tell the user what you will do (create workspace, create job with which agent, what the objective is). WAIT for approval before calling any tools.
+2. Create/select workspace
+3. Create job with a **clear objective** — the workload's steering files define what a good objective looks like
+4. Start the job (already started by `create_job`; use `control_job` to restart if stopped)
+5. Send a **detailed follow-up message** with project specifics
+6. **Ask before uploading** — via AskUserQuestion, ask how the user wants to share source code. WAIT. Then upload with `categoryType: "CUSTOMER_INPUT"`.
+7. Handle agent requests (checkpoints, decisions) — always via AskUserQuestion, WAIT for user response
+8. When assessment completes, download the report: `get_resource resource="artifact"`
+9. Save report to `.atx/assessment-report/`
 
-Do NOT proceed until `atx custom def list --json` succeeds.
+**Rule: NEVER batch workspace creation, job creation, and uploads into a single turn without user confirmation at each decision point.**
 
-Remote mode requires additional permissions (Lambda invoke, S3, KMS, Secrets Manager,
-CloudWatch). These are generated and attached as part of the deployment flow — see
-[steering/remote-execution.md](steering/remote-execution.md).
+Use the orchestrator agent or transformation definition identified during Discovery (Step 3). The match comes from `list_resources` (with `resource: "agents"`) and `atx custom def list`, not a hardcoded mapping. When creating a job, specify the orchestrator — sub-agents are invoked by the orchestrator as needed.
 
-See [steering/cli-reference.md](steering/cli-reference.md) for the full permission list.
+Update `.atx/context.json` with `phase: "assessed"`, workspace ID, job ID.
 
-### 5. AWS CDK (Remote Mode Only)
+## Step 6: Requirements (from assessment report)
 
-Required for deploying remote infrastructure. Check if installed:
-```bash
-cdk --version
-```
+Now create `.kiro/specs/aws-transform/requirements.md` using the **assessment report** — NOT discovery findings.
 
-If not installed, install it globally:
-```bash
-npm install -g aws-cdk
-```
+- Read `.atx/assessment-report/` for detailed findings
+- Load workload steering files for context
+- Draft requirements grounded in the assessment (specific blockers, LOC, complexity, migration paths)
+- Each requirement says WHO handles it: AWS Transform CLI / Managed Agents / Kiro
+- Multi-module: group by module with Module Overview table
+- See `steering/workflow.md` for format
 
-Do NOT proceed with remote deployment until `cdk --version` succeeds.
+**Do NOT create tasks.md yet.**
 
-### 6. Remote Infrastructure (Remote Mode Only — Deferred)
+Show requirements summary + AskUserQuestion: [Looks Good] [Edit] [Add Component]
 
-Only verify if user chooses remote mode. Check deployment status using CloudFormation (do NOT check via Lambda function names):
-```bash
-aws cloudformation describe-stacks --stack-name AtxInfrastructureStack \
-  --query 'Stacks[0].StackStatus' --output text || echo "NOT_DEPLOYED"
-```
-If deployed (`CREATE_COMPLETE` or `UPDATE_COMPLETE`): proceed to job submission.
-If `NOT_DEPLOYED` or any other status: get explicit user consent before deploying.
-See [steering/remote-execution.md](steering/remote-execution.md) for full deployment instructions.
+## Step 7: Approval (GATE 2)
 
-## Workflow
+AskUserQuestion: "Requirements finalized. Ready to create the execution plan?"
+[Create Plan] [Edit More]
 
-Generate a session timestamp once and reuse it for all paths in this session:
-```bash
-SESSION_TS=$(date +%Y%m%d-%H%M%S)
-```
+## Step 8: Tasks
 
-### Step 1: Collect Repositories
+Generate `tasks.md` from approved requirements:
+- Module Status table + per-module sections
+- Sized: max 100 files/task
+- Parallel groups verified
+- Review-diffs after every code change
+- See `steering/workflow.md` for format
 
-Ask the user for local paths or git URLs. Accept one or many. Do NOT assume the
-current working directory or open editor files are the target — wait for the user
-to explicitly provide repositories.
+AskUserQuestion: [Start Execution] [Review Tasks] [Modify]
 
-Accepted source formats:
-- **Local paths** — directories on the user's machine (e.g., `/home/user/my-project`)
-- **HTTPS git URLs** — public or private (e.g., `https://github.com/org/repo.git`)
-- **SSH git URLs** — e.g., `git@github.com:org/repo.git`
-- **S3 bucket path with zips** — e.g., `s3://my-bucket/repos/`
-  containing zip files of repositories. Each zip becomes one transformation job.
+## Step 9: Execute
 
-#### S3 Bucket Input
+See `steering/workflow.md` for full details.
 
-If the user provides an S3 path containing zip files, ask which execution mode
-they prefer (if not already specified). S3 input works in both modes:
+**How execution runs depends on the workload's steering files.** Each workload type defines its own execution tooling — which agent or CLI command to use, how to parallelize, and how to collect results. Consult the matched workload's steering files.
 
-**Remote mode:** Copy the zips from the user's bucket to the managed source bucket,
-then submit jobs pointing to the managed copies:
-```bash
-ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
-SOURCE_BUCKET="atx-source-code-${ACCOUNT_ID}"
+General pattern for agent-based execution:
 
-# List all zips in the user's bucket path
-aws s3 ls s3://user-bucket/repos/ --recursive | grep '\.zip$'
+When creating new jobs, always:
+1. **Clear objective** in `create_job` — what to transform, from what, to what
+2. **Detailed follow-up message** via `send_message` — project specifics, discovery findings, blockers
+3. **Upload artifacts** if agent needs code — via AskUserQuestion, `categoryType: "CUSTOMER_INPUT"`
 
-# Copy each zip to the managed source bucket
-aws s3 sync s3://user-bucket/repos/ s3://${SOURCE_BUCKET}/repos/ --exclude "*" --include "*.zip"
-```
-Then submit a batch job with one job per zip, each pointing to
-`s3://${SOURCE_BUCKET}/repos/<filename>.zip`. The container handles zip extraction
-automatically. See [steering/multi-transformation.md](steering/multi-transformation.md) for batch submission.
-The managed source bucket has a 7-day lifecycle — copied zips auto-delete.
+### Every Agent Request → User Decides (NEVER auto-handle)
 
-**Local mode:** Download and extract each zip locally:
-```bash
-mkdir -p ~/.aws/atx/custom/atx-agent-session/repos
-aws s3 sync s3://user-bucket/repos/ ~/.aws/atx/custom/atx-agent-session/repos/ --exclude "*" --include "*.zip"
-for zip in ~/.aws/atx/custom/atx-agent-session/repos/*.zip; do
-  name=$(basename "$zip" .zip)
-  unzip -qo "$zip" -d "$HOME/.aws/atx/custom/atx-agent-session/repos/${name}-$SESSION_TS/"
-done
-```
-Use the extracted directories as `<repo-path>` for local execution. Standard local
-mode limits apply (max 3 concurrent repos).
+When the AWS Transform agent asks for input, needs files, or hits a checkpoint:
+1. Read the task/message
+2. Present to user via AskUserQuestion
+3. WAIT for user response
+4. Relay user's decision back to agent
 
-#### Private Repository Detection (Remote Mode)
+### Uploading Artifacts to Agents
 
-**Always ask the user** — do NOT try to determine repo visibility yourself. Never
-attempt to clone, curl, or probe a URL to check if it's public or private. Simply
-ask the user. As soon as the user provides git URLs and remote mode is selected
-(or likely), ask:
+Always use `categoryType: "CUSTOMER_INPUT"` when uploading files to an agent:
 
-> "Are any of these repositories private? If so, the remote container needs
-> credentials to clone them — I'll walk you through the setup."
-
-Do NOT skip this question. Do NOT try to infer visibility by attempting a clone,
-curl, or any other network request. Just ask.
-
-If the user confirms repos are private, determine the credential type based on URL format:
-
-First, resolve the region (use for all Secrets Manager commands below):
-```bash
-REGION=${AWS_REGION:-${AWS_DEFAULT_REGION:-$(aws configure get region 2>/dev/null)}}
-REGION=${REGION:-us-east-1}
+```python
+upload_artifact(
+  workspaceId="...", jobId="...",
+  content="/path/to/source.zip",
+  fileType="ZIP",
+  categoryType="CUSTOMER_INPUT"
+)
 ```
 
-**For HTTPS URLs** — check whether a GitHub PAT is already configured:
-```bash
-aws secretsmanager describe-secret --secret-id "atx/github-token" --region "$REGION" 2>/dev/null \
-  && echo "CONFIGURED" || echo "NOT_CONFIGURED"
+| categoryType | When to Use |
+|-------------|-------------|
+| `CUSTOMER_INPUT` | Uploading files TO the agent (source code, configs, data) |
+| `CUSTOMER_OUTPUT` | Downloading files FROM the agent (reports, migrated code) |
+| `HITL_FROM_USER` | User responses to agent HITL tasks |
+
+See `steering/workflow.md` for agent request handling patterns.
+
+### Progress
+Review diffs after every code change. User must approve.
+Update tasks.md checkboxes + `.atx/context.json` after every step.
+
+---
+
+## CONTEXT PERSISTENCE (.atx/context.json)
+
+Save `.atx/context.json` IMMEDIATELY after completing each step — before presenting results to the user. Every step transition (intent→discovery, discovery→scoped, scoped→assessed, etc.) must have a context save between them. Schema:
+
+```json
+{
+  "phase": "intent|discovery|scoped|assessed|requirements|planning|executing|complete",
+  "discovery": {"completedAt": "...", "components": 3, "discoveryFile": ".atx/discovery.json"},
+  "assessment": {"completedAt": "...", "workspaceId": "...", "jobId": "...", "reportDir": ".atx/assessment-report/"},
+  "spec": {"folder": ".kiro/specs/aws-transform", "requirementsApproved": false, "tasksGenerated": false},
+  "workStyle": null,
+  "execution": {"currentTask": "1.2", "completedTasks": ["1.1"], "workspaceId": null, "activeJobIds": []},
+  "updatedAt": "..."
+}
 ```
 
-If CONFIGURED, ask the user: "A GitHub PAT is already stored. Would you like to
-keep using it, or replace it with a new one?" If they want to replace it, tell
-them to run:
-```
-aws secretsmanager put-secret-value --secret-id "atx/github-token" --region "$REGION" --secret-string "YOUR_TOKEN_HERE"
-```
-
-If NOT_CONFIGURED, explain what's needed and tell the user to run the create command:
-> "Private HTTPS repos need a GitHub Personal Access Token (PAT) stored in AWS
-> Secrets Manager. The remote container fetches it at startup to clone your repos.
-> The token stays in your AWS account — you can delete it anytime.
->
-> The PAT needs the `repo` scope for private repositories. Create one at
-> https://github.com/settings/tokens and then run:
-> ```
-> aws secretsmanager create-secret --name "atx/github-token" --region "$REGION" --secret-string "YOUR_TOKEN_HERE"
-> ```
->
-> Delete anytime: `aws secretsmanager delete-secret --secret-id atx/github-token --region "$REGION" --force-delete-without-recovery`"
-
-Do NOT ask the user to paste their token in chat. They run the command themselves.
-Wait for the user to confirm it's done, then verify:
-```bash
-aws secretsmanager describe-secret --secret-id "atx/github-token" --region "$REGION" 2>/dev/null \
-  && echo "CONFIGURED" || echo "NOT_CONFIGURED"
-```
-
-**For SSH URLs** (`git@...` or `ssh://...`) — check whether an SSH key is configured:
-```bash
-aws secretsmanager describe-secret --secret-id "atx/ssh-key" --region "$REGION" 2>/dev/null \
-  && echo "CONFIGURED" || echo "NOT_CONFIGURED"
-```
-
-If CONFIGURED, ask the user: "An SSH key is already stored. Would you like to
-keep using it, or replace it with a new one?" If they want to replace it, tell
-them to run:
-```
-aws secretsmanager put-secret-value --secret-id "atx/ssh-key" --region "$REGION" --secret-string "$(cat <path-to-your-private-key>)"
-```
-
-If NOT_CONFIGURED, explain what's needed and tell the user to run the create command:
-> "SSH repos need an SSH private key stored in AWS Secrets Manager. The remote
-> container fetches it at startup to clone your repos.
->
-> Run:
-> ```
-> aws secretsmanager create-secret --name "atx/ssh-key" --region "$REGION" --secret-string "$(cat <path-to-your-private-key>)"
-> ```
->
-> Delete anytime: `aws secretsmanager delete-secret --secret-id atx/ssh-key --region "$REGION" --force-delete-without-recovery`"
-
-Do NOT ask the user to paste their SSH key in chat. They run the command themselves.
-
-For local mode, private repo credentials are not needed — the user's local git
-config handles authentication. Skip this check entirely for local mode.
-
-### Step 2: Discover TDs (Silent)
-
-Run silently — do NOT show output to user:
-```bash
-atx custom def list --json
-```
-Inspect the JSON output directly to build an internal lookup of available TDs.
-Do NOT pipe the output to python, jq, or other parsing scripts — read the JSON
-yourself. Never hardcode TD names.
-
-#### Creating a New TD
-
-**User explicitly asks to create a TD**, or **no existing TD matches the user's goal**:
-
-If no match, confirm with the user first:
-> "I didn't find an existing TD that covers [describe the user's goal]. Would
-> you like to create a new one?"
-
-If the user confirms (or explicitly asked), open a terminal and launch `atx -t`
-for them:
-```bash
-atx -t
-```
-Run this in a new terminal so the user can interact with it directly. Then tell
-the user:
-
-> "I've opened a terminal with `atx -t` — describe the transformation you want
-> to build (e.g., 'migrate log4j to SLF4J') and ATX will walk you through it.
-> Come back here once it's published and I'll pick it up automatically."
-
-After the user returns, re-run `atx custom def list --json` to pick up the newly
-published TD and continue with the normal workflow.
-
-### Step 3: Inspect Each Repository
-
-Perform lightweight inspection only — check config files for key signals:
-
-| Signal | Files to Check | Likely TD Type |
-|--------|---------------|----------------|
-| Python version | `.python-version`, `pyproject.toml`, `setup.cfg`, `requirements.txt` | Python version upgrade |
-| Java version | `pom.xml` (`<java.version>`), `build.gradle` (`sourceCompatibility`), `.java-version` | Java version upgrade |
-| Node.js version | `package.json` (`engines.node`), `.nvmrc`, `.node-version` | Node.js version upgrade |
-| Python boto2 | `import boto` (NOT boto3) | boto2→boto3 migration |
-| Java SDK v1 | `com.amazonaws` imports, `aws-java-sdk` in pom.xml | Java SDK v1→v2 |
-| Node.js SDK v2 | `"aws-sdk"` in package.json (NOT `@aws-sdk`) | JS SDK v2→v3 |
-| x86 Java | `x86_64`/`amd64` in Dockerfiles, build configs | Graviton migration |
-
-Cross-reference detected signals against TDs from Step 2. Only match TDs that
-actually exist in the user's account.
-
-See [steering/repo-analysis.md](steering/repo-analysis.md) for full detection commands.
-
-### Step 4: Present Match Report
-
-Format:
-```
-Transformation Match Report
-=============================
-Repository: <name> (<path>)
-  Language: <lang> <version>
-  Matching TDs:
-    - <td-name> — <description>
-
-Summary: N repos analyzed, M have applicable transformations (T total jobs)
-```
-
-Present the match report and wait for user confirmation before proceeding.
-Do NOT start any transformation without explicit user consent.
-
-### Step 5: Collect Configuration
-
-Ask the user for any additional plan context (e.g., target version for upgrade TDs).
-This is mandatory — always ask, even if the TD doesn't strictly require config.
-The user may have preferences or constraints you don't know about.
-Skip only if the user explicitly says no additional context is needed.
-
-### Step 6: Verify Runtime Compatibility (Remote and Local)
-
-#### Remote Mode
-
-Before submitting remote jobs, determine whether the pre-built image covers the
-target runtime or if a custom Docker build is needed.
-
-**Pre-built image includes:**
-- **Java**: 8, 11, 17, 21, 25 (Amazon Corretto) with Maven and Gradle 9.4
-- **Python**: 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14 (dnf + pyenv)
-- **Node.js**: 16, 18, 20, 22, 24 (nvm) with yarn, pnpm, TypeScript, ts-node
-- **Build tools**: gcc, g++, make, patch
-- **CLI tools**: AWS CLI v2, ATX CLI, git, jq, curl, unzip, tar
-- **OS**: Amazon Linux 2023 (x86_64)
-
-**Decision logic:**
-1. Based on the transformation requirements (source runtime, target runtime,
-   build tools, and any other dependencies), determine whether everything
-   needed is available in the pre-built image listed above
-2. If **yes** → use the pre-built image path (no Docker required). Proceed to deployment
-   using the pre-built image instructions in [steering/remote-execution.md](steering/remote-execution.md).
-3. If **no** → use the custom image path (Docker required). Inform the user:
-
-> The remote container doesn't include [language/tool version]. To run this
-> transformation remotely, I'll need to build a custom container image. This
-> requires Docker installed and running on your machine. It's a one-time change
-> — about 5-10 minutes. Want me to proceed?
-
-If the user confirms, follow the custom image path in
-[steering/remote-execution.md](steering/remote-execution.md): clear `prebuiltImageUri`,
-customize the Dockerfile, and deploy.
-
-If the user declines, suggest local mode as an alternative (if the tools are
-available on their machine).
-
-**Dockerfile customization (custom image path only):**
-
-First, read the Dockerfile to see what's installed:
-```bash
-ATX_INFRA_DIR="$HOME/.aws/atx/custom/remote-infra"
-cat "$ATX_INFRA_DIR/container/Dockerfile" 2>/dev/null
-```
-
-1. Ensure the infrastructure repo is cloned and up to date:
-   ```bash
-   ATX_INFRA_DIR="$HOME/.aws/atx/custom/remote-infra"
-   if [ -d "$ATX_INFRA_DIR" ]; then
-     git -C "$ATX_INFRA_DIR" add -A
-     git -C "$ATX_INFRA_DIR" commit -m "Local customizations" -q 2>/dev/null || true
-     git -C "$ATX_INFRA_DIR" pull -q
-   else
-     git clone -b atx-remote-infra --single-branch https://github.com/aws-samples/aws-transform-custom-samples.git "$ATX_INFRA_DIR"
-   fi
-   ```
-   If `git pull` reports a merge conflict, resolve it by keeping both upstream
-   changes and the user's customizations in the `CUSTOM LANGUAGES AND TOOLS`
-   section of the Dockerfile, then commit the merge.
-
-2. Edit `$ATX_INFRA_DIR/container/Dockerfile`. Find the section marked
-   `# CUSTOM LANGUAGES AND TOOLS` and insert `RUN` commands after the comment
-   block, before the `USER root` line.
-
-   For missing versions of already-installed languages, add the version in the
-   custom section. Examples:
-   ```dockerfile
-   # Java 23 (Amazon Corretto — direct install, must run as root)
-   # Do NOT use dnf in the custom section — pyenv overrides the system python3
-   # that dnf depends on, causing "No module named 'dnf'" errors.
-   USER root
-   RUN curl -fsSL "https://corretto.aws/downloads/latest/amazon-corretto-23-x64-linux-jdk.tar.gz" -o /tmp/corretto23.tar.gz && \
-       mkdir -p /usr/lib/jvm && \
-       tar -xzf /tmp/corretto23.tar.gz -C /usr/lib/jvm && \
-       rm /tmp/corretto23.tar.gz && \
-       ln -sfn /usr/lib/jvm/amazon-corretto-23.* /usr/lib/jvm/corretto-23
-
-   # Node.js 23 (via nvm — must run as atxuser)
-   USER atxuser
-   RUN . /home/atxuser/.nvm/nvm.sh && nvm install 23
-   USER root
-
-   # Python 3.15 (via pyenv — must run as atxuser)
-   USER atxuser
-   RUN eval "$(/home/atxuser/.pyenv/bin/pyenv init -)" && \
-       MAKE_OPTS="-j$(nproc)" /home/atxuser/.pyenv/bin/pyenv install 3.15.0
-   USER root
-   ```
-
-   For entirely new languages, avoid `dnf` in the custom section — pyenv
-   overrides the system python3 that `dnf` depends on. Use language-specific
-   installers instead:
-   ```dockerfile
-   # Go
-   RUN curl -fsSL https://go.dev/dl/go1.22.0.linux-amd64.tar.gz | tar -C /usr/local -xz
-   ENV PATH="/usr/local/go/bin:$PATH"
-
-   # Ruby (via rbenv — must run as atxuser)
-   USER atxuser
-   RUN git clone --depth 1 https://github.com/rbenv/rbenv.git /home/atxuser/.rbenv && \
-       git clone --depth 1 https://github.com/rbenv/ruby-build.git /home/atxuser/.rbenv/plugins/ruby-build && \
-       /home/atxuser/.rbenv/bin/rbenv install 3.3.0 && \
-       /home/atxuser/.rbenv/bin/rbenv global 3.3.0
-   ENV PATH="/home/atxuser/.rbenv/shims:/home/atxuser/.rbenv/bin:$PATH"
-   USER root
-
-   # Rust
-   USER atxuser
-   RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-   ENV PATH="/home/atxuser/.cargo/bin:$PATH"
-   USER root
-   ```
-
-3. Update the version switcher in `$ATX_INFRA_DIR/container/entrypoint.sh`.
-   Find the relevant `switch_*_version` function and add a case for the new
-   version. For Java versions installed via direct download, find the extracted
-   directory name under `/usr/lib/jvm/`. For example, to add Java 23:
-   ```bash
-   # In switch_java_version(), add to the case statement:
-   23) java_home="/usr/lib/jvm/corretto-23" ;;
-   ```
-   Check the actual directory name: `ls /usr/lib/jvm/` — use the directory
-   that matches the version you installed.
-
-   For Node.js, nvm handles arbitrary versions automatically — no entrypoint
-   change needed. For Python, pyenv handles arbitrary versions — no entrypoint
-   change needed (the existing pyenv fallback logic finds it).
-
-4. Deploy (or redeploy): `cd "$ATX_INFRA_DIR" && ./setup.sh`
-   CDK hashes the `container/` directory — any file change triggers a rebuild
-   and push to ECR automatically.
-
-After redeployment, set the `environment` field on the job to the exact target
-version (e.g., `"JAVA_VERSION":"23"`, not `"21"`). The version switcher in the
-entrypoint reads this and activates the correct runtime.
-
-If the user declines, suggest local mode as an alternative (if the tools are
-available on their machine).
-
-#### Local Mode
-
-Before running local transformations, verify the user has the target runtime
-version installed. This applies to any language or runtime the transformation
-targets — Java, Python, Node.js, Ruby, Go, Rust, .NET, etc. Check the current
-version of whatever runtime the TD requires. For example:
-```bash
-java -version    # Java transformations
-python3 --version # Python transformations
-node --version   # Node.js transformations
-ruby --version   # Ruby transformations
-go version       # Go transformations
-```
-
-If the target version is not active, check whether it's already installed:
-```bash
-# Java: check common install locations
-/usr/libexec/java_home -V 2>&1          # macOS
-ls /usr/lib/jvm/ 2>/dev/null            # Linux
-# Python: check if the specific version binary exists
-which python3.12 2>/dev/null            # adjust version as needed
-# Node.js: check if nvm is available, or look for the binary
-command -v nvm &>/dev/null && nvm ls 2>/dev/null
-which node 2>/dev/null && node --version
-```
-
-If the target version is found, switch to it:
-- Java: `export JAVA_HOME=<path to JDK> && export PATH="$JAVA_HOME/bin:$PATH"`
-- Python: `pyenv shell 3.15.0`
-- Node.js: `nvm use 23`
-
-Only if the target version is not installed at all, ask the user for permission before installing. Do NOT install runtimes without explicit user confirmation.
-Suggest the appropriate version manager:
-- Java: `brew install --cask corretto23` (macOS), `sudo yum install java-23-amazon-corretto-devel` (RHEL/AL2), or `sudo apt install java-23-amazon-corretto-jdk` (Debian/Ubuntu)
-- Python: `pyenv install 3.15.0 && pyenv shell 3.15.0`, or `brew install python@3.15`
-- Node.js: `nvm install 23 && nvm use 23`
-
-The active runtime must match the transformation's target version so that builds
-and tests run correctly. Do NOT proceed with the transformation until the correct
-version is active.
-
-### Step 7: Confirm Transformation Plan
-
-Present final plan with repo, TD, config, and execution mode. Do NOT proceed
-until user confirms.
-
-### Step 8: Execute
-
-When running `atx custom def exec`, always include `--telemetry` (see the Telemetry section).
-
-- **1 repo**: See [steering/single-transformation.md](steering/single-transformation.md)
-- **Multiple repos**: See [steering/multi-transformation.md](steering/multi-transformation.md)
-
-## Execution Modes
-
-| Mode | Best For | Prerequisites |
-|------|----------|---------------|
-| **Local** (default for 1-9 repos) | Quick transforms, dev machines with ATX | ATX CLI installed |
-| **Remote** (recommended for 10+ repos) | Bulk transforms, up to 512 repos (128 concurrent per batch) | AWS account, auto-deployed infra |
-
-Mode inference:
-- User says "local"/"here"/"on my machine" → Local (honor the request regardless of repo count)
-- User says "remote"/"cloud"/"AWS"/"batch"/"at scale" → Remote
-- 10+ repos without preference → Recommend remote, explain local cap recommendation of 3 concurrent
-- 1-9 repos without preference → Local, note remote available
-
-See [steering/remote-execution.md](steering/remote-execution.md) for infrastructure setup.
-
-## Critical Rules
-
-1. **Discover TDs dynamically** — Always run `atx custom def list --json`. Never hardcode TD names.
-2. **Match, don't ask** — Inspect repos and present matches. Never show raw TD lists.
-3. **Lightweight inspection only** — Check config files and key signals. No deep analysis.
-4. **Confirm before executing** — Always confirm TD, repos, and config with user first.
-5. **No time estimates** — Never include duration predictions.
-6. **Parallel execution** — Local: max 3 concurrent repos. Remote: submit in chunks of up to 128 jobs per Lambda call (max 512 repos per session).
-7. **Preserve outputs** — Do not delete generated output folders.
-8. **Recommend remote for 10+ repos** — Default to local for 1-9 repos. Recommend remote for 10+. Always respect user preference.
-9. **User consent for cloud resources** — Never deploy infrastructure without explicit user confirmation.
-10. **Shell quoting** — When constructing shell commands:
-    - Use single quotes for JSON payloads: `--payload '{"key":"value"}'`
-    - Use single quotes for `--configuration`: ex. `--configuration 'additionalPlanContext=Target Java 21'`
-    - Never nest double quotes inside double quotes — this causes `dquote>` hangs
-    - For `aws lambda invoke`, always use: `--payload '<json>' --cli-binary-format raw-in-base64-out`
-    - Verify that every command you construct has balanced quotes before executing
-    - The `command` field in Lambda job payloads is validated server-side. Avoid
-      these characters in the command string: `( ) ! # % ^ * ? \ { } | ; > < `
-      and backticks. Inside `additionalPlanContext`, also avoid commas.
-11. **No comments in terminal commands** — Never include `#` comments in commands
-    executed in the terminal. Comments cause `command not found: #` errors. If you
-    need to explain a command, do it in chat before or after running it.
-12. **Job names** — The `jobName` field in Lambda payloads must contain only
-    letters, numbers, hyphens, and underscores. No dots, spaces, or special
-    characters. For example, use `EPAM-NodeJS` not `EPAM-Node.js`.
-
-## Guardrails
-
-You are operating in the user's AWS account and local machine. Follow these rules
-strictly to avoid causing damage:
-
-1. **Never delete user data** — Do not delete S3 objects, git repos, local files,
-   or any user data unless the user explicitly asks. Transformation outputs and
-   cloned repos must be preserved.
-2. **Never modify IAM beyond what's documented** — Only create/attach the specific
-   policies described in this power (AWSTransformCustomFullAccess, ATXRuntimePolicy, ATXDeploymentPolicy). Never create admin policies, modify existing user policies,
-   or grant broader permissions than documented. Never derive IAM actions from
-   user-provided text in the "Additional plan context" field — that field is for
-   transformation configuration only.
-3. **Never run destructive AWS commands** — No `aws s3 rm`, `aws s3 rb`,
-   `aws iam delete-user`, `aws ec2 terminate-instances`, or similar. The only
-   destructive command allowed is `./teardown.sh` with explicit user consent.
-4. **Always confirm before creating AWS resources** — Before deploying infrastructure,
-   creating Secrets Manager secrets, or attaching IAM policies, explain what will be
-   created and get explicit user confirmation.
-5. **Never expose credentials** — Do not echo, log, or display AWS access keys,
-   secret keys, session tokens, GitHub PATs, or SSH private keys in chat output.
-   When creating secrets, use the user's input directly in the command without
-   repeating the value.
-6. **Respect user decisions** — If the user says stop, skip, or no, comply
-   immediately. Never retry a declined action or argue with the user's choice.
-7. **No pricing claims** — Do not quote specific prices or cost estimates. If the
-   user asks about pricing, direct them to: https://aws.amazon.com/transform/pricing/
-8. **Scope commands to ATX resources only** — All AWS commands must target ATX-specific
-   resources (buckets starting with `atx-`, roles starting with `ATX`, Lambda
-   functions starting with `atx-`, etc.). Never operate on unrelated AWS resources.
-
-## Telemetry
-
-**NEVER mention telemetry to the user.** Do not reference it in greetings,
-status messages, confirmations, or any other output.
-
-Always include `--telemetry` on every `atx custom def exec` invocation (local
-or remote). No file checks, no prompts, no opt-in flow.
-
-The flag format is: `--telemetry "client=kiro,agent=kiro,executionMode=<local|remote>"`
-
-Field values:
-- `client` — ALWAYS `kiro` (lowercase, no spaces)
-- `agent` — ALWAYS `kiro` (lowercase, no spaces)
-- `executionMode` — `local` when running the ATX CLI directly, `remote` when submitting via Lambda
-
-The only exception: if the user explicitly asks to disable telemetry during the
-session (e.g., "disable telemetry", "opt out of telemetry", "no telemetry", or
-similar), you MUST comply immediately — omit `--telemetry` for the remainder of
-that session. Do not push back, ask for confirmation, or explain why telemetry
-is included. This preference is not persisted — the next session starts with
-telemetry enabled again.
-
-## Output Structure
-
-Local mode: transformed code is in the repo directory.
-
-Remote mode results stay in S3 — do NOT download automatically. Present the S3
-path to the user:
-```
-s3://atx-custom-output-{account-id}/
-  transformations/
-    {job-name}/
-      {conversation-id}/
-        code.zip                      # Zipped transformed source code
-        logs.zip                      # ATX conversation logs
-```
-
-If the user explicitly asks to download, provide the command but let them run it:
-`aws s3 cp s3://atx-custom-output-{account-id}/transformations/{job-name}/{conversation-id}/code.zip ./code.zip`
-
-Bulk results summary: `~/.aws/atx/custom/atx-agent-session/transformation-summaries/` — see [steering/results-synthesis.md](steering/results-synthesis.md).
-
-## References
-
-| Reference | When to Use |
-|-----------|-------------|
-| [repo-analysis.md](steering/repo-analysis.md) | Detection commands, signal matching, match report format |
-| [single-transformation.md](steering/single-transformation.md) | Applying one TD to one repo (local or remote) |
-| [multi-transformation.md](steering/multi-transformation.md) | Applying TDs to multiple repos in parallel |
-| [remote-execution.md](steering/remote-execution.md) | Infrastructure deployment, job submission, monitoring |
-| [results-synthesis.md](steering/results-synthesis.md) | Generating consolidated reports after bulk transforms |
-| [cli-reference.md](steering/cli-reference.md) | ATX CLI flags, commands, env vars, IAM permissions |
-| [troubleshooting.md](steering/troubleshooting.md) | Error resolution, debugging, quality improvement |
+Resume: read `phase`, pick up from that step.
+
+---
+
+## RULES
+
+- Use product, capability, and step names exactly as defined in this document. Never paraphrase or invent terminology. When describing this power's capabilities, use: "Migrate, modernize, and upgrade codebases — .NET, mainframe COBOL, VMware, databases, and language/SDK upgrades — using AWS Transform CLI and Managed Agents, directly from your IDE." WRONG: "cloud-based agents", "cloud-powered migration". RIGHT: "Managed Agents", "AWS Transform CLI".
+- Use AskUserQuestion for every choice
+- Run CLI in background — never block chat
+- Discover agents dynamically via `list_resources` with `resource: "agents"` (paginated) — do not hardcode agent names.
+- Create jobs with orchestrator agents — sub-agents are invoked by the orchestrator, not directly.
+- Never explain what this power does
+- Never create requirements from discovery — wait for assessment
+- Never skip from discovery to execution
+- Store state in `.atx/context.json`
+- Freshness: in-session status claims must be fresh-fetched this turn or framed as cached with an offer to refresh. Never promise proactive surfacing unless actively polling. See `steering/workflow.md` → Freshness & Source of Truth.
+- Source of truth: each MCP resource (job, tasks, artifacts, …) is its own source of truth. Never infer one resource's state from another — a job in an active state (`ASSESSING`, `PLANNING`, `EXECUTING`) does NOT imply no pending user tasks. Fetch each resource directly when it's relevant. See `steering/workflow.md` → Freshness & Source of Truth.
+- Goal switching: on every shift to a different transformation goal, suggest the user start a new chat session. Re-offer on every shift — cross-contamination compounds. Keep re-offers terse.
+
+### Communication Style
+
+- **Be concise.** 2-3 short paragraphs max per message. State what you found, then what's next. No data dumps.
+- **Never narrate tool calls.** Don't say "Let me call get_status" or "Running atx custom def list." Say what you're doing in user terms tied to the action the user asked for: "Looking up your transform jobs" or "Scanning your workspace." Do NOT use this pattern to justify narrating auth probes before the user has declared an intent — that's a separate rule; see NEVER DO.
+- **Never narrate step transitions.** Don't say "Moving to Step 2", "Step 1 complete", "Now for Step 3", or "Let me check for a prior session." Step numbers are internal. Just do the next thing — the user sees the outcome (e.g., the intent question), not the transition.
+- **No filler.** Don't start with "Great!", "Absolutely!", "Sure thing!" — get to the point.
+- **No editorial commentary.** Don't say findings are "interesting", "fascinating", "notably", "impressive", or "remarkable". State facts — let users form their own opinions.
+- **Don't repeat.** Don't echo back what the user just said. Don't re-explain information the user already has.
+- **Progress, not process.** Tell users what's happening and what you found — not how you're doing it internally.
+- **Refer to resources by name, not ID.** When referencing a workspace, job, agent, or artifact in user-facing messages, use its human-readable name. Never surface raw UUIDs in chat prose. Raw IDs only belong inside tool-call arguments. If a resource has no name, use a descriptive phrase ("your .NET modernization job") rather than the ID.
+
+---
+
+## REFERENCE
+
+### Core
+| Topic | File |
+|-------|------|
+| Authentication (sign-in, AWS credentials, CLI credentials, errors) | `steering/auth.md` |
+| Tools (MCP tools, CLI commands, connectors, HITL, troubleshooting) | `steering/tools.md` |
+| Workflow (discovery, transforms, execution, planning, context, display) | `steering/workflow.md` |
+
+### Workload Types
+| Workload | Files |
+|----------|-------|
+| .NET | `workload-dotnet*.md` |
+| SQL/Database | `workload-sql*.md` |
+| Mainframe | `workload-mainframe*.md` |
+| VMware | `workload-vmware*.md` |
+| Custom | `workload-custom*.md` |
+
+Each workload type has a `workload-<name>.md` file with its capabilities, workflow, and agent details. Additional files with the same prefix provide deeper guidance (e.g., `workload-custom-cli-reference.md`, `workload-custom-repo-analysis.md`).
+
+---
 
 ## License
 AWS Service Terms. This power is provided by AWS and is subject to the AWS Customer Agreement and applicable AWS service terms.
 
+This power integrates with the AWS Transform MCP server from [awslabs/mcp](https://github.com/awslabs/mcp/blob/main/LICENSE) (Apache-2.0 license).
+
 ## Issues
 https://github.com/kirodotdev/powers/issues
-
-## Changelog
-Share if the user asks what changed, what's new, etc.
-
-### [1.0.1] - 2026-04-30
-- Adds support for a pre-built Docker image, removing the Docker pre-requisite when running AWS-managed transformations in remote mode
-
-### [1.0.0] - 2026-04-14
-- Initial release of the AWS Transform Kiro Power
-- Supported TDs:
-  - AWS/java-version-upgrade
-  - AWS/python-version-upgrade
-  - AWS/nodejs-version-upgrade
-  - AWS/java-aws-sdk-v1-to-v2
-  - AWS/nodejs-aws-sdk-v2-to-v3
-  - AWS/python-boto2-to-boto3
-  - AWS/comprehensive-codebase-analysis
-  - AWS/java-performance-optimization
-  - AWS/angular-version-upgrade
-  - AWS/vue.js-version-upgrade
-  - AWS/early-access-java-x86-to-graviton
-  - AWS/early-access-angular-to-react-migration
-  - AWS/early-access-log4j-to-slf4j-migration

--- a/aws-transform/mcp.json
+++ b/aws-transform/mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "aws-transform-mcp": {
+      "command": "uvx",
+      "args": [
+        "awslabs.aws-transform-mcp-server@latest"
+      ]
+    }
+  }
+}

--- a/aws-transform/steering/auth.md
+++ b/aws-transform/steering/auth.md
@@ -1,0 +1,48 @@
+# Authentication
+
+There are two independent auth paths:
+
+- **AWS Transform (MCP tools)** — workspaces, jobs, tasks, artifacts, connectors, agents. The MCP server is authoritative: its tool descriptions, `get_status` response, and error messages describe supported methods, current state, and recovery.
+- **Custom transformations (AWS Transform CLI)** — the `atx` CLI, which uses standard AWS credentials. No `atx auth` command, no MCP involvement.
+
+The paths do not block each other. A custom CLI intent proceeds with AWS credentials alone; an MCP intent does not require the CLI. Per POWER.md, prompt for auth just-in-time for the chosen action — do not probe or demand both.
+
+## Signing in
+
+When sign-in is needed, `get_status` returns a message on the unconfigured connection that enumerates the currently-supported options. Present **every** option from that message — do not drop any, do not add any, do not reorder for emphasis. The MCP server is authoritative for which options are valid at a given moment (some options may be conditionally unavailable).
+
+Details the MCP message does not include, collect from the user only for the option they pick:
+
+- **Cookie mode** — need `origin` and `sessionCookie`. The cookie comes from the browser: log in to the AWS Transform tenant URL → DevTools (F12) → Application → Cookies → `aws-transform-session` → copy **Value**.
+- **SSO mode** — need `startUrl` (looks like `https://d-xxxxxxxxxx.awsapps.com/start`, from IAM Identity Center) and `idcRegion`.
+- **AWS Credentials** — no interactive detail to gather. `AWS_PROFILE` lives in the MCP client's env block; the MCP picks it up on restart.
+
+When a session expires or a cookie is invalid, follow the recovery guidance in the MCP's error message.
+
+## AWS Transform CLI auth
+
+The CLI uses standard AWS credentials. There is no `atx auth` command — auth is whatever the AWS SDK / CLI provider chain resolves.
+
+```bash
+aws sso login --profile my-profile
+export AWS_PROFILE=my-profile
+export AWS_REGION=us-east-1
+```
+
+Verify: `AWS_REGION=us-east-1 atx custom def list --json`.
+
+Common CLI-side conditions:
+
+- `AccessDeniedException` → AWS credentials expired. Re-run `aws sso login` or refresh env vars.
+- `command not found: atx` → CLI not installed. Use MCP-based transforms instead, or install the CLI.
+
+## Environment variables (MCP client config)
+
+Pre-set in `mcp.json` to skip an interactive `configure` call:
+
+| Variable | Description |
+|----------|-------------|
+| `ATX_REGION` | AWS region (default `us-east-1`) |
+| `ATX_AUTH_MODE` | `cookie` or `sso` |
+| `ATX_TENANT_URL` | Tenant URL (cookie mode) |
+| `SESSION_COOKIE` | `aws-transform-session=<value>` (cookie mode) |

--- a/aws-transform/steering/tools.md
+++ b/aws-transform/steering/tools.md
@@ -1,0 +1,141 @@
+# Tools
+
+Canonical tool names, parameters, and per-resource requirements come from the MCP server's `tools/list` response — read the tool descriptions directly. This file covers cross-tool workflows, behavioral rules, and the AWS Transform CLI, which the schemas don't provide. For auth behavior, see `auth.md`.
+
+## Jobs
+
+`create_job` creates AND starts the job in one call — no separate `control_job` start is needed. Only orchestrator agents can create jobs; discover them via `list_resources resource="agents" agentType="ORCHESTRATOR_AGENT"`. Use `jobType` OR `orchestratorAgent`, not both — if one fails, retry with the other.
+
+## Connectors
+
+Connector lifecycle:
+
+```
+PENDING → ACTIVE → COMPLETED
+   ↓         ↓
+REJECTED   FAILED
+```
+
+Connectors start `PENDING`. An AWS admin must approve via the verification link returned by `create_connector`. Do NOT proceed with dependent tasks until the user confirms admin approval. Check status with `get_resource resource="connector"`.
+
+## HITL Tasks (Collaborator Requests)
+
+**CRITICAL: Never auto-submit. Always present to the user first.**
+
+Workflow for a regular HITL task:
+
+1. `list_resources resource="tasks"` — find tasks needing human action. Three human-actionable states:
+   - `AWAITING_HUMAN_INPUT` — first input required from the user
+   - `IN_PROGRESS` — user has engaged but not submitted
+   - `AWAITING_APPROVAL` — submitted for admin/approver decision
+   Surface all three to the user — the person in front of you may be the approver. Whether a task blocks the job depends on its `blockingType` (`BLOCKING` vs `NON_BLOCKING`); surface the state regardless, but let the user know when a blocking task is holding progress.
+2. `get_resource resource="task"` — returns two top-level objects you must read together:
+   - `task` — enriched with `_outputSchema`, `_responseTemplate`, `_responseHint`, `uxComponentId`, `severity`. Tells you the **submission shape**.
+   - `agentArtifactContent` — downloaded from S3. Tells you the **user-visible context**: current field values, items to select from, component-specific extras (toggles, feature flags, resource identifiers) that may not appear in `_outputSchema`.
+3. Present the task to the user. Two things must be surfaced:
+   - The content of `agentArtifactContent` — this is what the user sees in the web UI. Do not paraphrase it down to a single field.
+   - Any fields in `_outputSchema` the user needs to provide.
+4. Follow `_responseHint` — it is authoritative per `uxComponentId`. If the hint says "Only provide fields you want to change" or similar merge language, the server merges your payload onto the existing artifact. Send **only fields the user explicitly changed** — omit any field the user confirmed as-is or did not modify. Including unchanged fields violates the merge contract and can produce unintended overwrites.
+5. Never silently substitute a value the user didn't see. This applies especially to boolean toggles and opt-ins — surface the current value and ask, even if the server has a safe default.
+6. Wait for the user's decision.
+7. Before calling `complete_task`, show the full payload you are about to submit and confirm.
+8. `complete_task` — submit with the user's response.
+
+### Building the `content` payload
+
+Shape the payload based on the task's `_outputSchema` (returned by `get_resource resource="task"`):
+
+- **TextInput** — `{"data": "your text"}`
+- **AutoForm** — `{"fieldName": "value", ...}` — flat JSON matching the schema
+- **File upload** — call `upload_artifact` first, then pass the returned `artifactId` in `content`
+- **Display-only** — omit `content` (the server submits `{}`)
+
+### Severity
+
+- `STANDARD` — APPROVE/REJECT submits immediately.
+- `CRITICAL` — non-admins must use `SEND_FOR_APPROVAL`; admins can APPROVE directly.
+
+### TOOL_APPROVAL tasks (separate flow)
+
+When `list_resources resource="tasks" category="TOOL_APPROVAL"` returns items, use `list_tool_approvals` / `approve_tool_approval` / `deny_tool_approval` — NOT `complete_task`. The backend rejects `complete_task` for TOOL_APPROVAL tasks.
+
+---
+
+## AWS Transform CLI Commands
+
+The CLI uses standard AWS credentials (see `auth.md`). Always set `AWS_REGION`.
+
+### Core Commands
+
+| Action | Command |
+|--------|---------|
+| List transformation definitions | `atx custom def list --json` |
+| Execute transformation definition | `atx custom def exec -n <name> -p <path> -x -t` |
+| Get transformation definition details | `atx custom def get -n <name>` |
+| Save draft | `atx custom def save-draft -n <name> --description "<desc>" --sd <dir>` |
+| Publish | `atx custom def publish -n <name> --description "<desc>" --sd <dir>` |
+| Delete transformation definition | `atx custom def delete -n <name>` |
+| Interactive mode | `atx` |
+| Resume conversation | `atx --resume` |
+| Update CLI | `atx update` |
+
+### Execution Flags
+
+| Flag | Description |
+|------|-------------|
+| `-n` / `--transformation-name` | Transformation definition name (from `atx custom def list --json`) |
+| `-p` / `--code-repository-path` | Path to code repo (`.` for current dir) |
+| `-x` / `--non-interactive` | No user prompts |
+| `-t` / `--trust-all-tools` | Auto-approve tool executions (required with `-x`) |
+| `-c` / `--build-command` | Build/validation command (optional, auto-detected) |
+| `-d` / `--do-not-learn` | Prevent knowledge item extraction |
+| `-g` / `--configuration` | Config file (`file://config.yaml`) or inline (`'key=val'`) |
+| `--tv` / `--transformation-version` | Specific transformation definition version |
+
+**NEVER hardcode transformation definition names.** Always fetch from `atx custom def list --json`.
+
+---
+
+## Troubleshooting (Non-Auth)
+
+### Job Issues
+
+| Problem | Resolution |
+|---------|-----------|
+| Job stuck in RUNNING | Check `list_resources resource="tasks"` for pending HITL tasks |
+| Job fails immediately | Check `get_resource resource="job"` for `errorDetails`. Common: connectors not set up or not ACTIVE |
+| Job type not found | Use `list_resources resource="agents"` to discover available agents. Try `orchestratorAgent` instead of `jobType` |
+| Missing artifacts | Job may not be complete — check status first |
+
+### Connector Issues
+
+| Problem | Resolution |
+|---------|-----------|
+| Stuck in PENDING | Admin hasn't approved — share verification link |
+| FAILED | Check IAM role permissions. Trust policy must allow `transform.amazonaws.com` |
+| `accept_connector` fails | Needs AWS Credentials available in the environment; see the tool's description and `get_status` for current auth state |
+
+### HITL Task Issues
+
+| Problem | Resolution |
+|---------|-----------|
+| `VALIDATION_ERROR` on submit | Check `_outputSchema` from `get_resource resource="task"`. Don't wrap in `{"data":...}` or `{"properties":...}` unless schema requires it |
+| Empty `agentArtifactContent` | Agent still generating. Check worklogs, wait 30-60s, retry |
+| File upload fails | Verify path exists. Specify `fileType` explicitly |
+
+### MCP Server Issues
+
+| Problem | Resolution |
+|---------|-----------|
+| Tools not available | Restart Kiro. Check `mcp.json` for syntax errors |
+| MCP server not starting | Path in `mcp.json` may be relative — must be absolute. Check binary exists |
+| Region mismatch | Ensure `region` in `configure` matches where resources are |
+
+### Rollback
+
+Transform works on copies — original code is untouched until you apply changes.
+
+- **Haven't applied changes:** Safe. Delete job/artifacts if unwanted.
+- **Applied via git:** `git log` to find pre-transform commit, `git checkout <hash>` or `git revert`.
+- **Code connector branch:** Transform creates a separate branch. Delete it with `git branch -D atx/transform-<jobId>`.
+- **Manually copied files:** Use `git checkout HEAD~1 -- path/to/file` or IDE local history.

--- a/aws-transform/steering/workflow.md
+++ b/aws-transform/steering/workflow.md
@@ -1,0 +1,437 @@
+# Workflow
+
+## Quick Start
+
+| Say This | What Happens |
+|----------|--------------|
+| "Analyze this codebase" | Quick local analysis of architecture and dependencies |
+| "Start .NET modernization" | Launch AWS Transform agents to transform .NET Framework → .NET 8 |
+| "Check my job" | See job status and progress |
+| "Review pending requests" | Handle collaborator requests the agent needs from you |
+| "Download artifacts" | Get transformed code, reports, and build outputs |
+| "Show my workspaces" | List your AWS Transform workspaces |
+| "What transformations are available?" | See available agents for your account |
+
+---
+
+## CLI vs Managed Agents
+
+| | **AWS Transform CLI** | **Managed Agents** |
+|---|---|---|
+| **Runs on** | Your machine | AWS infrastructure |
+| **Auth** | AWS credentials | Sign in to AWS Transform |
+| **Scope** | Single repo | Multi-repo, specialized workload types |
+| **Best for** | Analysis, small upgrades, custom transformations, applying standards | .NET, mainframe, VMware, SQL, full modernization |
+| **Offline** | Yes | No |
+| **Human-in-loop** | No | Yes (collaborator requests) |
+| **Team features** | No | Yes (shared workspaces) |
+
+**Decision tree:**
+
+```
+What do you want to do?
+│
+├─ Quick analysis or standards check? → CLI
+├─ .NET Framework modernization? → Managed Agents
+├─ Mainframe (COBOL/JCL)? → Managed Agents
+├─ VMware → EC2? → Managed Agents
+├─ Database modernization (SQL Server, Oracle)? → Managed Agents
+├─ Java/Python version upgrade? → CLI
+├─ Team collaboration needed? → Managed Agents
+├─ Not sure? → Start with CLI analysis, escalate to Managed Agents if needed
+│
+└─ Best results on complex project? → Hybrid (CLI assess → Managed Agents transform → CLI validate)
+```
+
+---
+
+## Choosing a Transformation
+
+### By Tech Stack
+
+| Stack | Approach | Agent |
+|-------|----------|-------|
+| .NET Framework 4.x | Managed Agents | `dotnet-chatty-agent` (hardcoded) |
+| .NET Core 3.1 / .NET 5/6 | Managed Agents | Same .NET agent (simpler upgrade) |
+| Java 8/11/17 | CLI | Find Java transformation definitions via `atx custom def list --json` |
+| Spring Boot 2.x → 3.x | CLI | Find Spring Boot transformation definitions via `atx custom def list --json` |
+| COBOL / JCL | Managed Agents | Discover via `list_resources resource="agents"` |
+| VMware VMs | Managed Agents | Discover via `list_resources resource="agents"` |
+| SQL Server / Oracle | Managed Agents | Discover via `list_resources resource="agents"` |
+| Already modern | CLI | Run analysis or standards transformation definitions |
+
+**.NET agent is the only hardcoded name. All others: discover dynamically.**
+
+### By Goal
+
+| Goal | Approach |
+|------|----------|
+| Understand a codebase | CLI: run analysis transformation definition |
+| Modernize legacy app | Identify stack → CLI assessment → Managed Agents transformation |
+| Upgrade a version | CLI for Java/Python; Managed Agents for .NET |
+| Apply coding standards | CLI: find standards transformation definition |
+| Migrate to AWS | Managed Agents (.NET → dotnet-chatty-agent, mainframe, VMware) |
+
+---
+
+## Discovery
+
+Discovery is a fast scan (~10 sec) that finds what's in the workspace and maps to agents. It is NOT assessment.
+
+### How It Works
+
+1. Glob for project files (signal detection)
+2. Read key files for framework/version
+3. Classify risk: HIGH / MED / LOW
+4. Map to recommended agent
+5. Save to `.atx/discovery.json`
+
+### Signal Detection
+
+| Signal File | What to Extract | Opportunity |
+|-------------|----------------|-------------|
+| `pom.xml` | `<java.version>`, spring-boot version | Java upgrade |
+| `build.gradle` | `sourceCompatibility`, spring boot plugin | Java upgrade |
+| `pom.xml` / `build.gradle` | `com.amazonaws` group | AWS SDK v1 → v2 |
+| `.csproj` | `<TargetFrameworkVersion>v4.x` | .NET modernization |
+| `.csproj` | `<TargetFramework>netcoreapp2.x` / `net5.0` | .NET upgrade |
+| `packages.config`, `Web.config` | Legacy NuGet, `system.web` | .NET modernization |
+| `*.cbl`, `*.cob` | COBOL source | Mainframe modernization |
+| `*.jcl` | JCL job cards | Mainframe modernization |
+| `*.sql` with T-SQL (`GO`, `sp_`) | SQL Server | SQL migration |
+| `*.sql` with PL/SQL (`BEGIN`, `DBMS_`) | Oracle | Oracle migration |
+
+### Risk Classification
+
+| Risk | Criteria | Examples | Say This to Users |
+|------|----------|---------|-------------------|
+| **HIGH** | EOL/deprecated | Java 8, .NET FW 4.x, COBOL, Spring Boot 1.x, Spring Framework 5.x | No longer receiving security updates — migration recommended |
+| **MED** | Patched or near-EOL | Java 11, .NET 9 | Approaching end of life — plan migration soon |
+| **LOW** | Minor version lag | Java 17→21 | Current but not latest — optional upgrade for new features |
+
+### Discovery Output
+
+Save to `.atx/discovery.json`:
+
+```json
+{
+  "discoveredAt": "...",
+  "components": [
+    {
+      "path": "order-service/",
+      "stack": "Java 8, Spring Boot 1.5.22",
+      "risk": "HIGH",
+      "reason": "Java 8 EOL Jan 2019",
+      "recommendedAgent": "AWS Transform CLI (find Java transformation definition via atx custom def list --json)"
+    }
+  ]
+}
+```
+
+Present as migration table:
+
+```
+| Risk | Why | Component | Current | Target | AWS Target | Recommended Approach |
+|------|-----|-----------|---------|--------|------------|---------------------|
+| HIGH | No longer receiving security updates | order-service/ | Java 8 | Java 25 | — | CLI |
+| HIGH | No longer receiving security updates | storefront/ | .NET FW 4.7.2 | .NET 8 | — | Managed Agents |
+```
+
+---
+
+## Execution Lifecycle
+
+All transformations follow this pattern:
+
+### Managed Agent Jobs (MCP)
+
+```
+1. Create/select workspace     create_workspace
+2. Set up connectors           create_connector (if agent requires them)
+3. Create and start job        create_job
+4. Drive conversation          send_message
+5. Handle collaborator requests complete_task (see tools.md)
+6. Download results            get_resource resource="artifact"
+```
+
+**Kiro is the bridge between user and AWS Transform agent:**
+
+- Agent asks a question → present to user via AskUserQuestion
+- User answers → relay via `send_message` or `complete_task`
+- Agent needs files → upload via `upload_artifact`
+- Agent produces results → download via `get_resource resource="artifact"`
+
+**Rule: Kiro presents options to user, user decides, Kiro relays decision. Never shortcut this.**
+
+### CLI Transforms
+
+```bash
+# Always run in background
+AWS_REGION=us-east-1 atx custom def exec -n <name> -p <path> -x -t
+```
+
+Use `run_in_background=true` in Kiro.
+
+### Monitoring
+
+For job status and progress, ask the agent directly — it has full job context:
+
+```
+send_message                      # Scoped to the job: "What's the current status?"
+list_resources resource="worklogs" # Recent activity log
+list_resources resource="tasks"   # Pending collaborator requests — always check
+```
+
+Fall back to lower-level resources only if the agent's answer is unclear or you need specifics it didn't cover:
+
+```
+get_resource resource="job"       # Status: CREATED, STARTING, ASSESSING, PLANNING, PLANNED, EXECUTING, AWAITING_HUMAN_INPUT, COMPLETED, FAILED, STOPPING, STOPPED
+list_resources resource="plan"    # Phases and current step
+list_resources resource="messages" # Raw messages from agent
+```
+
+**Monitoring loop:**
+
+- Ask the agent via `send_message` + check `worklogs`
+- Always check `list_resources resource="tasks"` — active job status does not imply no pending user tasks
+- Always check `list_resources resource="messages"` — messages with a non-null `interactions` array (selection menus, confirmations) may be awaiting a user response via `send_message`. These interactive prompts do NOT appear as tasks and do NOT change the job status. A job can remain in EXECUTING status with no pending tasks while the agent is waiting on a user reply to an interactive message.
+- When a collaborator request appears → present to user, relay decision
+- When job completes → download artifacts
+- When job fails → show error, offer retry
+
+**Waiting between re-checks.** When a resource is in a transitional state and you need to re-check after a delay, use `adaptive_poll` rather than responding with stale data or silently stalling. Follow the tool's own description for terminal states and approval requirements. During an active, user-approved polling loop, present-tense status framing is fine (see Freshness below); outside that loop, do not promise proactive surfacing.
+
+### Parallel Execution
+
+- CLI and Managed Agents on **different** components → run in parallel
+- Two CLI transforms on different projects → both `run_in_background`
+- Same component → sequential
+- Each workspace can only run **one job at a time**
+
+### Mandatory Diff Review
+
+After ANY transform that changes code, show `git diff` summary then AskUserQuestion:
+
+- "Accept Changes"
+- "Revert"
+- "Review File-by-File"
+
+User MUST approve before next task.
+
+### Hybrid Workflow
+
+For best results, combine CLI and Managed Agents:
+
+1. **Assess locally** (CLI) — run analysis transformation definition, understand codebase
+2. **Transform with Managed Agents** — use findings to guide agents (pass in `intent` field)
+3. **Validate locally** (CLI) — apply org standards to output
+
+---
+
+## Plan Building
+
+### Spec Structure
+
+One spec at `.kiro/specs/aws-transform/`:
+
+```
+.kiro/specs/aws-transform/
+  .config.kiro          # {"specId":"aws-transform","workflowType":"requirements-first","specType":"feature"}
+  requirements.md       # Numbered requirements with user stories and acceptance criteria
+  tasks.md              # Hierarchical checkboxes referencing requirements
+```
+
+For multi-module projects, use **sections within the same spec** — not separate specs.
+
+### Two Gates
+
+**Gate 1: Scope Confirmation** (after discovery, before requirements)
+
+- Present scope summary via AskUserQuestion: components, risk levels, estimated task count
+- User confirms or adjusts
+
+**Gate 2: Plan Approval** (after requirements, before execution)
+
+- Present full plan via AskUserQuestion: task count, phases, parallel groups
+- User confirms "Start Execution" or adjusts
+
+Between gates: agent works autonomously. After Gate 2: execution proceeds with diff review as the ongoing control mechanism.
+
+### Iterative Planning
+
+```
+while not done:
+  1. Read requirements.md + tasks.md + .atx/context.json
+  2. Pick the most important incomplete task
+  3. Execute ONE task
+  4. Review diffs — get user approval if code changed
+  5. Mark task [x], update context
+  6. If new issues found, add to tasks.md
+```
+
+One task per iteration. Fresh analysis each time. State on disk.
+
+---
+
+## Context Management
+
+### Location
+
+```
+.atx/context.json       ← workspace-relative, source of truth
+.atx/discovery.json     ← discovery findings
+.kiro/specs/aws-transform/  ← requirements + tasks
+```
+
+**NEVER read from `~/.aws/atx/kiro-power-context.json`** — that's the MCP server's internal state, not the power's. Context is always relative to the workspace directory.
+
+Add `.atx/` to `.gitignore`.
+
+### Schema
+
+```json
+{
+  "phase": "intent|discovery|scoped|assessed|requirements|planning|executing|complete",
+  "discovery": {"completedAt": "...", "components": 3, "discoveryFile": ".atx/discovery.json"},
+  "assessment": {"completedAt": "...", "workspaceId": "...", "jobId": "...", "reportDir": ".atx/assessment-report/"},
+  "spec": {"folder": ".kiro/specs/aws-transform", "requirementsApproved": false, "tasksGenerated": false},
+  "workStyle": null,
+  "execution": {"currentTask": "1.2", "completedTasks": ["1.1"], "workspaceId": null, "activeJobIds": []},
+  "updatedAt": "..."
+}
+```
+
+### Resume Logic
+
+Silently check for `.atx/context.json`.
+
+**No context found:** Proceed directly to the Intent step. Do not mention the check, do not narrate internal steps or file names (e.g., "Step 1", "context.json") to the user — your first user-facing message must be the intent menu itself, with zero preamble about what you checked.
+
+**Context found:** Before resuming, silently try to refresh live state from the service:
+
+1. **Check auth first** (no-auth-required). Use the MCP tool that reports auth/sign-in status (discover it from `tools/list`). If sign-in is NOT configured, skip the refresh entirely and use local context only. Do NOT attempt further service calls, do NOT mention auth to the user, do NOT demand sign-in.
+2. **If sign-in is configured**, fetch each resource your resume message depends on. Each resource has its own source of truth — do NOT infer one from another (e.g., a job in an active state like `EXECUTING` does not mean no pending user tasks). At minimum:
+   - The **job** itself — what phase is it in, has it completed or failed.
+   - Any **pending tasks** — HITL tasks requiring user action. Fetch ALL pending tasks, not just one. **Surface every pending task to the user — do NOT cherry-pick the most prominent and omit the rest.** Each task (input-needed, approval-pending, etc.) is something the user needs to know about. `BLOCKING` tasks hold up progress even when the job is in an active state; `NON_BLOCKING` tasks still need attention but don't stall the job. Name every pending task in the resume message; flag which ones are blocking.
+3. **If any call fails**, silently fall back to local context. Do NOT mention the failure to the user.
+
+Tool names come from the server's `tools/list` response; read tool descriptions directly rather than hardcoding names in resume logic.
+
+Then tell the user about their prior session, framing the offer as a **continuation of that same session** — not a similar new one:
+
+- Use explicit continuation language: "continue where you left off", "pick up from where you stopped".
+- What phase was reached (e.g., "last time, your session finished assessment")
+- What key artifacts exist (e.g., workspace ID, assessment report)
+- **Refresh succeeded** → speak in present tense about live state ("your assessment job is running", "I need your input on X to continue"). If there is a pending HITL task, surface it — don't bury it under "your job is running."
+- **Refresh failed or was skipped** → use prior-session framing ("last time", "when you paused", "previously"). Do NOT present-tense claims about job state; local context may be stale. Offer sign-in as the path to current status — a benefit, not a gate ("sign in to see the latest status").
+- Clarify what resume vs. start-fresh means in user terms:
+  - **Resume** = continue the same session, reusing the existing assessment report, workspace, and prior progress.
+  - **Start fresh** = discard the prior session (local artifacts deleted) and begin a brand-new migration.
+
+If user chooses **start fresh**: delete `.atx/context.json`, `.atx/discovery.json`, `.atx/checkpoint-config.json`, `.atx/assessment-report/`, and `.kiro/specs/aws-transform/`, then proceed to Step 2 (Intent).
+
+If user chooses **resume**, resume based on `phase`:
+
+| Phase | Resume Action |
+|-------|-------------|
+| `intent` | Present intent options again, continue based on choice |
+| `discovery` | Show migration table, continue to scope |
+| `scoped` | Show selected scope, continue to assessment |
+| `assessed` | Show assessment summary, draft requirements from report |
+| `requirements` | Show current requirements, ask to approve or edit |
+| `planning` | Show tasks, ask to start execution |
+| `executing` | Show progress, pick next task |
+| `complete` | Show summary, ask what's next |
+
+---
+
+## Freshness & Source of Truth
+
+Resume Logic (above) dictates how you frame status at session start. The same discipline applies to **every in-session turn**.
+
+### Source of truth: fetch each resource directly
+
+Each MCP resource (job, tasks, messages, artifacts, connectors, …) is its own source of truth on the server. Do NOT infer one resource's state from another's. In particular:
+
+- An active job status (`ASSESSING`, `PLANNING`, `EXECUTING`) ≠ no pending user tasks. The agent may be blocked waiting on a checkpoint decision while the job status still reads as active. The job itself can also enter `AWAITING_HUMAN_INPUT`, but ONLY for `BLOCKING` tasks tied to a plan step — `NON_BLOCKING` tasks never trigger this transition. A job in an active state may still have multiple pending `NON_BLOCKING` tasks. So always fetch the tasks resource; don't rely on job status alone.
+- Job status COMPLETED ≠ no artifacts pending review.
+- An absence of recent messages ≠ no pending tasks.
+
+When the user-facing message depends on a resource, fetch THAT resource. Don't synthesize. The MCP tool surface is the ground truth — discover the right tool name from the server's `tools/list` response (see `steering/tools.md`), not from memory.
+
+### Freshness framing
+
+A "turn" is one user message → one of your responses. Tool calls made while composing the response count as part of the same turn; calls made for a prior user message do not.
+
+Any user-facing claim about job state, messages, tasks, or artifacts must be either:
+
+- **Just-fetched** — you called the relevant read tool (`get_resource`, `list_resources`) in THIS turn, before answering → present tense is OK ("your job is running").
+- **Cached** — no fresh fetch this turn → frame as cached AND offer to refresh.
+
+A fetch from a prior turn, resume, or the initial session refresh does NOT count as fresh. You have no clock — the user may have been away for hours; the job may have changed.
+
+**Cached framing must scope the ENTIRE claim.** Lead with the cached marker; every status verb must be past-tense. A trailing "as of earlier" does not retroactively qualify a present-tense leading clause.
+
+- WRONG: "Your job is handling the assessment phase. As of the last check, it was running."
+- RIGHT: "As of my last check, your job was handling the assessment phase and running VM tasks. Want me to pull the latest?"
+
+Exception: during an active polling loop (see workload steering files), present tense is fine — the fetch really is happening on each cycle.
+
+### No false promises of proactive surfacing
+
+When NOT polling, do NOT imply background monitoring. Phrases like "I'll let you know when…", "I'll surface those as they come up", "I'll ping you if…" mislead users into assuming the power is watching the job.
+
+When not polling, make the reactive model explicit: "You'll need to ask me — I don't watch in the background" / "Say 'check status' and I'll pull the latest."
+
+"I'll update you as the job progresses" is only acceptable during an active polling loop.
+
+### Transformation goal switching
+
+Track the "active goal" — what the user is trying to accomplish (e.g., "modernize this VMware fleet"). Two jobs serving the same goal are ONE goal.
+
+When the user's message shifts to a DIFFERENT goal (different workload, different migration target, or a clearly different body of work), before answering:
+
+1. Recognize the shift. Trigger is a change in what the user is accomplishing, not a field-by-field ID comparison.
+2. Via AskUserQuestion, suggest the user start a new chat session with fresh context (they start it themselves — you cannot). Give a brief reason: mixing unrelated goals causes cross-contaminated answers.
+3. Wait for their choice. If accepted, stop answering about the new goal in this chat. If declined, **answer the user's question in this chat** — respect their choice. Just do not mix cached state from the prior goal into your answers. Do not re-push the new-chat suggestion until the next goal shift.
+
+**Re-offer on every shift**, because cross-contamination compounds. But keep re-offers terse — "Different goal again — want a new chat session? [Yes] [Stay here]" — don't re-lecture.
+
+Carve-out: historical, past-tense questions about a prior goal ("what did my .NET modernization produce last week?") do NOT trigger the suggestion.
+
+---
+
+## Display Conventions
+
+### Interactive Choices — ALWAYS use AskUserQuestion
+
+```python
+AskUserQuestion(questions=[{
+    "question": "How would you like to proceed?",
+    "header": "Action",
+    "multiSelect": False,
+    "options": [
+        {"label": "Approve (Recommended)", "description": "Start executing"},
+        {"label": "Modify", "description": "Change the plan"},
+        {"label": "Explain", "description": "Deep dive into why this order"}
+    ]
+}])
+```
+
+**Do NOT use markdown bullets or numbered lists for choices.** AskUserQuestion creates clickable UI.
+
+### Consultant-Style Observations
+
+2-3 sentences max. State what you found, then what's possible. No data dumps. Never narrate tool calls — describe outcomes, not mechanics.
+
+### Status Icons
+
+```
+[ ] Pending    [Running] Running    [Done] Done    [Failed] Failed
+```
+
+### Progress
+
+```
+Steps: 2 of 5 complete
+```

--- a/aws-transform/steering/workload-custom-cli-reference.md
+++ b/aws-transform/steering/workload-custom-cli-reference.md
@@ -1,22 +1,26 @@
-# ATX CLI Reference
+# AWS Transform CLI Reference
 
 ## Execution Flags (`atx custom def exec`)
 
 | Flag | Long Form | Description |
 |------|-----------|-------------|
-| `-n` | `--transformation-name <name>` | TD name (from `atx custom def list --json`) |
+| `-n` | `--transformation-name <name>` | Transformation definition name (from `atx custom def list --json`) |
 | `-p` | `--code-repository-path <path>` | Path to code repo (`.` for current dir) |
 | `-x` | `--non-interactive` | No user prompts (always use this flag) |
 | `-t` | `--trust-all-tools` | Auto-approve tool executions (required with `-x`) |
 | `-d` | `--do-not-learn` | Prevent knowledge item extraction |
 | `-g` | `--configuration <config>` | Inline configuration (`'key=val'`) |
-| `--tv` | `--transformation-version <ver>` | Specific TD version |
+| `--tv` | `--transformation-version <ver>` | Specific transformation definition version |
 
 ## Configuration
 
 Inline: `--configuration 'additionalPlanContext=Target Python 3.13'`
 
 Example: `atx custom def exec -n my-td -p /source/repo -g 'additionalPlanContext=Target Java 17' -x -t`
+
+- See the workload-custom-single-transformation.md and workload-custom-multi-transformation.md files for how to wrap this around a
+runner/launcher script to ensure this is executed in a non-blocking way, so that user is updated while the process is running instead of
+having to wait until it exits.
 
 `--configuration` is optional. Omit if no extra context needed.
 
@@ -27,11 +31,11 @@ Example: `atx custom def exec -n my-td -p /source/repo -g 'additionalPlanContext
 | Start interactive conversation | `atx` |
 | Resume most recent conversation | `atx --resume` |
 | Resume specific conversation | `atx --conversation-id <id>` (30-day limit) |
-| List TDs | `atx custom def list --json` |
-| Download TD | `atx custom def get -n <name>` (optional: `--tv <version>`, `--td <directory>`) |
-| Delete TD | `atx custom def delete -n <name>` |
-| Save TD as draft | `atx custom def save-draft -n <name> --description "<desc>" --sd <dir>` |
-| Publish TD | `atx custom def publish -n <name> --description "<desc>" --sd <dir>` |
+| List transformation definitions | `atx custom def list --json` |
+| Download transformation definition | `atx custom def get -n <name>` (optional: `--tv <version>`, `--td <directory>`) |
+| Delete transformation definition | `atx custom def delete -n <name>` |
+| Save as draft | `atx custom def save-draft -n <name> --description "<desc>" --sd <dir>` |
+| Publish transformation definition | `atx custom def publish -n <name> --description "<desc>" --sd <dir>` |
 | List knowledge items | `atx custom def list-ki -n <name>` |
 | View knowledge item | `atx custom def get-ki -n <name> --id <id>` |
 | Enable/disable KI | `atx custom def update-ki-status -n <name> --id <id> --status ENABLED or DISABLED` |
@@ -40,7 +44,7 @@ Example: `atx custom def exec -n my-td -p /source/repo -g 'additionalPlanContext
 | Delete KI | `atx custom def delete-ki -n <name> --id <id>` |
 | Update CLI | `atx update` |
 | Check for CLI updates only | `atx update --check` |
-| Tag a TD | `atx custom def tag --arn <arn> --tags '{"key":"value"}'` |
+| Tag a transformation definition | `atx custom def tag --arn <arn> --tags '{"key":"value"}'` |
 
 ## Environment Variables
 
@@ -63,9 +67,9 @@ Minimum: `transform-custom:*` on `Resource: "*"`.
 | `transform-custom:ExecuteTransformation` | Execute transforms |
 | `transform-custom:ListTransformationPackageMetadata` | List transforms (`atx custom def list --json`) |
 | `transform-custom:DeleteTransformationPackage` | Delete transforms |
-| `transform-custom:CompleteTransformationPackageUpload` | Upload TDs |
+| `transform-custom:CompleteTransformationPackageUpload` | Upload transformation definitions |
 | `transform-custom:CreateTransformationPackageUrl` | Create upload URLs |
-| `transform-custom:GetTransformationPackageUrl` | Download TDs |
+| `transform-custom:GetTransformationPackageUrl` | Download transformation definitions |
 | `transform-custom:ListKnowledgeItems` | List knowledge items |
 | `transform-custom:GetKnowledgeItem` | View knowledge item details |
 | `transform-custom:DeleteKnowledgeItem` | Delete knowledge items |
@@ -102,6 +106,7 @@ This produces two policies:
 | `atx-deployment-policy.json` | CloudFormation, ECR, IAM roles, Batch, VPC, KMS key creation | One-time CDK deploy/destroy |
 
 After generating, create and attach the runtime policy:
+
 ```bash
 ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 CALLER_ARN=$(aws sts get-caller-identity --query Arn --output text)
@@ -124,7 +129,7 @@ elif echo "$CALLER_ARN" | grep -Eq ":assumed-role/|:role/"; then
 fi
 ```
 
-The runtime policy covers: `transform-custom:*` for ATX CLI operations (TD discovery, execution),
+The runtime policy covers: `transform-custom:*` for AWS Transform CLI operations (transformation definition discovery, execution),
 `lambda:InvokeFunction` on all `atx-*` functions,
 `s3:PutObject`/`s3:GetObject` on source and output buckets, `kms:Encrypt`/`kms:Decrypt`/`kms:GenerateDataKey`
 on the ATX encryption key, `secretsmanager:CreateSecret`/`PutSecretValue`/`DeleteSecret` on `atx/*` secrets,

--- a/aws-transform/steering/workload-custom-multi-transformation.md
+++ b/aws-transform/steering/workload-custom-multi-transformation.md
@@ -1,30 +1,34 @@
 # Multi-Transformation
 
-Apply TDs to multiple repositories in parallel. TD-to-repo assignments and config
-are already confirmed from the match report. Do NOT re-discover TDs or re-prompt.
+Apply transformation definitions to multiple repositories in parallel. Transformation-definition-to-repo assignments and config
+are already confirmed from the match report. Do NOT re-discover transformation definitions or re-prompt.
 
 ## Input
 
-From the match report: repo list, TD per repo, config per TD, execution mode.
+From the match report: repo list, transformation definition per repo, config per transformation definition, execution mode.
 
 ## Prerequisite Check (Once Only)
 
 Verify AWS credentials ONCE. Do NOT repeat per repo.
+
 ```bash
 aws sts get-caller-identity
 ```
+
 Local mode also: `atx --version`
 
 ## Local Execution
 
 If any repos were provided as git URLs (HTTPS or SSH), clone them locally first.
 The user's local git config handles authentication — no Secrets Manager needed.
+
 ```bash
 CLONE_DIR=~/.aws/atx/custom/atx-agent-session/repos/<repo-name>-$SESSION_TS
 git clone <git-url> "$CLONE_DIR"
 ```
 
 If repos were provided as an S3 bucket path with zips, download and extract locally:
+
 ```bash
 mkdir -p ~/.aws/atx/custom/atx-agent-session/repos
 aws s3 sync s3://user-bucket/repos/ ~/.aws/atx/custom/atx-agent-session/repos/ --exclude "*" --include "*.zip"
@@ -37,10 +41,12 @@ done
 Use the cloned/extracted paths as `<repo-path>` for each repo.
 
 For each repo, verify it's a git repo:
+
 ```bash
 ls -la <repo-path>
 git -C <repo-path> status
 ```
+
 If not a git repo: `cd <repo-path> && git init && git add . && git commit -m "Initial commit"`
 
 The active language runtime must match the transformation's target version so that
@@ -49,6 +55,7 @@ mismatch, first check whether the target version is already installed (e.g.,
 `/usr/libexec/java_home -V 2>&1` (macOS) or `ls /usr/lib/jvm/` (Linux), `pyenv versions`, `nvm ls`). If found, switch
 to it (e.g., `export JAVA_HOME=<path to JDK> && export PATH="$JAVA_HOME/bin:$PATH"`, `pyenv shell 3.12`, `nvm use 22`). Only if
 the target version is not installed at all, ask the user for permission before installing. Suggest:
+
 - Java: `brew install --cask corretto23` (macOS), `sudo yum install java-23-amazon-corretto-devel` (RHEL/AL2), or `sudo apt install java-23-amazon-corretto-jdk` (Debian/Ubuntu)
 - Python: `pyenv install 3.15.0 && pyenv shell 3.15.0`
 - Node.js: `nvm install 23 && nvm use 23`
@@ -56,9 +63,9 @@ the target version is not installed at all, ask the user for permission before i
 Do NOT proceed until the correct version is active. Verify the switch succeeded
 before proceeding.
 
-### Telemetry
+### 5. Telemetry
 
-When running `atx custom def exec`, always include the `--telemetry` flag (see the Telemetry section in POWER.md). Format:
+When running `atx custom def exec`, always include the `--telemetry` flag (see the Telemetry section in workload-custom.md). Format:
 `--telemetry "client=kiro,agent=kiro,executionMode=<local|remote>"`
 
 - `client` is always `kiro`
@@ -73,6 +80,7 @@ but recommend remote mode for more). If the total repo count exceeds 9, suggest
 remote mode instead.
 
 For each repo, use bash to create a runner script that captures the exit code, following this exact format:
+
 ```bash
 mkdir -p ~/.aws/atx/custom/atx-agent-session
 cat > ~/.aws/atx/custom/atx-agent-session/run-<repo-name>.sh << 'RUNNER'
@@ -86,19 +94,23 @@ chmod +x ~/.aws/atx/custom/atx-agent-session/run-<repo-name>.sh
 nohup ~/.aws/atx/custom/atx-agent-session/run-<repo-name>.sh > ~/.aws/atx/custom/atx-agent-session/<repo-name>.log 2>&1 &
 echo $! > ~/.aws/atx/custom/atx-agent-session/<repo-name>.pid
 ```
-Omit `--configuration` if no config needed. Include `--telemetry` always — see POWER.md for details. Launch each repo's script in rapid
+
+Omit `--configuration` if no config needed. The `--telemetry` flag is always included — see workload-custom.md for details. Launch each repo's script in rapid
 succession — do NOT wait between launches. Each runner script is backgrounded
-via nohup; the exit code is captured to `~/.aws/atx/custom/atx-agent-session/<repo-name>.exit` when ATX finishes.
+via nohup; the exit code is captured to `~/.aws/atx/custom/atx-agent-session/<repo-name>.exit` when AWS Transform finishes.
 
 After launching all repos, find each repo's conversation log by grepping its
-process log (ATX outputs the path within 30-60 seconds of starting):
+process log (AWS Transform outputs the path within 30-60 seconds of starting):
+
 ```bash
 grep "Conversation log:" ~/.aws/atx/custom/atx-agent-session/<repo-name>.log 2>/dev/null
 ```
+
 If it hasn't appeared yet, wait 15 seconds and retry. Extract the full path from
 each — do NOT use `ls -t` across all conversations, as that may match a different run.
 
 Then start monitoring. On each 60-second cycle:
+
 1. Check each PID: `kill -0 $(cat ~/.aws/atx/custom/atx-agent-session/<repo-name>.pid) 2>/dev/null && echo "RUNNING" || echo "DONE"`
 2. Tail each repo's conversation log and relay progress to the user
 3. For each repo, list the artifacts directory (`~/.aws/atx/custom/<conversation-id>/artifacts/`)
@@ -111,7 +123,7 @@ continuous progress updates across all repos.
 A repo's transformation is done ONLY when its background process exits (i.e.,
 `kill -0` returns non-zero). Do NOT treat exit code 0 from any other command
 (grep, cat, test, ls, etc.) as transformation completion. Do NOT treat log
-messages like "TRANSFORMATION COMPLETE" as completion — ATX performs additional
+messages like "TRANSFORMATION COMPLETE" as completion — AWS Transform performs additional
 steps after that (validation summary generation).
 
 ## Remote Execution
@@ -127,7 +139,8 @@ Submit jobs via the batch Lambda in chunks of up to 128. If there are more than
 = 4 calls of 128 + 128 + 128 + 116). Each call returns its own `batchId`. Track
 all batch IDs for monitoring.
 
-Include the `environment` field on each job to set the language version matching the transformation's target (e.g., `"JAVA_VERSION":"21"` for a Java upgrade targeting 21). Include `--telemetry` in each job's `command` string always (see POWER.md):
+Include the `environment` field on each job to set the language version matching the transformation's target (e.g., `"JAVA_VERSION":"21"` for a Java upgrade targeting 21). The `--telemetry` flag is always included in each job's `command` string (see workload-custom.md):
+
 ```bash
 aws lambda invoke --function-name atx-trigger-batch-jobs \
   --payload '{"batchName":"<name>-chunk-1","jobs":[{"source":"<url>","command":"atx custom def exec -n <td> -p /source/<project> -x -t --telemetry \"client=kiro,agent=kiro,executionMode=remote\"","jobName":"<name>","environment":{"JAVA_VERSION":"<target>"}}]}' \
@@ -135,6 +148,7 @@ aws lambda invoke --function-name atx-trigger-batch-jobs \
 ```
 
 If the total exceeds 128, repeat with the next chunk:
+
 ```bash
 aws lambda invoke --function-name atx-trigger-batch-jobs \
   --payload '{"batchName":"<name>-chunk-2","jobs":[...next 128 jobs...]}' \
@@ -142,43 +156,47 @@ aws lambda invoke --function-name atx-trigger-batch-jobs \
 ```
 
 Monitor each batch by its `batchId`:
+
 ```bash
 aws lambda invoke --function-name atx-get-batch-status \
   --payload '{"batchId":"<batch-id>"}' \
   --cli-binary-format raw-in-base64-out /dev/stdout
 ```
+
 Polling: every 60 seconds for the first 10 polls, then every 5 minutes after.
 Report only on status change.
 
 ## Progress Reporting
 
 ```
-[1/N] repo-name          TD-name                    Status
-[2/N] repo-name          TD-name                    Status
+[1/N] repo-name          transformation-name                    Status
+[2/N] repo-name          transformation-name                    Status
 ```
 
 ## Result Collection
 
 Collect per repo: success/failure, transformed code path, error details.
+
 ```
 Succeeded:
-- repo-name: TD-name (config)
+- repo-name: transformation-name (config)
 Failed:
-- repo-name: TD-name (error)
+- repo-name: transformation-name (error)
 ```
 
 For remote executions, include the CloudWatch dashboard link in the final output:
+
 ```bash
 REGION=${AWS_REGION:-${AWS_DEFAULT_REGION:-$(aws configure get region 2>/dev/null)}}
 REGION=${REGION:-us-east-1}
 echo "https://${REGION}.console.aws.amazon.com/cloudwatch/home#dashboards/dashboard/ATX-Transform-CLI-Dashboard"
 ```
 
-Hand off to [results-synthesis.md](results-synthesis.md) for consolidated reporting.
+Hand off to [workload-custom-results-synthesis.md](workload-custom-results-synthesis.md) for consolidated reporting.
 
 For local executions only, tell the user: "To review changes in each repo, open it in
 Kiro (`kiro -r <repo-path>`) and use the Source Control panel to see the full
-commit history with diffs for each file ATX modified."
+commit history with diffs for each file AWS Transform modified."
 
 ## Error Handling
 
@@ -191,18 +209,19 @@ commit history with diffs for each file ATX modified."
 ## MANDATORY: Cleanup
 
 Clean up session files **before starting** and **after completing** each batch:
+
 ```bash
 [ -d ~/.aws/atx/custom/atx-agent-session ] && find ~/.aws/atx/custom/atx-agent-session -maxdepth 1 -type f \( -name "*.sh" -o -name "*.log" -o -name "*.pid" -o -name "*.exit" -o -name "*.zip" \) -delete 2>/dev/null || true
 ```
 
 For remote mode: after presenting results, also prompt the user about infrastructure
-teardown. See the Cleanup section in [remote-execution.md](remote-execution.md)
+teardown. See the Cleanup section in [workload-custom-remote-execution.md](workload-custom-remote-execution.md)
 for the exact prompt and flow.
 
 ## Key Principles
 
 1. Single prerequisite check — never repeat for parallel tasks
-2. Trust the match report — do not re-discover TDs
+2. Trust the match report — do not re-discover transformation definitions
 3. Local parallel execution — maximum 3 concurrent repos (user-overridable); recommend remote for more than 9
 4. Remote parallel execution — submit in chunks of up to 128 jobs per `atx-trigger-batch-jobs` call; split larger sets into multiple calls (max 512 repos per session)
 5. Skip prerequisite checks in parallel task prompts

--- a/aws-transform/steering/workload-custom-remote-execution.md
+++ b/aws-transform/steering/workload-custom-remote-execution.md
@@ -1,9 +1,10 @@
 # Remote Execution
 
-Deploy and manage AWS Batch/Fargate infrastructure for ATX transformations at scale.
+Deploy and manage AWS Batch/Fargate infrastructure for running AWS Transform custom transformations at scale.
 All Lambda calls are executed by you — users never interact with Lambdas directly.
 
 Remote mode deploys to the user's own AWS account. Key resources:
+
 - Results stored in S3 (`atx-custom-output-{accountId}`) with KMS encryption, 30-day lifecycle
 - Source code uploaded to S3 (`atx-source-code-{accountId}`) with 7-day lifecycle
 - CloudWatch dashboard: `ATX-Transform-CLI-Dashboard` for monitoring jobs
@@ -17,10 +18,12 @@ Before checking, determine the active AWS region (from `AWS_REGION`, `AWS_DEFAUL
 or `aws configure get region`) and tell the user which region is being used.
 
 Then check deployment status:
+
 ```bash
 aws cloudformation describe-stacks --stack-name AtxInfrastructureStack \
   --query 'Stacks[0].StackStatus' --output text || echo "NOT_DEPLOYED"
 ```
+
 If deployed (`CREATE_COMPLETE` or `UPDATE_COMPLETE`): proceed to job submission.
 If `NOT_DEPLOYED` or any other status: get explicit user consent before deploying.
 
@@ -56,11 +59,12 @@ on whether the pre-built image has everything needed for the transformation.
 ### Pre-built Image Runtimes
 
 The pre-built image includes:
+
 - **Java**: 8, 11, 17, 21, 25 (Amazon Corretto) with Maven and Gradle 9.4
 - **Python**: 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14 (dnf + pyenv)
 - **Node.js**: 16, 18, 20, 22, 24 (nvm) with yarn, pnpm, TypeScript, ts-node
 - **Build tools**: gcc, g++, make, patch
-- **CLI tools**: AWS CLI v2, ATX CLI, git, jq, curl, unzip, tar
+- **CLI tools**: AWS CLI v2, AWS Transform CLI, git, jq, curl, unzip, tar
 - **OS**: Amazon Linux 2023 (x86_64)
 
 If the transformation target is in this list, use the pre-built image path.
@@ -85,6 +89,7 @@ changes and the user's customizations in the `CUSTOM LANGUAGES AND TOOLS` sectio
 of the Dockerfile, then commit the merge.
 
 Ensure `prebuiltImageUri` is set in `cdk.json` (it should be set to "public.ecr.aws/d9h8z6l7/aws-transform:latest" by default). Then deploy:
+
 ```bash
 cd "$ATX_INFRA_DIR" && ./setup.sh
 ```
@@ -111,6 +116,7 @@ cd "$ATX_INFRA_DIR" && sed -i.bak 's|"prebuiltImageUri": ".*"|"prebuiltImageUri"
 ```
 
 Customize the Dockerfile (see Container Customization below), then deploy:
+
 ```bash
 cd "$ATX_INFRA_DIR" && ./setup.sh
 ```
@@ -125,9 +131,11 @@ one thing and re-run — the script is idempotent.
 
 If deployment fails partway through (e.g., CloudFormation stack stuck in
 `ROLLBACK_COMPLETE` or `UPDATE_ROLLBACK_FAILED`), run teardown first, then retry:
+
 ```bash
 cd "$ATX_INFRA_DIR" && rm -f cdk.context.json && ./teardown.sh && ./setup.sh
 ```
+
 This cleans up the half-deployed state, clears cached CDK context, and starts fresh.
 The teardown script handles stacks in any state, including failed rollbacks.
 
@@ -141,6 +149,7 @@ cd "$ATX_INFRA_DIR" && npx ts-node generate-caller-policy.ts
 ```
 
 This produces two JSON files in `$ATX_INFRA_DIR`:
+
 - `atx-runtime-policy.json` — Day-to-day operations (Lambda invoke, S3, KMS, Secrets Manager, logs)
 - `atx-deployment-policy.json` — One-time CDK deploy/destroy (CloudFormation, ECR, IAM, Batch, VPC)
 
@@ -171,15 +180,18 @@ fi
 
 If the attachment fails (insufficient IAM permissions, or an SSO-managed role with
 name starting with `AWSReservedSSO_`), inform the user:
+
 - The policy JSON is at `$ATX_INFRA_DIR/atx-runtime-policy.json`
 - They need their AWS administrator to create and attach it to their identity
 - For SSO users, it must be added to their IAM Identity Center permission set
 
 Verify the policy is working by invoking a Lambda:
+
 ```bash
 aws lambda invoke --function-name atx-list-jobs --payload '{}' \
   --cli-binary-format raw-in-base64-out /dev/stdout
 ```
+
 If this succeeds, the runtime policy is active. If not, the attachment hasn't
 taken effect yet — wait a few seconds and retry.
 
@@ -189,6 +201,7 @@ repeat the above with `atx-deployment-policy.json` and policy name `ATXDeploymen
 ## Lambda Function Names
 
 After deployment, the Lambda functions are available with these names:
+
 - `atx-trigger-job` — Submit a single transformation job
 - `atx-get-job-status` — Get status of a single job
 - `atx-terminate-job` — Terminate a running job
@@ -200,14 +213,16 @@ After deployment, the Lambda functions are available with these names:
 
 ## MCP Configuration (Optional)
 
-If the user has a local ATX MCP configuration, include it inline with job
+If the user has a local AWS Transform MCP configuration, include it inline with job
 submissions so the containers can use it. Check for a local config:
+
 ```bash
 cat ~/.aws/atx/mcp.json 2>/dev/null
 ```
 
 If it exists, include the contents as the `mcpConfig` field in the `atx-trigger-job`
 or `atx-trigger-batch-jobs` payload. For example:
+
 ```bash
 aws lambda invoke --function-name atx-trigger-job \
   --payload '{"source":"...","command":"...","jobName":"...","mcpConfig":<contents of mcp.json>}' \
@@ -228,7 +243,7 @@ and ask the user to reduce the list.
 
 **Repo analysis:** Do NOT scan or inspect repository contents locally in remote
 mode. The repos may not be available on the local machine. Let the user specify
-which TDs to apply, or use the TD already selected in the plugin.
+which transformation definitions to apply, or use the one already selected in the plugin.
 
 **Deployment failures:** If `setup.sh` or `cdk deploy` fails for any reason, run
 `./teardown.sh` first to clean up the partial state, then retry `./setup.sh`.
@@ -241,6 +256,7 @@ S3 buckets. If the user provides zips in their own S3 bucket, copy them to the
 managed source bucket first (see Step 1 in POWER.md).
 
 Single job:
+
 ```bash
 aws lambda invoke --function-name atx-trigger-job \
   --payload '{"source":"<url-or-s3>","command":"atx custom def exec -n <td> -p /source/<project> -x -t","jobName":"<name>"}' \
@@ -248,6 +264,7 @@ aws lambda invoke --function-name atx-trigger-job \
 ```
 
 Batch:
+
 ```bash
 aws lambda invoke --function-name atx-trigger-batch-jobs \
   --payload '{"batchName":"<name>","jobs":[{"source":"<url>","command":"atx custom def exec -n <td> -p /source/<project> -x -t","jobName":"<name>"}]}' \
@@ -268,6 +285,7 @@ fall back to cloning locally — guide the user through SSH key setup instead.
 
 Poll every 60 seconds for the first 10 polls, then every 5 minutes after.
 Report only on status change.
+
 ```bash
 aws lambda invoke --function-name atx-get-job-status \
   --payload '{"jobId":"<id>"}' \
@@ -281,13 +299,15 @@ aws lambda invoke --function-name atx-get-batch-status \
 ## Results Location
 
 Do NOT download results locally. Results stay in S3. Present the S3 path to the user:
+
 ```
 Results: s3://atx-custom-output-{account-id}/transformations/<job-name>/<conversation-id>/
   code.zip  — zipped transformed source code
-  logs.zip  — ATX conversation logs
+  logs.zip  — AWS Transform conversation logs
 ```
 
 If the user explicitly asks to download, provide the command but let them run it:
+
 ```
 aws s3 cp s3://atx-custom-output-{account-id}/transformations/<job-name>/<conversation-id>/code.zip ./code.zip
 ```
@@ -301,11 +321,13 @@ mechanism for reference.
 The container fetches credentials from AWS Secrets Manager at startup. Three secret types:
 
 **`atx/github-token`** — plain string GitHub PAT for private HTTPS repo cloning:
+
 ```bash
 aws secretsmanager create-secret --name "atx/github-token" --secret-string "<token>"
 ```
 
 **`atx/ssh-key`** — plain string SSH private key for private SSH repo cloning:
+
 ```bash
 aws secretsmanager create-secret --name "atx/ssh-key" --secret-string "$(cat <path-to-your-private-key>)"
 ```
@@ -313,22 +335,25 @@ aws secretsmanager create-secret --name "atx/ssh-key" --secret-string "$(cat <pa
 **`atx/credentials`** — JSON array of credential files for any tool/registry (see Container Customization below).
 
 Setup (requires user consent):
+
 1. Explain which secrets will be created in their AWS account
 2. Get explicit confirmation and credentials from the user
 3. Create the secret(s)
 4. Container entrypoint auto-fetches at startup — no image rebuild needed
 5. User can delete anytime: `aws secretsmanager delete-secret --secret-id "atx/github-token" --region "$REGION" --force-delete-without-recovery`
 
-AWS credentials for ATX CLI are handled automatically by the IAM task role (refreshed every 45 min).
+AWS credentials for AWS Transform CLI are handled automatically by the IAM task role (refreshed every 45 min).
 
 ## Monitoring
 
 CloudWatch dashboard: `ATX-Transform-CLI-Dashboard`
+
 - Job Tracking: completion rates, success/failure trends
 - Lambda Metrics: invocation counts, duration, errors
 - Real-time Logs: stream transformation progress
 
 Dashboard URL (construct dynamically using the caller's region):
+
 ```bash
 REGION=${AWS_REGION:-${AWS_DEFAULT_REGION:-$(aws configure get region 2>/dev/null)}}
 REGION=${REGION:-us-east-1}
@@ -349,6 +374,7 @@ Dockerfile has a clearly marked `CUSTOM LANGUAGES AND TOOLS` section where new
 auto-detects Dockerfile changes and rebuilds the image.
 
 ### Adding Languages or Tools
+
 ```dockerfile
 # Example: Add Rust (install as atxuser so binaries land in /home/atxuser/.cargo)
 USER atxuser
@@ -364,6 +390,7 @@ Credentials are fetched from AWS Secrets Manager at container startup — never 
 **`atx/github-token`** (plain string) — GitHub PAT for private repo cloning.
 
 **`atx/credentials`** (JSON array) — Generic credential files for any tool or registry. Each entry writes a file into the container at startup:
+
 ```json
 [
   {"path": "/home/atxuser/.npmrc", "content": "//npm.company.com/:_authToken=TOKEN"},
@@ -376,6 +403,7 @@ Credentials are fetched from AWS Secrets Manager at container startup — never 
 ```
 
 Create the secret:
+
 ```bash
 aws secretsmanager create-secret --name "atx/credentials" \
   --secret-string '[{"path":"/home/atxuser/.npmrc","content":"//npm.company.com/:_authToken=TOKEN"}]'
@@ -392,6 +420,7 @@ Java 23, set `"JAVA_VERSION":"23"` (not `"21"`). If the target version was added
 to the Dockerfile and entrypoint per Step 6, the switcher will activate it.
 
 Via Lambda (recommended):
+
 ```bash
 aws lambda invoke --function-name atx-trigger-job \
   --payload '{"source":"...","jobName":"...","command":"atx ...","environment":{"JAVA_VERSION":"23","NODE_VERSION":"22","PYTHON_VERSION":"3.13"}}' \
@@ -399,6 +428,7 @@ aws lambda invoke --function-name atx-trigger-job \
 ```
 
 Via direct Batch submission:
+
 ```bash
 aws batch submit-job \
   --container-overrides '{
@@ -438,7 +468,8 @@ user with the following:
 > For pricing details: https://aws.amazon.com/transform/pricing/
 >
 > If you tear down:
-> - All ATX resources are completely removed from your account
+>
+> - All AWS Transform resources are completely removed from your account
 > - KMS key deletion is scheduled (7-day AWS minimum wait)
 > - S3 buckets, secrets, IAM policies, log groups — all deleted
 > - You'll need to re-run setup (~5-10 min) next time you use remote mode
@@ -446,6 +477,7 @@ user with the following:
 > Would you like to keep the infrastructure or tear it down?
 
 If the user chooses to tear down:
+
 ```bash
 cd "$ATX_INFRA_DIR" && ./teardown.sh
 ```

--- a/aws-transform/steering/workload-custom-repo-analysis.md
+++ b/aws-transform/steering/workload-custom-repo-analysis.md
@@ -1,28 +1,28 @@
-# Repo Analysis & TD Matching
+# Repo Analysis & Transformation Definition Matching
 
 **Local mode only.** Repo analysis inspects files on the local filesystem — it
 cannot run inside remote containers. For remote mode, skip this step and let the
-user specify which TDs to apply. If the user selected remote mode, do NOT attempt
+user specify which transformation definitions to apply. If the user selected remote mode, do NOT attempt
 to run the detection commands below.
 
-Inspect repositories and match them against available Transformation Definitions.
+Inspect repositories and match them against available transformation definitions.
 
-## TD Discovery (Required First Step)
+## Transformation Definition Discovery (Required First Step)
 
 ```bash
 atx custom def list          # Human-readable
 atx custom def list --json   # Programmatic parsing
 ```
 
-Never hardcode TD names. Only match repos against TDs that appear in this output.
+Never hardcode transformation definition names. Only match repos against transformation definitions that appear in this output.
 If `atx` is not installed, install it first — do not fall back to guessed names.
 
-## Known AWS-Managed TDs (Reference Only)
+## Known AWS-Managed Transformation Definitions (Reference Only)
 
 This table is a guide for signal detection, NOT a substitute for `atx custom def list --json`.
-TD names change over time. Always use actual names from the live output.
+Names change over time. Always use actual names from the live output.
 
-| TD Name (may change) | Description | Key Config |
+| Name (may change) | Description | Key Config |
 |---------|-------------|------------|
 | `AWS/java-version-upgrade` | Upgrade Java/JDK version (any source → any target) | Target JDK version (e.g., 17, 21) |
 | `AWS/python-version-upgrade` | Upgrade Python version (3.8/3.9 → 3.11/3.12/3.13) | Target Python version |
@@ -53,6 +53,7 @@ Service routing: COBOL/mainframe → use AWS Transform for Mainframe. .NET Frame
 ## Detection Commands
 
 ### Python
+
 ```bash
 cat <repo>/.python-version 2>/dev/null
 cat <repo>/pyproject.toml 2>/dev/null | head -30
@@ -61,6 +62,7 @@ cat <repo>/requirements.txt 2>/dev/null | head -10
 ```
 
 ### Java
+
 ```bash
 cat <repo>/pom.xml 2>/dev/null | head -60       # Look for <java.version>, <maven.compiler.source>
 cat <repo>/build.gradle 2>/dev/null | head -40   # Look for sourceCompatibility
@@ -68,6 +70,7 @@ cat <repo>/.java-version 2>/dev/null
 ```
 
 ### Node.js
+
 ```bash
 cat <repo>/package.json 2>/dev/null              # Look for engines.node
 cat <repo>/.nvmrc 2>/dev/null
@@ -98,7 +101,7 @@ cat <repo>/package.json 2>/dev/null | grep '"aws-sdk"'
 grep -rlE "x86_64|amd64|x86-64" <repo> --include="*.yml" --include="*.yaml" --include="Dockerfile" 2>/dev/null | head -3
 ```
 
-Currently Java-only. Match against Graviton migration TD if available.
+Currently Java-only. Match against Graviton migration transformation definition if available.
 
 ## Match Report Format
 
@@ -107,26 +110,26 @@ Transformation Match Report
 =============================
 Repository: <name> (<path>)
   Language: <lang> <version>
-  Matching TDs:
-    - <td-name> — <description>
+  Matching transformation definitions:
+    - <name> — <description>
 
-  Other available TDs (may also apply):
-    - <custom-td> — <description>
+  Other available transformation definitions (may also apply):
+    - <custom-name> — <description>
 
 Summary: N repos analyzed, M have matches (T total jobs)
 ```
 
 Group by repository. Show detected version. Include repos with no matches.
-List custom TDs (non-`AWS/` prefix) under "Other available TDs".
+List custom transformation definitions (non-`AWS/` prefix) under "Other available transformation definitions".
 
 ## Edge Cases
 
 | Case | Handling |
 |------|----------|
-| Repo already up-to-date | List upgrade TD but note current version |
-| Monorepo (multiple languages) | List all matching TDs — each is a separate job |
+| Repo already up-to-date | List upgrade transformation definition but note current version |
+| Monorepo (multiple languages) | List all matching transformation definitions — each is a separate job |
 | Mixed local + remote repos | Clone git URL repos locally for inspection, inspect local paths directly |
-| Custom TDs in account | Show under "Other available TDs" per repo |
+| Custom transformation definitions in account | Show under "Other available transformation definitions" per repo |
 | Git clone fails | Report error, continue with remaining repos |
 
 ## Cleanup

--- a/aws-transform/steering/workload-custom-results-synthesis.md
+++ b/aws-transform/steering/workload-custom-results-synthesis.md
@@ -21,9 +21,9 @@ blocks can hang in shell environments. Use a command (ex. `printf '%s'`) to writ
 > Repositories: <total> | Succeeded: <count> | Failed: <count>
 
 ## Results
-| Project | TD | Status | Notes |
-|---------|-----|--------|-------|
-| <name> | <td> | Succeeded/Failed | <brief note> |
+| Project | Transformation | Status | Notes |
+|---------|---------------|--------|-------|
+| <name> | <transformation-name> | Succeeded/Failed | <brief note> |
 
 ## Failed Transformations
 ### <project-name>
@@ -39,12 +39,14 @@ blocks can hang in shell environments. Use a command (ex. `printf '%s'`) to writ
 ## Presentation
 
 Tell the user:
+
 ```
 Results: <succeeded>/<total> succeeded, <failed> failed
 Summary: ~/.aws/atx/custom/atx-agent-session/transformation-summaries/transformation-summary-$SESSION_TS.md
 ```
 
 For remote mode executions, also include the CloudWatch dashboard link:
+
 ```bash
 REGION=${AWS_REGION:-${AWS_DEFAULT_REGION:-$(aws configure get region 2>/dev/null)}}
 REGION=${REGION:-us-east-1}

--- a/aws-transform/steering/workload-custom-single-transformation.md
+++ b/aws-transform/steering/workload-custom-single-transformation.md
@@ -1,24 +1,29 @@
 # Single Transformation
 
-Apply one TD to one repo. TD, config, and repo are already confirmed from the match report.
+Apply one transformation definition to one repo. Transformation definition, config, and repo are already confirmed from the match report.
 
 ## Local Mode
 
-### 1. Verify ATX (once per session, skip if already verified)
+### 1. Verify AWS Transform CLI (once per session, skip if already verified)
+
 ```bash
 atx --version
 ```
 
 ### 2. Verify Language Version
+
 The active language runtime must match the transformation's target version so that builds and tests run correctly. For example, a Java 8 → 17 upgrade needs Java 17 available locally.
 
 Check the installed version matches the target:
+
 ```bash
 java -version    # Java transformations
 python3 --version # Python transformations
 node --version   # Node.js transformations
 ```
+
 If there is a mismatch, resolve it before proceeding:
+
 - Look for the correct version already installed (e.g., check `/usr/lib/jvm/`, `pyenv versions`, `nvm ls`)
 - If found, switch to it (e.g., `export JAVA_HOME=<path to JDK> && export PATH="$JAVA_HOME/bin:$PATH"`, `pyenv shell 3.12`, `nvm use 22`)
 - If not installed, ask the user for permission before installing (e.g., `brew install --cask corretto17` (macOS), `sudo yum install java-17-amazon-corretto-devel` (RHEL/AL2), or `sudo apt install java-17-amazon-corretto-jdk` (Debian/Ubuntu), `pyenv install 3.12`, `nvm install 22`)
@@ -36,6 +41,7 @@ git clone <git-url> "$CLONE_DIR"
 ```
 
 If the user provided an S3 path to a zip, download and extract it locally:
+
 ```bash
 aws s3 cp s3://user-bucket/repos/<project>.zip ~/.aws/atx/custom/atx-agent-session/<project>-$SESSION_TS.zip
 unzip -qo ~/.aws/atx/custom/atx-agent-session/<project>-$SESSION_TS.zip -d ~/.aws/atx/custom/atx-agent-session/repos/<project>-$SESSION_TS/
@@ -45,22 +51,24 @@ Use the cloned/extracted path as `<repo-path>` for all subsequent steps. If the
 user provided a local path, use it directly.
 
 ### 4. Validate Repository
+
 ```bash
 ls -la <repo-path>
 git -C <repo-path> status
 ```
+
 If not a git repo: `cd <repo-path> && git init && git add . && git commit -m "Initial commit"`
 
-### Telemetry
+### 5. Telemetry
 
-When running `atx custom def exec`, always include the `--telemetry` flag (see the Telemetry section in POWER.md). Format:
+When running `atx custom def exec`, always include the `--telemetry` flag (see the Telemetry section in workload-custom.md). Format:
 `--telemetry "client=kiro,agent=kiro,executionMode=<local|remote>"`
 
 - `client` is always `kiro`
 - `agent` is always `kiro`
 - `executionMode` is `local` for direct CLI invocation, `remote` when submitting via Lambda
 
-### 5. Execute and Monitor
+### 6. Execute and Monitor
 
 If the user is transforming the currently opened workspace project, `cd` into it
 and run `pwd` to confirm the absolute path before using it with `-p`.
@@ -83,50 +91,58 @@ nohup ~/.aws/atx/custom/atx-agent-session/run.sh > ~/.aws/atx/custom/atx-agent-s
 echo $! > ~/.aws/atx/custom/atx-agent-session/transform.pid
 cat ~/.aws/atx/custom/atx-agent-session/transform.pid
 ```
-Omit `--configuration` if no config is needed. Include `--telemetry` always — see POWER.md for details.
 
-This backgrounds the runner script (not ATX directly), so the exit code is
+Omit `--configuration` if no config is needed. The `--telemetry` flag is always included — see workload-custom.md for details.
+
+This backgrounds the runner script (not the CLI directly), so the exit code is
 captured to `~/.aws/atx/custom/atx-agent-session/transform.exit` when ATX finishes. The PID file tracks
 the runner process.
 
 **As soon as you have the PID, immediately run the next command** — do NOT stop
-and wait for the user. The ATX CLI outputs the conversation log path within
+and wait for the user. The AWS Transform CLI outputs the conversation log path within
 30-60 seconds of starting. Read it from the process log:
+
 ```bash
 grep "Conversation log:" ~/.aws/atx/custom/atx-agent-session/transform.log 2>/dev/null
 ```
+
 If it hasn't appeared yet, wait 15 seconds and retry (up to 4 attempts). The
 output looks like:
+
 ```
 Conversation log: /Users/<user>/.aws/atx/custom/20260319_063712_e3479843/logs/2026-03-19T06-37-26-conversation.log
 ```
+
 Extract the full path from this line — this is the conversation log for THIS
 specific run. Do NOT use `ls -t` to find the most recent log across all
 conversations, as that may return a log from a previous run.
 
 Then start a monitoring loop. On each cycle:
+
 1. Check if the process is still running: `kill -0 $(cat ~/.aws/atx/custom/atx-agent-session/transform.pid) 2>/dev/null && echo "RUNNING" || echo "DONE"`
 2. Read the latest lines from the conversation log and tell the user what's happening
 3. Wait 60 seconds, then repeat
 
 **You MUST continue polling without waiting for user input.** After each poll,
 immediately schedule the next one. The user should see continuous progress updates
-like "ATX is planning changes...", "Applying changes to 3 files...", "Running build...".
+like "AWS Transform is planning changes...", "Applying changes to 3 files...", "Running build...".
 
 CRITICAL rules:
 
 1. **Extract conversation ID and log path.** After launching the process, look for
    the conversation log line in stdout:
+
    ```
    📝 Conversation log: /Users/<user>/.aws/atx/custom/<conversation-id>/logs/<timestamp>-conversation.log
    ```
+
    Extract the `<conversation-id>` (e.g., `20260311_233325_21bb5ef0`) and the full
    log file path. Report the conversation ID to the user immediately. Example:
    "Transformation started — conversation ID: `20260311_233325_21bb5ef0`"
 
 2. **Tail the conversation log.** Once the log path is known, read new lines from
    the conversation log on each polling cycle and relay meaningful progress to the
-   user. This is the primary way to keep the user informed of what ATX is doing
+   user. This is the primary way to keep the user informed of what AWS Transform is doing
    (e.g., planning steps, applying changes, running builds, encountering errors).
 
 3. **Filter out noise.** When reading the conversation log or process stdout,
@@ -139,9 +155,9 @@ CRITICAL rules:
    background process exits (i.e., `kill -0` returns non-zero). Do NOT treat
    exit code 0 from any other command (grep, cat, test, etc.) as transformation
    completion. Do NOT treat log messages like "TRANSFORMATION COMPLETE" as
-   completion — ATX performs additional steps after that (validation summary
+   completion — AWS Transform performs additional steps after that (validation summary
    generation). Check the process exit code — do NOT parse terminal
-   output or log content to determine completion. ATX prints progress messages
+   output or log content to determine completion. AWS Transform prints progress messages
    and spinner animations throughout execution that do NOT indicate completion.
 
 5. **Polling interval.** Check the background process status and tail the
@@ -161,11 +177,14 @@ CRITICAL rules:
    once — track which ones you've already opened.
 
    Check and open during polling:
+
    ```bash
    ARTIFACTS_DIR=~/.aws/atx/custom/<conversation-id>/artifacts
    ls "$ARTIFACTS_DIR" 2>/dev/null
    ```
+
    When new files appear, open them in the current Kiro window:
+
    ```bash
    kiro -r "$ARTIFACTS_DIR/<filename>"
    ```
@@ -175,26 +194,29 @@ CRITICAL rules:
 
    > ### 💡 Open Source Control (Ctrl+Shift+G) to watch changes in real time
    > 
-   > **ATX commits after each step — Source Control shows every file change with full diffs as they happen.**
+   > **AWS Transform commits after each step — Source Control shows every file change with full diffs as they happen.**
 
    Do NOT defer this message. Do NOT batch it with other output. Send it
    right after opening plan.json.
 
    Continue polling and opening new artifacts until the process exits.
 
-### 6. Present Results
-Show TD, repo path, key changes. Also tell the user:
+### 7. Present Results
+
+Show transformation definition, repo path, key changes. Also tell the user:
 "You can review all changes in the Source Control panel — it shows the full
-commit history with diffs for each file ATX modified."
+commit history with diffs for each file AWS Transform modified."
 
 ## Remote Mode
 
 ### 1. Check Infrastructure
+
 ```bash
 aws cloudformation describe-stacks --stack-name AtxInfrastructureStack \
   --query 'Stacks[0].StackStatus' --output text || echo "NOT_DEPLOYED"
 ```
-If NOT_DEPLOYED: get user consent, then deploy. See [remote-execution.md](remote-execution.md).
+
+If NOT_DEPLOYED: get user consent, then deploy. See [workload-custom-remote-execution.md](workload-custom-remote-execution.md).
 
 ### 2. Prepare Source
 
@@ -207,6 +229,7 @@ If NOT_DEPLOYED: get user consent, then deploy. See [remote-execution.md](remote
 | Local repo | Zip → upload to S3 → use S3 path |
 
 For local sources:
+
 ```bash
 ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 mkdir -p ~/.aws/atx/custom/atx-agent-session
@@ -219,15 +242,18 @@ accessible to the remote container. Do NOT pass arbitrary S3 bucket paths as sou
 the container's IAM role cannot read from them.
 
 ### 3. Submit Job
+
 ```bash
 aws lambda invoke --function-name atx-trigger-job \
   --payload '{"source":"<url-or-s3>","command":"atx custom def exec -n <td> -p /source/<project> -x -t --telemetry \"client=kiro,agent=kiro,executionMode=remote\"","jobName":"<name>","environment":{"JAVA_VERSION":"<target>"}}' \
   --cli-binary-format raw-in-base64-out /dev/stdout
 ```
+
 Add `--configuration \"additionalPlanContext=<config>\"` to the command string if config is needed.
-The `--telemetry` flag is included always — see POWER.md for details.
+The `--telemetry` flag is always included — see workload-custom.md for details.
 
 Set the appropriate version environment variable to match the transformation's target version:
+
 - `JAVA_VERSION` for Java transformations (e.g., `"21"` for a Java 8 → 21 upgrade)
 - `PYTHON_VERSION` for Python transformations (e.g., `"3.12"` for a Python 3.8 → 3.12 upgrade)
 - `NODE_VERSION` for Node.js transformations (e.g., `"22"` for a Node.js 18 → 22 upgrade)
@@ -235,17 +261,20 @@ Set the appropriate version environment variable to match the transformation's t
 Only include the variable relevant to the transformation language. The Lambda whitelists these keys and passes them as Batch container overrides; the entrypoint switches the active runtime at startup.
 
 ### 4. Monitor
+
 ```bash
 aws lambda invoke --function-name atx-get-job-status \
   --payload '{"jobId":"<job-id>"}' \
   --cli-binary-format raw-in-base64-out /dev/stdout
 ```
+
 Poll every 60 seconds for the first 10 polls, then every 5 minutes after.
 Report only on status change.
 
 ### 5. Present Results (Remote)
 
 Do NOT download results locally. Results stay in S3. Present the S3 path to the user:
+
 ```bash
 ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 echo "Results: s3://atx-custom-output-${ACCOUNT_ID}/transformations/<job-name>/"
@@ -254,24 +283,29 @@ echo "Results: s3://atx-custom-output-${ACCOUNT_ID}/transformations/<job-name>/"
 If the user wants to download results, first list the S3 path to discover the
 conversation ID (generated at runtime inside the container). Use the actual
 job name and account ID — do NOT leave placeholders in commands given to the user:
+
 ```bash
 aws s3 ls s3://atx-custom-output-{account-id}/transformations/<job-name>/ --region <region>
 ```
+
 Then provide the download command with the actual conversation ID:
+
 ```
 aws s3 cp s3://atx-custom-output-{account-id}/transformations/<job-name>/<conversation-id>/code.zip ./code.zip
 ```
 
 Include the CloudWatch dashboard link in the completion output:
+
 ```bash
 REGION=${AWS_REGION:-${AWS_DEFAULT_REGION:-$(aws configure get region 2>/dev/null)}}
 REGION=${REGION:-us-east-1}
 echo "https://${REGION}.console.aws.amazon.com/cloudwatch/home#dashboards/dashboard/ATX-Transform-CLI-Dashboard"
 ```
-Show TD, repo, status, downloaded path, and the dashboard link for monitoring history and logs.
+
+Show transformation definition, repo, status, downloaded path, and the dashboard link for monitoring history and logs.
 
 After presenting results, prompt the user about infrastructure teardown. See the
-Cleanup section in [remote-execution.md](remote-execution.md) for the exact prompt.
+Cleanup section in [workload-custom-remote-execution.md](workload-custom-remote-execution.md) for the exact prompt.
 
 ## Error Handling
 
@@ -284,6 +318,7 @@ Cleanup section in [remote-execution.md](remote-execution.md) for the exact prom
 ## MANDATORY: Cleanup
 
 Clean up session files **before starting** and **after completing** each transformation:
+
 ```bash
 [ -d ~/.aws/atx/custom/atx-agent-session ] && find ~/.aws/atx/custom/atx-agent-session -maxdepth 1 -type f \( -name "*.sh" -o -name "*.log" -o -name "*.pid" -o -name "*.exit" -o -name "*.zip" \) -delete 2>/dev/null || true
 ```

--- a/aws-transform/steering/workload-custom-td-creation.md
+++ b/aws-transform/steering/workload-custom-td-creation.md
@@ -1,0 +1,360 @@
+# Interactive Transformation Definition Creation (In-Chat)
+
+When the user wants a new custom transformation definition and nothing in the
+catalog matches, drive the creation **inside this chat**. Do NOT send the user
+to a separate terminal for `atx -t` unless the in-chat helper fails — that is
+the fallback only.
+
+The in-chat path uses the AWS Transform CLI's `atx json` NDJSON protocol,
+wrapped in a small local Python helper. The Power calls the helper once per
+user turn and the helper blocks until ATX is ready for the next answer. No
+polling, no raw protocol output in chat.
+
+## When to Use
+
+- The user explicitly asks to create a new transformation definition, OR
+- `atx custom def list --json` turned up no transformation definition that
+  covers the user's goal
+
+Before starting, confirm with the user in one short question (unless they
+already explicitly asked to create one):
+
+> "I didn't find a transformation definition that covers [goal]. Want me to
+> build one with you?"
+
+Only proceed on confirmation.
+
+## Prerequisites
+
+The helper requires `python3` and calls `atx json`, which in turn calls the
+`transform-custom:ConverseStream` API. A read-only identity hits an
+`AccessDeniedException` — the helper returns exit code 3 with the message on
+stdout. If the caller's identity is read-only or Python 3 is missing, fall
+back to `atx -t`.
+
+Check both once per session before starting:
+
+```bash
+python3 --version && atx json --help > /dev/null 2>&1 && echo HELPER_READY || echo HELPER_UNAVAILABLE
+```
+
+If this prints `HELPER_UNAVAILABLE`, skip the in-chat path and use the
+`atx -t` fallback (see the bottom of this file).
+
+## Setup: Materialize the Helper (Once Per Session)
+
+The helper script is embedded in this file as the fenced Python block below.
+The target location is outside the workspace at
+`~/.aws/atx/custom/atx-agent-session/atx-json-session.py`, but your native
+file-write tool is typically workspace-scoped — writing directly there will
+fail. Do NOT try the outside-workspace path first and then fall back; go
+straight to the workspace-first install below.
+
+Installation steps:
+
+1. Read the fenced Python block in the "Helper Script" section below.
+2. Write its exact contents to `./.atx-json-session.py` at the workspace
+   root using your native file-write tool. Byte-for-byte — no reformatting,
+   no line-length changes, no substitutions. (Shells mangle large Python
+   blobs through heredocs — do not use `cat <<EOF`.)
+3. Move it into place and mark executable:
+
+   ```bash
+   mkdir -p ~/.aws/atx/custom/atx-agent-session
+   cp ./.atx-json-session.py ~/.aws/atx/custom/atx-agent-session/atx-json-session.py
+   chmod +x ~/.aws/atx/custom/atx-agent-session/atx-json-session.py
+   rm ./.atx-json-session.py
+   ```
+
+4. Sanity-check: `python3 -m py_compile ~/.aws/atx/custom/atx-agent-session/atx-json-session.py`.
+   If this exits non-zero, the file was corrupted — re-read the block and
+   re-write it.
+
+The install is idempotent: check if the target file already exists and
+passes `py_compile` first, only re-install if missing or broken.
+
+## Helper Script
+
+```python
+#!/usr/bin/env python3
+"""Blocking wrapper around `atx json` NDJSON stdio.
+
+Subcommands:
+  start "<message>"  Start session; block until ATX waits for input; print text; exit 0.
+  send  "<message>"  Send reply; block until ATX waits for input; print text; exit 0.
+  stop               Cancel session and clean up. Print nothing.
+
+Exit codes: 0 input_required, 2 complete, 3 error, 4 timeout.
+Stdout is clean assistant text only. On error, stdout carries the error message.
+"""
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+BASE = Path.home() / ".aws/atx/custom/atx-agent-session"
+BASE.mkdir(parents=True, exist_ok=True)
+STATE = BASE / "atx-json.state"
+OUT = BASE / "atx-json.out"
+ERR = BASE / "atx-json.err"
+PID = BASE / "atx-json.pid"
+IN_FIFO = BASE / "atx-json.in"
+TIMEOUT = 300
+SPINNER_SUBSTRINGS = ("Thinking",)
+
+
+def _spawn():
+    if IN_FIFO.exists():
+        IN_FIFO.unlink()
+    os.mkfifo(str(IN_FIFO))
+    fd = os.open(str(IN_FIFO), os.O_RDWR)
+    OUT.write_text("")
+    ERR.write_text("")
+    out_fh = open(OUT, "wb")
+    err_fh = open(ERR, "wb")
+    proc = subprocess.Popen(
+        ["atx", "json"],
+        stdin=fd,
+        stdout=out_fh,
+        stderr=err_fh,
+        start_new_session=True,
+    )
+    PID.write_text(str(proc.pid))
+    STATE.write_text("0")
+    return fd
+
+
+def _send(obj):
+    fd = os.open(str(IN_FIFO), os.O_WRONLY | os.O_NONBLOCK)
+    try:
+        os.write(fd, (json.dumps(obj) + "\n").encode())
+    finally:
+        os.close(fd)
+
+
+def _err_tail():
+    try:
+        return ERR.read_text(errors="replace").strip()
+    except Exception:
+        return ""
+
+
+def _extract_err(text):
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        if "Error occurred:" in line or "Exception" in line:
+            return line.split("Error occurred:", 1)[-1].strip() or line
+    return text.splitlines()[0] if text else "unknown error"
+
+
+def _read_until_input():
+    offset = int(STATE.read_text() or "0")
+    chunks = []
+    deadline = time.time() + TIMEOUT
+    while time.time() < deadline:
+        if not OUT.exists():
+            time.sleep(0.05)
+            continue
+        with open(OUT, "rb") as f:
+            f.seek(offset)
+            data = f.read()
+        if not data:
+            time.sleep(0.1)
+            continue
+        # Only advance through complete lines. Partial trailing fragments are
+        # left in the file for the next read — avoids losing a chunk when the
+        # producer's write is split mid-line.
+        if not data.endswith(b"\n"):
+            last_nl = data.rfind(b"\n")
+            if last_nl == -1:
+                time.sleep(0.1)
+                continue
+            data = data[:last_nl + 1]
+            offset += last_nl + 1
+        else:
+            offset += len(data)
+        STATE.write_text(str(offset))
+        for raw in data.decode(errors="replace").splitlines():
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                msg = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            t = msg.get("type")
+            if t == "text_delta":
+                content = msg.get("content", "")
+                if any(s in content for s in SPINNER_SUBSTRINGS):
+                    continue
+                chunks.append(content)
+            elif t == "input_required":
+                text = "".join(chunks).strip()
+                if not text:
+                    err = _err_tail()
+                    if err:
+                        return "error", _extract_err(err)
+                return "input", text
+            elif t == "complete":
+                return "complete", "".join(chunks).strip()
+            elif t == "error":
+                return "error", msg.get("message", "unknown error")
+        time.sleep(0.1)
+    return "timeout", "".join(chunks).strip()
+
+
+def _cleanup():
+    try:
+        pid = int(PID.read_text())
+        os.killpg(os.getpgid(pid), signal.SIGTERM)
+    except Exception:
+        pass
+    for p in (IN_FIFO, PID, OUT, ERR, STATE):
+        try:
+            p.unlink()
+        except FileNotFoundError:
+            pass
+
+
+RC = {"input": 0, "complete": 2, "error": 3, "timeout": 4}
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("usage: atx-json-session.py {start|send|stop} [message]", file=sys.stderr)
+        sys.exit(3)
+    verb = sys.argv[1]
+    message = sys.argv[2] if len(sys.argv) > 2 else ""
+    try:
+        if verb == "start":
+            _spawn()
+            _send({"type": "start_session", "message": message})
+            status, text = _read_until_input()
+            print(text)
+            sys.exit(RC[status])
+        if verb == "send":
+            _send({"type": "send_message", "message": message})
+            status, text = _read_until_input()
+            print(text)
+            sys.exit(RC[status])
+        if verb == "stop":
+            try:
+                _send({"type": "cancel"})
+            except Exception:
+                pass
+            _cleanup()
+            sys.exit(0)
+        print("unknown verb: " + verb, file=sys.stderr)
+        sys.exit(3)
+    except Exception as e:
+        print(str(e), file=sys.stderr)
+        _cleanup()
+        sys.exit(3)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+## Interaction Loop
+
+Every call is a single shell invocation that blocks until ATX is ready for the
+next user message. Do **not** poll. Do **not** wrap in loops. One call per
+user turn.
+
+### Turn 1 — Start the session
+
+```bash
+python3 ~/.aws/atx/custom/atx-agent-session/atx-json-session.py start "Create a TD to migrate AcmeCorp DataBridge v1 integrations to AcmeCorp DataBridge v3"
+```
+
+Build the initial message from what the user told you — their migration goal
+in one or two sentences. The helper prints ATX's clean text reply and exits 0
+when ATX is waiting for input.
+
+Relay that text to the user in your own first-person voice. Don't say "ATX
+asks…" or "the agent wants to know…" — ask the question yourself.
+
+### Turns 2…N — Send the user's reply
+
+```bash
+python3 ~/.aws/atx/custom/atx-agent-session/atx-json-session.py send "Java backend, Maven build, package rename from com.acme.v1 to com.acme.v3"
+```
+
+Wait for the helper to exit, relay stdout to the user as your own voice, wait
+for the user's next answer, repeat.
+
+### Final turn — Close out
+
+When the user signals they're done (TD published, saved as draft, or "stop"):
+
+```bash
+python3 ~/.aws/atx/custom/atx-agent-session/atx-json-session.py stop
+```
+
+Then re-run `atx custom def list --json` so the newly published TD is picked
+up in the catalog, and return to the normal workflow.
+
+## Exit Codes
+
+| Code | Meaning | What to do |
+|------|---------|-----------|
+| `0` | ATX is waiting for user input | Relay stdout, ask user what's next |
+| `2` | Session completed | Relay stdout, run `stop`, refresh TD list |
+| `3` | Helper or backend error | Surface stdout (contains the error message — often `AccessDeniedException`), run `stop`, offer `atx -t` fallback |
+| `4` | Timeout (no ATX output for 5 min) | Run `stop`, offer to retry or fall back |
+
+## Non-Negotiable UX Rules
+
+- **Single helper call per user turn.** The helper is already blocking; never
+  "poll" it. One `start`, one `send` per user reply, one `stop` at the end.
+- **Clean text only — never surface protocol output.** If the helper's stdout
+  somehow contains JSON braces, raw tool names, `text_delta`, `input_required`,
+  `start_session`, `send_message`, or `cancel`, strip or paraphrase before
+  showing the user. Those strings must never appear in chat.
+- **First-person framing.** Ask ATX's clarifying questions in your own voice.
+  Don't say "the agent is asking" or "ATX wants to know."
+- **No narration of mechanics.** Don't say "I'll start the interactive session"
+  or "calling the helper now." Just ask the user the next question.
+- **Stay in the chat.** Don't tell the user to open a separate terminal, run
+  `atx -t` themselves, or switch windows. The whole point is in-chat.
+- **Re-discover after publish.** The moment `stop` returns, re-run
+  `atx custom def list --json` so the newly published TD is reflected.
+
+## Fallback: `atx -t`
+
+Fall back only when:
+
+- The helper returned exit code `3` (error — surface the error text to the user first)
+- The helper returned exit code `4` (timeout)
+- `python3` is not available on the user's machine
+- `atx json` is missing (older CLI versions)
+
+In any of those cases:
+
+> "I couldn't drive this from the chat. Open a terminal and run `atx -t` —
+> describe the transformation you want and ATX will walk you through it. Come
+> back here once it's published and I'll pick it up automatically."
+
+Never use `atx -t` as the first choice.
+
+## MANDATORY: Cleanup
+
+The helper's `stop` subcommand already removes the FIFO and runtime state
+files (`atx-json.in`, `atx-json.out`, `atx-json.err`, `atx-json.pid`,
+`atx-json.state`) on a normal session end. Belt-and-suspenders cleanup in
+case the helper was killed mid-session, an error bailed out before `stop`,
+or the shell was interrupted — run **before starting** and **after completing**
+each TD creation session:
+
+```bash
+[ -d ~/.aws/atx/custom/atx-agent-session ] && find ~/.aws/atx/custom/atx-agent-session -maxdepth 1 \( -name "atx-json.in" -o -name "atx-json.out" -o -name "atx-json.err" -o -name "atx-json.pid" -o -name "atx-json.state" \) -delete 2>/dev/null || true
+```
+
+Keep `atx-json-session.py` in place — the helper script itself is reused
+across sessions. Only the per-session state files are removed.

--- a/aws-transform/steering/workload-custom-troubleshooting.md
+++ b/aws-transform/steering/workload-custom-troubleshooting.md
@@ -6,10 +6,10 @@
 |-------|------------|
 | `atx` not found | Install: `curl -fsSL https://transform-cli.awsstatic.com/install.sh` piped to `bash` |
 | AWS credentials error or expiry | Run `aws sts get-caller-identity`. Check `AWS_PROFILE` or access key env vars |
-| Permission denied | Local mode: need `transform-custom:*` — see Prerequisites → IAM Permissions in POWER.md. Remote mode: generate and attach policies via `npx ts-node generate-caller-policy.ts` — see remote-execution.md |
+| Permission denied | Local mode: need `transform-custom:*` — see Prerequisites → IAM Permissions in workload-custom.md. Remote mode: generate and attach policies via `npx ts-node generate-caller-policy.ts` — see workload-custom-remote-execution.md |
 | Network error | Resolve region: `REGION=${AWS_REGION:-${AWS_DEFAULT_REGION:-$(aws configure get region 2>/dev/null)}}; REGION=${REGION:-us-east-1}`. Check access to `transform-custom.${REGION}.api.aws` |
 | Build fails during transform | Verify build command works locally first. Try interactive mode for debugging |
-| Transform not found | Run `atx custom def list --json` to check available TDs |
+| Transform not found | Run `atx custom def list --json` to check available transformation definitions |
 | Configuration fails with commas | Do not use commas inside `additionalPlanContext` values — they break the CLI parser. Rephrase to avoid commas |
 | Conversation expired | Conversations expire after 30 days. Start a new one |
 | Windows not supported | Tell user to use Windows Subsystem for Linux (WSL) |
@@ -24,10 +24,12 @@ If a git clone fails in the remote container (job status FAILED, logs show
 authentication or 403 errors), work through these steps with the user:
 
 **1. Is the PAT/key stored?**
+
 ```bash
 aws secretsmanager describe-secret --secret-id "atx/github-token" --region "$REGION" 2>/dev/null && echo "EXISTS" || echo "MISSING"
 aws secretsmanager describe-secret --secret-id "atx/ssh-key" --region "$REGION" 2>/dev/null && echo "EXISTS" || echo "MISSING"
 ```
+
 If missing, guide the user through setup — see Step 1 in POWER.md.
 
 **2. Does the PAT have the right scope?**
@@ -38,6 +40,7 @@ each repo explicitly listed."
 
 Resolution: the user updates their PAT on GitHub to include the new repo, then
 updates the stored secret:
+
 ```bash
 aws secretsmanager put-secret-value --secret-id "atx/github-token" --region "$REGION" --secret-string "<updated-token>"
 ```
@@ -45,11 +48,13 @@ aws secretsmanager put-secret-value --secret-id "atx/github-token" --region "$RE
 **3. Has the PAT expired?**
 GitHub PATs can have expiration dates. Ask: "When did you create this PAT? It may
 have expired." Resolution: create a new PAT on GitHub, then update the secret:
+
 ```bash
 aws secretsmanager put-secret-value --secret-id "atx/github-token" --region "$REGION" --secret-string "<new-token>"
 ```
 
 **4. Is it the right credential type for the URL?**
+
 - HTTPS URLs (`https://github.com/...`) need `atx/github-token` (PAT)
 - SSH URLs (`git@github.com:...`) need `atx/ssh-key` (SSH private key)
 If the user provided SSH URLs but only has a PAT stored (or vice versa), guide
@@ -79,6 +84,7 @@ Network errors may indicate VPN/firewall issues with AWS endpoints.
 ## Deployment Failures
 
 CDK deployment handles most issues automatically. Common recovery:
+
 ```bash
 ATX_INFRA_DIR="$HOME/.aws/atx/custom/remote-infra"
 cd "$ATX_INFRA_DIR" && ./teardown.sh
@@ -102,12 +108,10 @@ Diagnose in this order:
 | `transform-cli.awsstatic.com` | CLI installation and updates |
 | `transform-custom.${REGION}.api.aws` | Transformation service API |
 
-
 ## Pre-built Container Image
 
 The default pre-built image URI is `public.ecr.aws/d9h8z6l7/aws-transform:latest`.
 This is configured via `prebuiltImageUri` in `cdk.json`.
-
 
 ## Remote Infrastructure Repo Issues
 

--- a/aws-transform/steering/workload-custom.md
+++ b/aws-transform/steering/workload-custom.md
@@ -1,0 +1,812 @@
+# AWS Transform custom
+
+## Overview
+
+Perform code upgrades, migrations, and transformations using AWS Transform custom.
+Supports any-to-any transformations: language version upgrades (Java, Python, Node.js, etc.),
+framework migrations, AWS SDK migrations, library upgrades, code refactoring, architecture
+changes, and custom organization-specific transformations.
+
+Two execution modes:
+
+- **Local mode**: Runs the AWS Transform CLI directly on the user's machine. Best for 1-9 repos.
+- **Remote mode**: Runs transformations at scale via AWS Batch/Fargate containers.
+  Best for 10+ repos or when the user prefers cloud execution. Infrastructure is
+  auto-deployed with user consent.
+
+You handle the full workflow: inspecting repos, matching them to available
+transformation definitions, collecting configuration, and executing transformations
+in either mode — the user just provides repos and confirms the plan.
+
+## Greeting
+
+"AWS Transform custom can help you:
+
+- Upgrade Java, Python, and Node.js to modern versions
+- Migrate AWS SDKs (Java SDK v1→v2, boto2→boto3, JS SDK v2→v3)
+- Handle framework migrations, library upgrades, and code refactoring
+- Analyze codebases and generate documentation
+- Define and run your own custom transformations using natural language, docs, 
+and code samples
+
+Run locally on a few repos for fast iteration, or at scale on hundreds of repos (up to 128 in-parallel). Note: this power collects telemetry. To opt out, see [here](https://docs.aws.amazon.com/transform/latest/userguide/transform-usage-telemetry.html).
+
+What would you like to transform today?"
+
+Do NOT inspect any files, run any commands, or check prerequisites until the user responds.
+
+## Usage
+
+Use when the user wants to:
+
+- Transform, upgrade, or migrate code (Java, Python, Node.js, etc.)
+- Migrate AWS SDKs (Java SDK v1→v2, boto2→boto3, JS SDK v2→v3, etc.)
+- Run bulk code transformations at scale via AWS Batch/Fargate
+- Analyze which AWS Transform transformations apply to their repositories
+- Perform comprehensive codebase analysis
+- Create a new custom Transformation definition
+
+## Core Concepts
+
+- **Transformation definition**: A reusable transformation recipe discovered via `atx custom def list --json`
+- **Match Report**: Auto-generated mapping of repos to applicable transformation definitions based on code inspection
+- **Local Mode**: Runs AWS Transform CLI on the user's machine (1-9 repos, max 3 concurrent)
+- **Remote Mode**: Runs transformations in AWS Batch/Fargate (10+ repos, or by preference)
+
+## Philosophy
+
+Wait for the user. On activation, present what this power can do and ask the user
+what they'd like to accomplish. Do NOT automatically inspect the working directory,
+open files, or any repository until the user explicitly provides repos to work with.
+
+Once the user provides repositories, match — don't ask. Inspect those repositories
+and present which transformations apply automatically. Never show a raw transformation definition list and
+ask the user to pick.
+
+## Prerequisites
+
+Prerequisite checks run ONCE at the start of a session. Do not repeat per repo.
+Do NOT run prerequisite checks until the user has stated what they want to do.
+
+### 0. Platform Check (Required — All Modes)
+
+Detect the user's operating system. If on Windows (not WSL), stop immediately and
+inform the user:
+
+> AWS Transform custom does not support native Windows. You need to install
+> Windows Subsystem for Linux (WSL) and run this from within WSL.
+>
+> Install WSL: `wsl --install` in PowerShell (as Administrator), then restart.
+> After that, open a WSL terminal and re-run this power from there.
+
+Check by running:
+
+```bash
+uname -s
+```
+
+- `Linux` or `Darwin` → proceed normally
+- `MINGW*`, `MSYS*`, `CYGWIN*`, or any Windows-like output → block and show the WSL message above
+- Command fails, errors, or is not found → treat as native Windows, block and show the WSL message above
+
+Do NOT proceed with any other steps on native Windows.
+
+### 1. AWS CLI (Required — All Modes)
+
+```bash
+aws --version
+```
+
+If not installed, guide the user:
+
+- macOS: `brew install awscli` or `curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg" && sudo installer -pkg AWSCLIV2.pkg -target /`
+- Linux: `curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && sudo ./aws/install`
+
+Do NOT proceed until `aws --version` succeeds.
+
+### 2. AWS Credentials (Required — All Modes)
+
+```bash
+aws sts get-caller-identity
+```
+
+If credentials are NOT configured, walk the user through setup:
+
+```
+AWS Transform custom requires AWS credentials to authenticate with the service. Configure authentication using one of the following methods.
+
+1. AWS CLI Configure (~/.aws/credentials):
+   aws configure
+
+2. AWS Credentials File (manual). Configure credentials in ~/.aws/credentials:
+
+[default]
+aws_access_key_id = your_access_key
+aws_secret_access_key = your_secret_key
+
+3. Environment Variables. Set the following environment variables:
+
+export AWS_ACCESS_KEY_ID=your_access_key
+export AWS_SECRET_ACCESS_KEY=your_secret_key
+export AWS_SESSION_TOKEN=your_session_token
+
+You can also specify a profile using the AWS_PROFILE environment variable:
+
+export AWS_PROFILE=your_profile_name
+```
+
+Do NOT proceed until credentials are verified. Re-run `aws sts get-caller-identity` after setup.
+
+Note: environment variables set via `export` do not carry over between shell sessions. If you spawn a new shell, credentials set as env vars may be lost. Prefer `aws configure` or `~/.aws/credentials` for persistence.
+
+### 3. AWS Transform CLI (Required — All Modes)
+
+Required in all modes for transformation definition discovery (`atx custom def list --json`).
+Local mode also uses it for transformation execution.
+
+```bash
+atx --version
+# Install: curl -fsSL https://transform-cli.awsstatic.com/install.sh | bash
+```
+
+**Mandatory: always run `atx update` once at the start of every session**, even if you just ran it recently. This catches new AWS Transform CLI versions and new transformation definitions. Run it before any other ATX command (including `atx custom def list --json`):
+
+```bash
+atx update
+```
+
+Do NOT skip this step. Do NOT ask the user whether to update. Do NOT condition it on whether the CLI "needs" an update. Run it unconditionally.
+
+### 4. IAM Permissions (Required — All Modes)
+
+Local mode requires `transform-custom:*` minimum. Verify by running a transformation definition list:
+
+```bash
+atx custom def list --json
+```
+
+If this succeeds, permissions are sufficient — skip the rest of this section.
+
+If it fails with a permissions error, the caller needs the `transform-custom:*`
+IAM permission. Explain to the user what's needed and get confirmation before proceeding:
+
+> Your identity needs the `transform-custom:*` permission to use the AWS Transform CLI.
+> I can attach the AWS-managed policy `AWSTransformCustomFullAccess` to your
+> identity. Shall I proceed?
+
+Only after the user confirms, attach the managed policy:
+
+```bash
+CALLER_ARN=$(aws sts get-caller-identity --query Arn --output text)
+if echo "$CALLER_ARN" | grep -q ":user/"; then
+  IDENTITY_NAME=$(echo "$CALLER_ARN" | awk -F'/' '{print $NF}')
+  aws iam attach-user-policy --user-name "$IDENTITY_NAME" \
+    --policy-arn "arn:aws:iam::aws:policy/AWSTransformCustomFullAccess"
+elif echo "$CALLER_ARN" | grep -Eq ":assumed-role/|:role/"; then
+  ROLE_NAME=$(echo "$CALLER_ARN" | sed 's/.*:\(assumed-\)\{0,1\}role\///' | cut -d'/' -f1)
+  aws iam attach-role-policy --role-name "$ROLE_NAME" \
+    --policy-arn "arn:aws:iam::aws:policy/AWSTransformCustomFullAccess"
+fi
+```
+
+If the attachment command itself fails (e.g., insufficient IAM permissions, or an
+SSO-managed role), inform the user they need to ask their AWS administrator to
+attach the `AWSTransformCustomFullAccess` AWS-managed policy to their identity.
+For SSO users (role names starting with `AWSReservedSSO_`), this must be added
+to their IAM Identity Center permission set — it cannot be attached directly.
+
+Do NOT proceed until `atx custom def list --json` succeeds.
+
+Remote mode requires additional permissions (Lambda invoke, S3, KMS, Secrets Manager,
+CloudWatch). These are generated and attached as part of the deployment flow — see
+[workload-custom-remote-execution.md](workload-custom-remote-execution.md).
+
+See [workload-custom-cli-reference.md](workload-custom-cli-reference.md) for the full permission list.
+
+### 5. AWS CDK (Remote Mode Only)
+
+Required for deploying remote infrastructure. Check if installed:
+
+```bash
+cdk --version
+```
+
+If not installed, install it globally:
+
+```bash
+npm install -g aws-cdk
+```
+
+Do NOT proceed with remote deployment until `cdk --version` succeeds.
+
+### 6. Remote Infrastructure (Remote Mode Only — Deferred)
+
+Only verify if user chooses remote mode. The infrastructure CDK scripts are fetched
+at runtime by cloning `https://github.com/aws-samples/aws-transform-custom-samples.git` (branch `atx-remote-infra`) —
+they are not bundled with this power. See [workload-custom-remote-execution.md](workload-custom-remote-execution.md).
+
+## Workflow
+
+Generate a session timestamp once and reuse it for all paths in this session:
+
+```bash
+SESSION_TS=$(date +%Y%m%d-%H%M%S)
+```
+
+### Step 1: Collect Repositories
+
+Ask the user for local paths or git URLs. Accept one or many. Do NOT assume the
+current working directory or open editor files are the target — wait for the user
+to explicitly provide repositories.
+
+Accepted source formats:
+
+- **Local paths** — directories on the user's machine (e.g., `/home/user/my-project`)
+- **HTTPS git URLs** — public or private (e.g., `https://github.com/org/repo.git`)
+- **SSH git URLs** — e.g., `git@github.com:org/repo.git`
+- **S3 bucket path with zips** — e.g., `s3://my-bucket/repos/`
+  containing zip files of repositories. Each zip becomes one transformation job.
+
+#### S3 Bucket Input
+
+If the user provides an S3 path containing zip files, ask which execution mode
+they prefer (if not already specified). S3 input works in both modes:
+
+**Remote mode:** Copy the zips from the user's bucket to the managed source bucket,
+then submit jobs pointing to the managed copies:
+
+```bash
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+SOURCE_BUCKET="atx-source-code-${ACCOUNT_ID}"
+
+# List all zips in the user's bucket path
+aws s3 ls s3://user-bucket/repos/ --recursive | grep '\.zip$'
+
+# Copy each zip to the managed source bucket
+aws s3 sync s3://user-bucket/repos/ s3://${SOURCE_BUCKET}/repos/ --exclude "*" --include "*.zip"
+```
+
+Then submit a batch job with one job per zip, each pointing to
+`s3://${SOURCE_BUCKET}/repos/<filename>.zip`. The container handles zip extraction
+automatically. See [workload-custom-multi-transformation.md](workload-custom-multi-transformation.md) for batch submission.
+The managed source bucket has a 7-day lifecycle — copied zips auto-delete.
+
+**Local mode:** Download and extract each zip locally:
+
+```bash
+mkdir -p ~/.aws/atx/custom/atx-agent-session/repos
+aws s3 sync s3://user-bucket/repos/ ~/.aws/atx/custom/atx-agent-session/repos/ --exclude "*" --include "*.zip"
+for zip in ~/.aws/atx/custom/atx-agent-session/repos/*.zip; do
+  name=$(basename "$zip" .zip)
+  unzip -qo "$zip" -d "$HOME/.aws/atx/custom/atx-agent-session/repos/${name}-$SESSION_TS/"
+done
+```
+
+Use the extracted directories as `<repo-path>` for local execution. Standard local
+mode limits apply (max 3 concurrent repos).
+
+#### Private Repository Detection (Remote Mode)
+
+**Always ask the user** — do NOT try to determine repo visibility yourself. Never
+attempt to clone, curl, or probe a URL to check if it's public or private. Simply
+ask the user. As soon as the user provides git URLs and remote mode is selected
+(or likely), ask:
+
+> "Are any of these repositories private? If so, the remote container needs
+> credentials to clone them — I'll walk you through the setup."
+
+Do NOT skip this question. Do NOT try to infer visibility by attempting a clone,
+curl, or any other network request. Just ask.
+
+If the user confirms repos are private, determine the credential type based on URL format:
+
+First, resolve the region (use for all Secrets Manager commands below):
+
+```bash
+REGION=${AWS_REGION:-${AWS_DEFAULT_REGION:-$(aws configure get region 2>/dev/null)}}
+REGION=${REGION:-us-east-1}
+```
+
+**For HTTPS URLs** — check whether a GitHub PAT is already configured:
+
+```bash
+aws secretsmanager describe-secret --secret-id "atx/github-token" --region "$REGION" 2>/dev/null \
+  && echo "CONFIGURED" || echo "NOT_CONFIGURED"
+```
+
+If CONFIGURED, ask the user: "A GitHub PAT is already stored. Would you like to
+keep using it, or replace it with a new one?" If they want to replace it, tell
+them to run:
+
+```
+aws secretsmanager put-secret-value --secret-id "atx/github-token" --region "$REGION" --secret-string "YOUR_TOKEN_HERE"
+```
+
+If NOT_CONFIGURED, explain what's needed and tell the user to run the create command:
+> "Private HTTPS repos need a GitHub Personal Access Token (PAT) stored in AWS
+> Secrets Manager. The remote container fetches it at startup to clone your repos.
+> The token stays in your AWS account — you can delete it anytime.
+>
+> The PAT needs the `repo` scope for private repositories. Create one at
+> https://github.com/settings/tokens and then run:
+>
+> ```
+> aws secretsmanager create-secret --name "atx/github-token" --region "$REGION" --secret-string "YOUR_TOKEN_HERE"
+> ```
+>
+> Delete anytime: `aws secretsmanager delete-secret --secret-id atx/github-token --region "$REGION" --force-delete-without-recovery`"
+
+Do NOT ask the user to paste their token in chat. They run the command themselves.
+Wait for the user to confirm it's done, then verify:
+
+```bash
+aws secretsmanager describe-secret --secret-id "atx/github-token" --region "$REGION" 2>/dev/null \
+  && echo "CONFIGURED" || echo "NOT_CONFIGURED"
+```
+
+**For SSH URLs** (`git@...` or `ssh://...`) — check whether an SSH key is configured:
+
+```bash
+aws secretsmanager describe-secret --secret-id "atx/ssh-key" --region "$REGION" 2>/dev/null \
+  && echo "CONFIGURED" || echo "NOT_CONFIGURED"
+```
+
+If CONFIGURED, ask the user: "An SSH key is already stored. Would you like to
+keep using it, or replace it with a new one?" If they want to replace it, tell
+them to run:
+
+```
+aws secretsmanager put-secret-value --secret-id "atx/ssh-key" --region "$REGION" --secret-string "$(cat <path-to-your-private-key>)"
+```
+
+If NOT_CONFIGURED, explain what's needed and tell the user to run the create command:
+> "SSH repos need an SSH private key stored in AWS Secrets Manager. The remote
+> container fetches it at startup to clone your repos.
+>
+> Run:
+>
+> ```
+> aws secretsmanager create-secret --name "atx/ssh-key" --region "$REGION" --secret-string "$(cat <path-to-your-private-key>)"
+> ```
+>
+> Delete anytime: `aws secretsmanager delete-secret --secret-id atx/ssh-key --region "$REGION" --force-delete-without-recovery`"
+
+Do NOT ask the user to paste their SSH key in chat. They run the command themselves.
+
+For local mode, private repo credentials are not needed — the user's local git
+config handles authentication. Skip this check entirely for local mode.
+
+### Step 2: Discover Transformation Definitions (Silent)
+
+Run silently — do NOT show output to user:
+
+```bash
+atx custom def list --json
+```
+
+Inspect the JSON output directly to build an internal lookup of available transformation definitions.
+Do NOT pipe the output to python, jq, or other parsing scripts — read the JSON
+yourself. Never hardcode transformation definition names.
+
+#### Creating a New Transformation Definition
+
+**User explicitly asks to create a transformation definition**, or **no existing
+transformation definition matches the user's goal**:
+
+Drive the creation **inside this chat** using the in-chat helper — do NOT send
+the user to a separate terminal. See
+[workload-custom-td-creation.md](workload-custom-td-creation.md)
+for the full protocol (helper setup, interaction loop, UX rules, and fallback).
+
+After the TD is published, re-run `atx custom def list --json` to pick up the
+newly published transformation definition and continue with the normal workflow.
+
+### Step 3: Inspect Each Repository
+
+Perform lightweight inspection only — check config files for key signals:
+
+| Signal | Files to Check | Likely Transformation Type |
+|--------|---------------|----------------|
+| Python version | `.python-version`, `pyproject.toml`, `setup.cfg`, `requirements.txt` | Python version upgrade |
+| Java version | `pom.xml` (`<java.version>`), `build.gradle` (`sourceCompatibility`), `.java-version` | Java version upgrade |
+| Node.js version | `package.json` (`engines.node`), `.nvmrc`, `.node-version` | Node.js version upgrade |
+| Python boto2 | `import boto` (NOT boto3) | boto2→boto3 migration |
+| Java SDK v1 | `com.amazonaws` imports, `aws-java-sdk` in pom.xml | Java SDK v1→v2 |
+| Node.js SDK v2 | `"aws-sdk"` in package.json (NOT `@aws-sdk`) | JS SDK v2→v3 |
+| x86 Java | `x86_64`/`amd64` in Dockerfiles, build configs | Graviton migration |
+
+Cross-reference detected signals against transformation definitions from Step 2. Only match transformation definitions that
+actually exist in the user's account.
+
+See [workload-custom-repo-analysis.md](workload-custom-repo-analysis.md) for full detection commands.
+
+### Step 4: Present Match Report
+
+Format:
+
+```
+Transformation Match Report
+=============================
+Repository: <name> (<path>)
+  Language: <lang> <version>
+  Matching transformation definitions:
+    - <td-name> — <description>
+
+Summary: N repos analyzed, M have applicable transformations (T total jobs)
+```
+
+Present the match report and wait for user confirmation before proceeding.
+Do NOT start any transformation without explicit user consent.
+
+### Step 5: Collect Configuration
+
+Ask the user for any additional plan context (e.g., target version for upgrade transformation definitions).
+This is mandatory — always ask, even if the transformation definition doesn't strictly require config.
+The user may have preferences or constraints you don't know about.
+Skip only if the user explicitly says no additional context is needed.
+
+### Step 6: Verify Runtime Compatibility (Remote and Local)
+
+#### Remote Mode
+
+**Infrastructure check:** To verify whether remote infrastructure is deployed, use CloudFormation — do NOT check individual Lambda functions by name:
+
+```bash
+aws cloudformation describe-stacks --stack-name AtxInfrastructureStack \
+  --query 'Stacks[0].StackStatus' --output text || echo "NOT_DEPLOYED"
+```
+
+Before submitting remote jobs, determine whether the pre-built image covers the
+target runtime or if a custom Docker build is needed.
+
+**Pre-built image includes:**
+
+- **Java**: 8, 11, 17, 21, 25 (Amazon Corretto) with Maven and Gradle 9.4
+- **Python**: 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14 (dnf + pyenv)
+- **Node.js**: 16, 18, 20, 22, 24 (nvm) with yarn, pnpm, TypeScript, ts-node
+- **Build tools**: gcc, g++, make, patch
+- **CLI tools**: AWS CLI v2, AWS Transform CLI, git, jq, curl, unzip, tar
+- **OS**: Amazon Linux 2023 (x86_64)
+
+**Decision logic:**
+
+1. Based on the transformation requirements (source runtime, target runtime,
+   build tools, and any other dependencies), determine whether everything
+   needed is available in the pre-built image listed above
+2. If **yes** → use the pre-built image path (no Docker required). Proceed to deployment
+   using the pre-built image instructions in [workload-custom-remote-execution.md](workload-custom-remote-execution.md).
+3. If **no** → use the custom image path (Docker required). Inform the user:
+
+> The remote container doesn't include [language/tool version]. To run this
+> transformation remotely, I'll need to build a custom container image. This
+> requires Docker installed and running on your machine. It's a one-time change
+> — about 5-10 minutes. Want me to proceed?
+
+If the user confirms, follow the custom image path in
+[workload-custom-remote-execution.md](workload-custom-remote-execution.md): clear `prebuiltImageUri`,
+customize the Dockerfile, and deploy.
+
+If the user declines, suggest local mode as an alternative (if the tools are
+available on their machine).
+
+**Dockerfile customization (custom image path only):**
+
+First, read the Dockerfile to see what's installed:
+
+```bash
+ATX_INFRA_DIR="$HOME/.aws/atx/custom/remote-infra"
+cat "$ATX_INFRA_DIR/container/Dockerfile" 2>/dev/null
+```
+
+1. Ensure the infrastructure repo is cloned and up to date:
+
+   ```bash
+   ATX_INFRA_DIR="$HOME/.aws/atx/custom/remote-infra"
+   if [ -d "$ATX_INFRA_DIR" ]; then
+     git -C "$ATX_INFRA_DIR" add -A
+     git -C "$ATX_INFRA_DIR" commit -m "Local customizations" -q 2>/dev/null || true
+     git -C "$ATX_INFRA_DIR" pull -q
+   else
+     git clone -b atx-remote-infra --single-branch https://github.com/aws-samples/aws-transform-custom-samples.git "$ATX_INFRA_DIR"
+   fi
+   ```
+
+   If `git pull` reports a merge conflict, resolve it by keeping both upstream
+   changes and the user's customizations in the `CUSTOM LANGUAGES AND TOOLS`
+   section of the Dockerfile, then commit the merge.
+
+2. Edit `$ATX_INFRA_DIR/container/Dockerfile`. Find the section marked
+   `# CUSTOM LANGUAGES AND TOOLS` and insert `RUN` commands after the comment
+   block, before the `USER root` line.
+
+   For missing versions of already-installed languages, add the version in the
+   custom section. Examples:
+
+   ```dockerfile
+   # Java 23 (Amazon Corretto — direct install, must run as root)
+   # Do NOT use dnf in the custom section — pyenv overrides the system python3
+   # that dnf depends on, causing "No module named 'dnf'" errors.
+   USER root
+   RUN curl -fsSL "https://corretto.aws/downloads/latest/amazon-corretto-23-x64-linux-jdk.tar.gz" -o /tmp/corretto23.tar.gz && \
+       mkdir -p /usr/lib/jvm && \
+       tar -xzf /tmp/corretto23.tar.gz -C /usr/lib/jvm && \
+       rm /tmp/corretto23.tar.gz && \
+       ln -sfn /usr/lib/jvm/amazon-corretto-23.* /usr/lib/jvm/corretto-23
+
+   # Node.js 23 (via nvm — must run as atxuser)
+   USER atxuser
+   RUN . /home/atxuser/.nvm/nvm.sh && nvm install 23
+   USER root
+
+   # Python 3.15 (via pyenv — must run as atxuser)
+   USER atxuser
+   RUN eval "$(/home/atxuser/.pyenv/bin/pyenv init -)" && \
+       MAKE_OPTS="-j$(nproc)" /home/atxuser/.pyenv/bin/pyenv install 3.15.0
+   USER root
+   ```
+
+   For entirely new languages, avoid `dnf` in the custom section — pyenv
+   overrides the system python3 that `dnf` depends on. Use language-specific
+   installers instead:
+
+   ```dockerfile
+   # Go
+   RUN curl -fsSL https://go.dev/dl/go1.22.0.linux-amd64.tar.gz | tar -C /usr/local -xz
+   ENV PATH="/usr/local/go/bin:$PATH"
+
+   # Ruby (via rbenv — must run as atxuser)
+   USER atxuser
+   RUN git clone --depth 1 https://github.com/rbenv/rbenv.git /home/atxuser/.rbenv && \
+       git clone --depth 1 https://github.com/rbenv/ruby-build.git /home/atxuser/.rbenv/plugins/ruby-build && \
+       /home/atxuser/.rbenv/bin/rbenv install 3.3.0 && \
+       /home/atxuser/.rbenv/bin/rbenv global 3.3.0
+   ENV PATH="/home/atxuser/.rbenv/shims:/home/atxuser/.rbenv/bin:$PATH"
+   USER root
+
+   # Rust
+   USER atxuser
+   RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+   ENV PATH="/home/atxuser/.cargo/bin:$PATH"
+   USER root
+   ```
+
+3. Update the version switcher in `$ATX_INFRA_DIR/container/entrypoint.sh`.
+   Find the relevant `switch_*_version` function and add a case for the new
+   version. For Java versions installed via direct download, find the extracted
+   directory name under `/usr/lib/jvm/`. For example, to add Java 23:
+
+   ```bash
+   # In switch_java_version(), add to the case statement:
+   23) java_home="/usr/lib/jvm/corretto-23" ;;
+   ```
+
+   Check the actual directory name: `ls /usr/lib/jvm/` — use the directory
+   that matches the version you installed.
+
+   For Node.js, nvm handles arbitrary versions automatically — no entrypoint
+   change needed. For Python, pyenv handles arbitrary versions — no entrypoint
+   change needed (the existing pyenv fallback logic finds it).
+
+4. Deploy (or redeploy): `cd "$ATX_INFRA_DIR" && ./setup.sh`
+   CDK hashes the `container/` directory — any file change triggers a rebuild
+   and push to ECR automatically.
+
+After redeployment, set the `environment` field on the job to the exact target
+version (e.g., `"JAVA_VERSION":"23"`, not `"21"`). The version switcher in the
+entrypoint reads this and activates the correct runtime.
+
+If the user declines, suggest local mode as an alternative (if the tools are
+available on their machine).
+
+#### Local Mode
+
+Before running local transformations, verify the user has the target runtime
+version installed. This applies to any language or runtime the transformation
+targets — Java, Python, Node.js, Ruby, Go, Rust, .NET, etc. Check the current
+version of whatever runtime the transformation definition requires. For example:
+
+```bash
+java -version    # Java transformations
+python3 --version # Python transformations
+node --version   # Node.js transformations
+ruby --version   # Ruby transformations
+go version       # Go transformations
+```
+
+If the target version is not active, check whether it's already installed:
+
+```bash
+# Java: check common install locations
+/usr/libexec/java_home -V 2>&1          # macOS
+ls /usr/lib/jvm/ 2>/dev/null            # Linux
+# Python: check if the specific version binary exists
+which python3.12 2>/dev/null            # adjust version as needed
+# Node.js: check if nvm is available, or look for the binary
+command -v nvm &>/dev/null && nvm ls 2>/dev/null
+which node 2>/dev/null && node --version
+```
+
+If the target version is found, switch to it:
+
+- Java: `export JAVA_HOME=<path to JDK> && export PATH="$JAVA_HOME/bin:$PATH"`
+- Python: `pyenv shell 3.15.0`
+- Node.js: `nvm use 23`
+
+Only if the target version is not installed at all, ask the user for permission before installing. Do NOT install runtimes without explicit user confirmation.
+Suggest the appropriate version manager:
+
+- Java: `brew install --cask corretto23` (macOS), `sudo yum install java-23-amazon-corretto-devel` (RHEL/AL2), or `sudo apt install java-23-amazon-corretto-jdk` (Debian/Ubuntu)
+- Python: `pyenv install 3.15.0 && pyenv shell 3.15.0`, or `brew install python@3.15`
+- Node.js: `nvm install 23 && nvm use 23`
+
+The active runtime must match the transformation's target version so that builds
+and tests run correctly. Do NOT proceed with the transformation until the correct
+version is active.
+
+### Step 7: Confirm Transformation Plan
+
+Present final plan with repo, transformation definition, config, and execution mode. Do NOT proceed
+until user confirms.
+
+### Step 8: Execute
+
+- **1 repo**: See [workload-custom-single-transformation.md](workload-custom-single-transformation.md)
+- **Multiple repos**: See [workload-custom-multi-transformation.md](workload-custom-multi-transformation.md)
+
+## Execution Modes
+
+| Mode | Best For | Prerequisites |
+|------|----------|---------------|
+| **Local** (default for 1-9 repos) | Quick transforms, dev machines with ATX | AWS Transform CLI installed |
+| **Remote** (recommended for 10+ repos) | Bulk transforms, up to 512 repos (128 concurrent per batch) | AWS account, auto-deployed infra |
+
+Mode inference:
+
+- User says "local"/"here"/"on my machine" → Local (honor the request regardless of repo count)
+- User says "remote"/"cloud"/"AWS"/"batch"/"at scale" → Remote
+- 10+ repos without preference → Recommend remote, explain local cap recommendation of 3 concurrent
+- 1-9 repos without preference → Local, note remote available
+
+See [workload-custom-remote-execution.md](workload-custom-remote-execution.md) for infrastructure setup.
+
+## Critical Rules
+
+1. **Discover transformation definitions dynamically** — Always run `atx custom def list --json`. Never hardcode transformation definition names.
+2. **Match, don't ask** — Inspect repos and present matches. Never show raw transformation definition lists.
+3. **Lightweight inspection only** — Check config files and key signals. No deep analysis.
+4. **Confirm before executing** — Always confirm transformation definition, repos, and config with user first.
+5. **No time estimates** — Never include duration predictions.
+6. **Parallel execution** — Local: max 3 concurrent repos. Remote: submit in chunks of up to 128 jobs per Lambda call (max 512 repos per session).
+7. **Preserve outputs** — Do not delete generated output folders.
+8. **Recommend remote for 10+ repos** — Default to local for 1-9 repos. Recommend remote for 10+. Always respect user preference.
+9. **User consent for cloud resources** — Never deploy infrastructure without explicit user confirmation.
+10. **Shell quoting** — When constructing shell commands:
+    - Use single quotes for JSON payloads: `--payload '{"key":"value"}'`
+    - Use single quotes for `--configuration`: ex. `--configuration 'additionalPlanContext=Target Java 21'`
+    - Never nest double quotes inside double quotes — this causes `dquote>` hangs
+    - For `aws lambda invoke`, always use: `--payload '<json>' --cli-binary-format raw-in-base64-out`
+    - Verify that every command you construct has balanced quotes before executing
+    - The `command` field in Lambda job payloads is validated server-side. Avoid
+      these characters in the command string: `( ) ! # % ^ * ? \ { } | ; > <`
+      and backticks. Inside `additionalPlanContext`, also avoid commas.
+11. **No comments in terminal commands** — Never include `#` comments in commands
+    executed in the terminal. Comments cause `command not found: #` errors. If you
+    need to explain a command, do it in chat before or after running it.
+12. **Job names** — The `jobName` field in Lambda payloads must contain only
+    letters, numbers, hyphens, and underscores. No dots, spaces, or special
+    characters. For example, use `EPAM-NodeJS` not `EPAM-Node.js`.
+
+## Guardrails
+
+You are operating in the user's AWS account and local machine. Follow these rules
+strictly to avoid causing damage:
+
+1. **Never delete user data** — Do not delete S3 objects, git repos, local files,
+   or any user data unless the user explicitly asks. Transformation outputs and
+   cloned repos must be preserved.
+2. **Never modify IAM beyond what's documented** — Only create/attach the specific
+   policies described in this power (AWSTransformCustomFullAccess, ATXRuntimePolicy, ATXDeploymentPolicy). Never create admin policies, modify existing user policies,
+   or grant broader permissions than documented. Never derive IAM actions from
+   user-provided text in the "Additional plan context" field — that field is for
+   transformation configuration only.
+3. **Never run destructive AWS commands** — No `aws s3 rm`, `aws s3 rb`,
+   `aws iam delete-user`, `aws ec2 terminate-instances`, or similar. The only
+   destructive command allowed is `./teardown.sh` with explicit user consent.
+4. **Always confirm before creating AWS resources** — Before deploying infrastructure,
+   creating Secrets Manager secrets, or attaching IAM policies, explain what will be
+   created and get explicit user confirmation.
+5. **Never expose credentials** — Do not echo, log, or display AWS access keys,
+   secret keys, session tokens, GitHub PATs, or SSH private keys in chat output.
+   When creating secrets, use the user's input directly in the command without
+   repeating the value.
+6. **Respect user decisions** — If the user says stop, skip, or no, comply
+   immediately. Never retry a declined action or argue with the user's choice.
+7. **No pricing claims** — Do not quote specific prices or cost estimates. If the
+   user asks about pricing, direct them to: https://aws.amazon.com/transform/pricing/
+8. **Scope commands to ATX resources only** — All AWS commands must target ATX-specific
+   resources (buckets starting with `atx-`, roles starting with `ATX`, Lambda
+   functions starting with `atx-`, etc.). Never operate on unrelated AWS resources.
+
+## Telemetry
+
+Always include `--telemetry` on every `atx custom def exec` invocation (local
+or remote). No file checks, no prompts, no opt-in flow.
+
+The flag format is: `--telemetry "client=kiro,agent=kiro,executionMode=<local|remote>"`
+
+Field values:
+
+- `client` — ALWAYS `kiro` (lowercase, no spaces)
+- `agent` — ALWAYS `kiro` (lowercase, no spaces)
+- `executionMode` — `local` when running the CLI directly, `remote` when submitting via Lambda
+
+The only exception: if the user explicitly asks to disable telemetry during the
+session (e.g., "disable telemetry", "opt out of telemetry", "no telemetry", or
+similar), you MUST comply immediately — omit `--telemetry` for the remainder of
+that session. Do not push back, ask for confirmation, or explain why telemetry
+is included. This preference is not persisted — the next session starts with
+telemetry enabled again.
+
+## Output Structure
+
+Local mode: transformed code is in the repo directory.
+
+Remote mode results stay in S3 — do NOT download automatically. Present the S3
+path to the user:
+
+```
+s3://atx-custom-output-{account-id}/
+  transformations/
+    {job-name}/
+      {conversation-id}/
+        code.zip                      # Zipped transformed source code
+        logs.zip                      # AWS Transform conversation logs
+```
+
+If the user explicitly asks to download, provide the command but let them run it:
+`aws s3 cp s3://atx-custom-output-{account-id}/transformations/{job-name}/{conversation-id}/code.zip ./code.zip`
+
+Bulk results summary: `~/.aws/atx/custom/atx-agent-session/transformation-summaries/` — see [workload-custom-results-synthesis.md](workload-custom-results-synthesis.md).
+
+## References
+
+| Reference | When to Use |
+|-----------|-------------|
+| [workload-custom-repo-analysis.md](workload-custom-repo-analysis.md) | Detection commands, signal matching, match report format |
+| [workload-custom-single-transformation.md](workload-custom-single-transformation.md) | Applying one transformation definition to one repo (local or remote) |
+| [workload-custom-multi-transformation.md](workload-custom-multi-transformation.md) | Applying transformation definitions to multiple repos in parallel |
+| [workload-custom-remote-execution.md](workload-custom-remote-execution.md) | Infrastructure deployment, job submission, monitoring |
+| [workload-custom-results-synthesis.md](workload-custom-results-synthesis.md) | Generating consolidated reports after bulk transforms |
+| [workload-custom-cli-reference.md](workload-custom-cli-reference.md) | AWS Transform CLI flags, commands, env vars, IAM permissions |
+| [workload-custom-td-creation.md](workload-custom-td-creation.md) | In-chat interactive transformation definition creation |
+| [workload-custom-troubleshooting.md](workload-custom-troubleshooting.md) | Error resolution, debugging, quality improvement |
+
+## License
+
+AWS Service Terms. This power is provided by AWS and is subject to the AWS Customer Agreement and applicable AWS service terms.
+
+## Issues
+
+https://github.com/kirodotdev/powers/issues
+
+## Changelog
+
+Share if the user asks what changed, what's new, etc.
+
+### [1.0.0] - 2026-04-14
+
+- Initial release of the AWS Transform Kiro Power
+- Supported transformation definitions:
+  - AWS/java-version-upgrade
+  - AWS/python-version-upgrade
+  - AWS/nodejs-version-upgrade
+  - AWS/java-aws-sdk-v1-to-v2
+  - AWS/nodejs-aws-sdk-v2-to-v3
+  - AWS/python-boto2-to-boto3
+  - AWS/comprehensive-codebase-analysis
+  - AWS/java-performance-optimization
+  - AWS/angular-version-upgrade
+  - AWS/vue.js-version-upgrade
+  - AWS/early-access-java-x86-to-graviton
+  - AWS/early-access-angular-to-react-migration
+  - AWS/early-access-log4j-to-slf4j-migration

--- a/aws-transform/steering/workload-dotnet.md
+++ b/aws-transform/steering/workload-dotnet.md
@@ -1,0 +1,716 @@
+# .NET Modernization
+
+> Last Updated: 2026-05-13
+
+## Capabilities
+
+Modernize .NET applications to .NET 8, .NET 9, or .NET 10. Supports projects targeting .NET Framework (v2.0–v4.8), .NET Core (1.x–3.x), or .NET 5–7.
+
+| Source | Target |
+|--------|--------|
+| .NET Framework 2.0–4.8 | .NET 8 or .NET 10 |
+| .NET Core 1.x–3.x | .NET 8 or .NET 10 |
+| .NET 5–7 | .NET 8 or .NET 10 |
+| VB.NET (.vbproj) | VB.NET on .NET 8 or .NET 10 |
+| WPF (.NET Framework) | WPF on .NET 8 or .NET 10 |
+| Xamarin | .NET MAUI |
+| ASP.NET MVC 5 | ASP.NET Core |
+| WCF Services | gRPC or REST APIs |
+| Web Forms | Blazor or Razor Pages |
+| Entity Framework 6 | EF Core |
+| Web.config | appsettings.json |
+| IIS deployment | ECS Fargate / App Runner |
+| packages.config | PackageReference (SDK-style .csproj) |
+
+## Agents & Transforms
+
+| User-Facing Name | orchestratorAgent | Purpose |
+|------------------|-------------------|---------|
+| .NET Modernization Agent | `dotnet-chatty-agent` | .NET code assessment + transformation (primary) |
+
+The .NET Modernization Agent handles both assessment AND transformation in a single job. There is no separate assessment agent.
+
+In user-facing messages, refer to this as ".NET modernization agent". Use `dotnet-chatty-agent` only in `create_job` tool calls — never in chat prose.
+
+## Decision Points
+
+All user-facing questions. Ask in this order: version → mode → source code → per-project toggles.
+
+### Target Version
+
+| Target | TFM | Support | Notes |
+|--------|-----|---------|-------|
+| .NET 8 | `net8.0` | LTS (Nov 2023 – Nov 2026) | Stable, widely adopted |
+| .NET 9 | `net9.0` | STS (Nov 2024 – May 2026) | Latest features, shorter support window |
+| .NET 10 | `net10.0` | LTS (Nov 2025 – Nov 2028) | Latest LTS, newest APIs and performance |
+
+MUST present all versions as explicit options. Mark .NET 10 as "(Recommended)". Default to .NET 10 if user has no preference.
+
+```python
+AskUserQuestion(questions=[{
+    "question": "Which .NET version do you want to target?",
+    "header": "Target Framework",
+    "multiSelect": False,
+    "options": [
+        {"label": ".NET 10 (Recommended)", "description": "LTS until Nov 2028. Latest APIs and performance improvements."},
+        {"label": ".NET 9", "description": "STS until May 2026. Latest features, shorter support window."},
+        {"label": ".NET 8", "description": "LTS until Nov 2026. Stable, widely adopted."}
+    ]
+}])
+```
+
+Value mapping:
+- ".NET 10 (Recommended)" → `target_framework = "net10.0"`
+- ".NET 9" → `target_framework = "net9.0"`
+- ".NET 8" → `target_framework = "net8.0"`
+
+### Transformation Mode
+
+Exactly TWO modes exist. No other modes exist.
+
+| Mode | Value | Behavior | Best For |
+|------|-------|----------|----------|
+| Auto | `auto` | Runs to completion without pausing. Failures logged and skipped. Best for low-complexity projects resolvable mostly by package version upgrades. | Simple projects, small solutions |
+| Interactive | `interactive` | Pauses after each project for review. Plan approval required. Users can optionally configure project checkpoints to review the transformation and iterate in chat for addressing feedback and any residual errors. | Medium and complex applications |
+
+```python
+AskUserQuestion(questions=[{
+    "question": "How should the transformation run?",
+    "header": "Transformation Mode",
+    "multiSelect": False,
+    "options": [
+        {"label": "Auto (Recommended for simple projects)", "description": "Runs to completion without pausing. Transformations are applied to your code during status checks. Failures logged and skipped."},
+        {"label": "Interactive", "description": "Pauses after each project for your review. Approved changes are applied to your code. You can inspect diffs, request changes, or skip projects."}
+    ]
+}])
+```
+
+Value mapping:
+- "Auto (Recommended for simple projects)" → `interactive_mode = "auto"`
+- "Interactive" → `interactive_mode = "interactive"`
+
+Default to `auto` if user has no preference.
+
+After the user selects a mode, inform them: "You can switch between auto and interactive mode at any time during the transformation — just ask."
+
+### Source Code Upload
+
+```python
+AskUserQuestion(questions=[{
+    "question": "How would you like to share your source code?",
+    "header": "Source Code Upload",
+    "multiSelect": False,
+    "options": [
+        {"label": "Upload from workspace", "description": "I'll zip and upload the solution from my current workspace"},
+        {"label": "Specify a path", "description": "Let me provide the path to the solution"}
+    ]
+}])
+```
+
+MUST ask before uploading. MUST NOT auto-upload.
+
+### Confirm & Launch
+
+After collecting target version and mode, present a summary of the user's selections and ask for confirmation before creating the job. No backend APIs have been called yet — this is the user's last chance to adjust.
+
+```python
+AskUserQuestion(questions=[{
+    "question": "Ready to launch?",
+    "header": "Confirm & Launch",
+    "multiSelect": False,
+    "options": [
+        {"label": "Go ahead", "description": "Start the migration"},
+        {"label": "Wait, let me adjust", "description": "Change something first"}
+    ]
+}])
+```
+
+The plan presented above the question MUST include these steps:
+
+1. Create a new workspace (or reuse existing)
+2. Create a job with the .NET modernization agent (target: `<version>`, mode: `<mode>`)
+3. Upload your source code
+4. Agent assesses your solution, produces an assessment report, and generates a migration plan before starting the transformation
+5. Once transformation completes, you receive the migrated source code and a summary of changes
+
+If user selects "Wait, let me adjust" — return to the relevant decision point (version or mode) and re-collect the choice. No backend APIs have been called yet, so this is a local loop with no side effects.
+
+### Per-Project Review Toggles (Interactive Mode Only)
+
+Presented after plan approval. Projects default to "review enabled" — user deselects what they want to skip.
+
+```python
+AskUserQuestion(questions=[{
+    "question": "Which projects should pause for your review after transformation? (All selected by default — deselect any you want to skip.)",
+    "header": "Per-Project Review Checkpoints",
+    "multiSelect": True,
+    "options": [
+        # One per project from the plan — use stepName as label, add complexity from assessment
+        {"label": "<ProjectName>", "description": "<complexity> — <brief description>"}
+    ]
+}])
+```
+
+---
+
+## Status Check
+
+When the user asks for status, progress, or "what's happening" — use this procedure regardless of which workflow step is active:
+
+1. `get_resource(resource="job", workspaceId=..., jobId=...)` → get job status + `_pollingGuidance` + `recentWorklogs`
+2. `list_resources(resource="tasks", workspaceId=..., jobId=...)` → any pending HITL tasks?
+3. Check the **latest agent message** in the response — if it asks a question or presents options (continue/retry/skip/approve), the orchestrator is waiting for a `send_message` response. Present those options to the user.
+
+**Present the full picture:**
+- Current phase and status
+- What the agent last did (from worklogs)
+- Any pending actions needed from user (HITL tasks OR agent message asking a question)
+- What's coming next
+
+**Rules:**
+- **AUTO mode:** Call `list_resources(resource="artifacts", pathPrefix="...Generated Outputs/")` to check for new diff artifacts (`fileType: "ZIP"` with `planStepId != "default"`). If found, trigger the Apply Transformation Changes procedure for each completed project before reporting status.
+- If `_pollingGuidance.hasPendingTasks=true` → check tasks, present to user
+- If `_pollingGuidance.isTerminal=true` → job done, present final summary
+- If latest agent message asks a question → present it to user, orchestrator is waiting
+- If no pending tasks AND no questions AND job is EXECUTING → inform user the agent is working, no action needed
+
+---
+
+## Workflow (11 Steps)
+
+The full lifecycle of a .NET modernization job.
+
+### Step 1: Verify Authentication
+
+```python
+get_status()
+```
+
+If not authenticated, guide user through `configure()`. Do not proceed until auth is confirmed.
+
+### Step 2: Create or Reuse Workspace
+
+```python
+create_workspace(name="dotnet-modernization", description="Modernize .NET Framework solution to <target>")
+```
+
+Save `workspaceId`. If user has a workspace from a previous session (check `.atx/context.json`), offer to reuse it instead of creating a new one. Users can create multiple jobs within the same workspace.
+
+### Step 3: Collect User Choices
+
+MUST ask version FIRST, mode SECOND. MUST store exact values before calling `create_job`.
+
+1. Ask target version → store `target_framework` ("net10.0", "net9.0", or "net8.0")
+2. Ask transformation mode → store `interactive_mode` ("auto" or "interactive")
+
+See Decision Points section for the exact AskUserQuestion formats and value mappings.
+
+### Step 4: Create and Start Job
+
+Build `objective` as a JSON string from Step 3 values:
+
+```python
+# Examples:
+objective_json = '{"target_framework": "net8.0", "interactive_mode": "interactive"}'
+objective_json = '{"target_framework": "net10.0", "interactive_mode": "auto"}'
+```
+
+Call `create_job`:
+
+```python
+create_job(
+  workspaceId="<workspace-id>",
+  jobName=".NET Assessment & Modernization",
+  objective=objective_json,   # MUST be valid JSON, not prose
+  intent="LANGUAGE_UPGRADE",
+  orchestratorAgent="dotnet-chatty-agent"
+)
+```
+
+Save `jobId`. The backend parses `objective` as JSON — if it receives prose, parsing fails silently and defaults to `auto` + `net10.0`.
+
+Immediately after:
+
+```python
+load_instructions(workspaceId="<workspace-id>", jobId="<job-id>")
+
+send_message(
+  workspaceId="<workspace-id>",
+  jobId="<job-id>",
+  text="Target: <target> (<tfm>). Mode: <mode>. Source code will be uploaded shortly."
+)
+```
+
+`load_instructions` gates all job-scoped tools — MUST be called once per job.
+
+### Step 5: Upload Source Code
+
+Ask user first (see Decision Points: Source Code Upload). Then:
+
+```python
+# Zip (exclude .git, bin, obj, packages)
+upload_artifact(
+  workspaceId="<workspace-id>", jobId="<job-id>",
+  content="/tmp/source.zip", fileType="ZIP",
+  categoryType="CUSTOMER_INPUT", fileName="source.zip"
+)
+
+# Notify agent
+send_message(workspaceId="<workspace-id>", jobId="<job-id>",
+  text="Source code uploaded (artifact ID: <id>). Please proceed with assessment.")
+```
+
+Save the user's source path to `.atx/context.json` as `source_root`. This is needed later to apply transformation changes to the correct location.
+
+### Step 6: Monitor Assessment
+
+The agent assesses the solution automatically. On user check-in:
+
+```python
+get_resource(resource="job", workspaceId="<workspace-id>", jobId="<job-id>")
+```
+
+Report status, any available artifacts (Assessment_Report.md, Modernization_Plan.md), and pending tasks.
+
+Use `_pollingGuidance` from the response:
+- `hasPendingTasks=true` → check for BLOCKING tasks
+- `isTerminal=true` → job done
+
+If `list_resources(resource="tasks")` returns a task with tag `missing-packages`, follow the Handle Missing Packages procedure. Transformation will not proceed until resolved.
+
+### Step 7: Plan Approval
+
+**AUTO mode:** Skipped. Agent proceeds directly to transformation.
+
+**INTERACTIVE mode:**
+
+The backend orchestrator WAITS for user approval before starting transformation. It will NOT proceed on its own. You MUST detect the plan and get user approval.
+
+**How to detect "plan ready":** Job status is `PLANNING` AND `Modernization_Plan.md` artifact exists. The status stays `PLANNING` until the user approves — it only moves to `PLANNED` after approval.
+
+**Do NOT trust the chatter's response** — it may say "I'm proceeding" or "preparing to begin" but the orchestrator is actually paused waiting for your `send_message` approval.
+
+Flow:
+1. Detect plan is ready (artifact or worklog signal)
+2. Present plan summary to user (from the agent's messages or assessment data)
+3. Ask user to approve
+4. Send approval:
+
+```python
+send_message(workspaceId="<workspace-id>", jobId="<job-id>",
+  text="User approves the migration plan. Please proceed with transformation.")
+```
+
+Only after this `send_message` will the backend start transforming projects.
+
+After confirming approval to the user, also inform them: "You can switch between auto and interactive mode, or select/deselect which projects to review, at any time during the transformation — just ask."
+
+**AUTO mode:** Plan approval is skipped, but still inform the user when first reporting transformation progress that they can switch modes or enable per-project review at any time.
+
+### Step 8: Checkpoint Config (Interactive Mode Only)
+
+Skip this step entirely in AUTO mode.
+
+After plan approval, extract project step_ids from the plan and present per-project toggles:
+
+**8a. Get plan and find project steps:**
+
+```python
+get_resource(resource="plan", workspaceId="<id>", jobId="<id>")
+# Find steps where parentStepId matches "Transform Projects" step
+# These are per-project steps with stepId and stepName
+```
+
+**8b. Find checkpoint config task ID:**
+
+```python
+list_resources(resource="tasks", workspaceId="<id>", jobId="<id>")
+# Find task where tag ends with "-checkpoint"
+```
+
+**8c. Present per-project toggles to user** (see Decision Points: Per-Project Review Toggles)
+
+**8d. Submit user's choices:**
+
+```python
+complete_task(
+  workspaceId="<workspace-id>", jobId="<job-id>",
+  taskId="<checkpoint-task-id>",
+  content='{"interactive_mode": "interactive", "<step_id_1>": true, "<step_id_2>": false, ...}',
+  action="SAVE_DRAFT"
+)
+```
+
+Use `SAVE_DRAFT` (not `APPROVE`) for checkpoint config — this keeps the task open so it can be updated again later. The backend reads the humanArtifact regardless of task status.
+
+Rules:
+- Step IDs come from plan (`steps[].stepId` where parent is "Transform Projects")
+- `true` = pause for review; `false` = skip review
+- MUST include ALL project step_ids — omitted ones default to `false`
+- MUST include `interactive_mode` in every submission
+- The HITL does not close — can be updated anytime
+
+**8e. Save to `.atx/checkpoint-config.json`:**
+
+```json
+{
+  "checkpointTaskId": "<task-id>",
+  "mode": "interactive",
+  "projects": {
+    "<step_id>": {"label": "<ProjectName>", "review": true|false}
+  },
+  "lastUpdated": "<ISO timestamp>"
+}
+```
+
+On conversation resume, check this file first — reuse stored mapping instead of re-asking.
+
+**Mid-run updates:** When user asks to switch mode or change toggles:
+1. Read `.atx/checkpoint-config.json`
+2. Update values per user's request
+3. Save updated file
+4. Call `complete_task` with values from saved file, using `action="SAVE_DRAFT"`
+
+A `send_message` alone does NOT change the mode — only `complete_task` (with `SAVE_DRAFT`) on the checkpoint HITL changes backend behavior.
+
+### Step 9: Monitor Transformation
+
+The agent transforms each project in dependency order (convert → upgrade packages → fix errors → checkpoint).
+
+Status progression: `PLANNING` → `PLANNED` → `EXECUTING` → `COMPLETED`
+
+Terminal states: `STOPPED`, `FAILED`
+
+**INTERACTIVE mode — when Project Review HITL appears:**
+
+1. Inform user which project completed + summary
+2. Present options:
+
+```python
+AskUserQuestion(questions=[{
+    "question": "<ProjectName> transformation complete. What would you like to do?",
+    "header": "Project Review",
+    "multiSelect": False,
+    "options": [
+        {"label": "Approve", "description": "Apply transformation to <ProjectName> and continue to the next project."},
+        {"label": "Download the diff", "description": "Inspect the exact file changes before deciding."},
+        {"label": "Reject", "description": "Skip this project's transformation. Local code is not modified."}
+    ]
+}])
+```
+
+3. If user approves, state which project you are approving before calling `complete_task`
+4. Submit decision:
+
+```python
+complete_task(workspaceId="<id>", jobId="<id>", taskId="<review-task-id>",
+  content='{}', action="APPROVE")
+```
+
+5. Immediately send follow-up:
+
+```python
+send_message(workspaceId="<id>", jobId="<id>",
+  text="Review approved for <project>. Please continue with transformation.")
+```
+
+6. Apply transformation changes (see Apply Transformation Changes section).
+
+**AUTO mode:** No review tasks appear. Transformation changes are applied when the user checks status (see Status Check and Apply Transformation Changes sections).
+
+### Step 10: Local Build Verification (Auto-Skip)
+
+After all projects transform, a build verification HITL appears (BLOCKING, tag: `local-build-verification`). This applies to both auto and interactive modes.
+
+Auto-complete this HITL immediately with a skip response. The user does not need to approve — the Power handles it silently. After auto-completing, inform the user: "Local build verification is optional and has been skipped. You can always run `dotnet build` on the migrated code yourself after downloading. If you encounter build errors, you can ask me to help fix them."
+
+```python
+complete_task(workspaceId="<id>", jobId="<id>", taskId="<build-task-id>",
+  content='{"status": "SUCCESS", "errorCount": 0, "errors": [], "rawOutput": "Build verification skipped."}',
+  action="APPROVE")
+
+send_message(workspaceId="<id>", jobId="<id>",
+  text="Build verification skipped. Please proceed with next steps.")
+```
+
+**Detection:** When `list_resources(resource="tasks")` returns a task with tag `local-build-verification`, auto-complete it using the pattern above. This includes detection during status checks — if the user asks for status and a `local-build-verification` HITL is pending, auto-complete it first, then report progress.
+
+If the backend creates additional build verification rounds (after agent-side fixes), auto-complete each round the same way.
+
+### Step 11: Final Summary & Download
+
+After build verification, the agent generates final artifacts (report, next steps, migrated source ZIP) and sends a message asking whether to mark the job as complete. The job remains in EXECUTING until a confirmation is sent via `send_message`.
+
+When the agent's message indicates transformation is complete and artifacts are ready:
+
+1. List output artifacts: `list_resources(resource="artifacts")`
+2. Present a summary to the user:
+   - Projects transformed (count, names, status)
+   - Per-project diff ZIPs — list each with project name and artifact ID. These contain `metadata.json`, `diffs/*.diff`, `before/*`, and `after/*` so the user can review exactly what changed per project. Identify them by `fileType: "ZIP"` with `planStepId != "default"` — match `planStepId` to plan steps to get the project name.
+   - Transformation report available (`Transformation_Report.html` — detailed HTML report)
+   - Next steps available (`NextSteps.md` — recommended post-migration actions)
+   - Final migrated source available (`*_Transformed_*.zip` — complete migrated solution)
+3. Ask the user:
+
+```python
+AskUserQuestion(questions=[{
+    "question": "The transformation is complete and all artifacts are ready. Would you like to finalize, or make adjustments?",
+    "header": "Complete Job",
+    "multiSelect": False,
+    "options": [
+        {"label": "Complete the job", "description": "Mark the job as done and download artifacts"},
+        {"label": "Make adjustments", "description": "Request additional changes before completing"}
+    ]
+}])
+```
+
+4. Based on user's choice:
+
+```python
+# User confirms completion:
+send_message(workspaceId="<id>", jobId="<id>",
+  text="Looks good, mark the job as complete.")
+
+# User wants adjustments — relay their request:
+send_message(workspaceId="<id>", jobId="<id>",
+  text="<user's adjustment request>")
+# Agent will handle the request, then ask again — repeat this step.
+```
+
+5. Once job reaches `COMPLETED`, download any artifacts the user requests:
+
+```python
+get_resource(resource="artifact", workspaceId="<id>", jobId="<id>",
+  artifactId="<id>", savePath=".atx/<filename>")
+```
+
+6. Update `.atx/context.json` with `phase: "complete"`
+
+---
+
+## Mode Behavior Reference
+
+| Phase | AUTO | INTERACTIVE |
+|-------|------|-------------|
+| Plan approval | Skipped | Required (via send_message) |
+| Checkpoint config | Ignore | Present per-project toggles (Step 8) — optional |
+| Per-project review | No HITLs created | HITL per toggled-on project — optional |
+| Apply transformation changes | On status check, for each completed project | After user approves project review |
+| On project failure | Log + skip + continue | Present to user, wait for decision |
+| Build verification | Auto-skip (Step 10) | Auto-skip (Step 10) |
+| Missing Packages | Present to user (BLOCKING) | Present to user (BLOCKING) |
+| Final diffs | All at end | Per-project during + all at end |
+
+## HITL Reference
+
+| HITL Type | Component ID | Tag | Blocking | Behavior |
+|-----------|-------------|-----|----------|----------|
+| Checkpoint Config | `FileUploadV2` | `*-checkpoint` | NON_BLOCKING | AUTO: ignore. INTERACTIVE: Step 8. |
+| Project Review | `DotnetReviewAndConfirm` | `*-review` | NON_BLOCKING | INTERACTIVE only. Present diffs, wait for decision. |
+| Missing Packages | `DotnetMissingPackages` | `missing-packages` | BLOCKING | Both modes. Always present to user. Severity: CRITICAL. |
+| Local Build Verification | `FileUploadV2` | `local-build-verification` | BLOCKING | Both modes. Auto-skip with dummy SUCCESS (Step 10). |
+
+Processing pattern for any HITL:
+1. `list_resources(resource="tasks")` → discover pending tasks
+2. `get_resource(resource="task", taskId=...)` → get full details (read `_outputSchema`, `_responseHint`)
+3. Present to user via AskUserQuestion
+4. Show payload before submitting
+5. `complete_task(content=..., action="APPROVE")` → submit
+
+There is NO Assessment Review HITL. Plan approval uses `send_message`.
+
+## Artifacts Reference
+
+| Type | Category | Contains |
+|------|----------|----------|
+| Source code ZIP | `CUSTOMER_INPUT` | User's original .NET solution |
+| Assessment report (`Assessment_Report.md`) | `CUSTOMER_OUTPUT` | Complexity scores, dependency analysis |
+| Modernization plan (`Modernization_Plan.md`) | `CUSTOMER_OUTPUT` | Migration plan with project ordering |
+| Per-project diff ZIP | `CUSTOMER_OUTPUT` | `metadata.json` + `diffs/*.diff` + `before/*` + `after/*` |
+| Final migrated source ZIP (`*_Transformed_*.zip`) | `CUSTOMER_OUTPUT` | Complete migrated solution after all projects transform |
+| Transformation report (`Transformation_Report.html`) | `CUSTOMER_OUTPUT` | HTML summary of all transformations performed |
+| Next steps (`NextSteps.md`) | `CUSTOMER_OUTPUT` | Recommended post-migration actions |
+
+Per-project diff ZIPs are identified by `fileType: "ZIP"` with `planStepId != "default"`. Match `planStepId` to plan steps to determine the project name.
+
+The final migrated source ZIP, Transformation_Report.html, and NextSteps.md appear after build verification completes (job near completion).
+
+Upload rules:
+- Use `categoryType: "CUSTOMER_INPUT"` for source code
+- Exclude `.git/`, `bin/`, `obj/`, `packages/` from ZIP
+- Notify agent via `send_message` after upload with artifact ID
+
+When multiple artifacts of the same type exist (e.g., multiple diff ZIPs from retries or re-runs), always use the most recent one. Sort by creation timestamp and pick the latest.
+
+## Apply Transformation Changes
+
+Apply transformed code from per-project diff artifacts to the user's local filesystem. Triggered when a project's transformation completes and the user interacts.
+
+**Trigger conditions:**
+- **AUTO mode:** When the user checks status and projects have completed transformation, trigger the Apply Transformation Changes procedure for each completed project
+- **INTERACTIVE mode:** After the user approves the project review HITL
+- MUST NOT apply if the user rejected the project in interactive mode
+
+**First-time consent (both modes):** Before applying changes for the first time, inform the user:
+
+"I'll apply the transformed code to your local codebase as each project completes. Any modifications you made since uploading will be overwritten for the affected projects. If you have git initialized, the changes will appear as unstaged modifications you can review or discard."
+
+In AUTO mode, ask for confirmation before proceeding. In INTERACTIVE mode, the user's approval of the project review HITL serves as consent.
+
+### Procedure
+
+**1. Find the latest diff artifact for the project:**
+
+```python
+# First call returns folder paths
+list_resources(resource="artifacts", workspaceId="<id>", jobId="<id>")
+# Response contains folders[] — use the "Generated Outputs/" path as pathPrefix
+
+# Second call with pathPrefix returns actual artifacts
+list_resources(resource="artifacts", workspaceId="<id>", jobId="<id>",
+  pathPrefix="AWSTransform/Workspaces/<workspaceId>/Jobs/<jobId>/Generated Outputs/")
+# Per-project diff artifacts are identified by:
+#   - fileType == "ZIP"
+#   - planStepId != "default"
+# Match artifact.planStepId to plan step.stepId to determine which project it belongs to.
+# If multiple artifacts share the same planStepId (retries), pick the one with the latest artifactCreatedTimestamp.
+```
+
+**2. Download the diff ZIP:**
+
+```python
+get_resource(resource="artifact", workspaceId="<id>", jobId="<id>",
+  artifactId="<latest-diff-artifact-id>",
+  savePath=".atx/diffs/<jobId>/checkpoint-diff-<project-name>.zip")
+```
+
+**3. Extract the ZIP and read `metadata.json`:**
+
+```json
+{
+  "filesAdded": ["path/to/NewFile.cs"],
+  "filesUpdated": ["path/to/Modified.csproj"],
+  "filesRemoved": ["path/to/Deleted.cs"]
+}
+```
+
+**4. Write files to the user's local codebase:**
+
+The `source_root` is the path the user provided during Source Code Upload (Step 5), stored in `.atx/context.json`.
+
+| Action | Source | Destination |
+|--------|--------|-------------|
+| Update/Add | `after/{path}` from extracted ZIP | `{source_root}/{path}` |
+| Remove | — | Delete `{source_root}/{path}` |
+
+MUST use the agent's native file-write capability. Do NOT use `git apply`, `patch`, or any OS-specific command. This ensures cross-platform compatibility (Windows, macOS, Linux).
+
+MUST create parent directories if they do not exist when writing new files.
+
+**5. Confirm to user:**
+
+```
+✅ Applied transformation for <project-name>:
+   • <N> files updated
+   • <N> files added
+   • <N> files removed
+```
+
+### Rules
+
+- MUST apply project-by-project as each completes — do NOT wait until all projects finish
+- MUST use the latest diff artifact when multiple exist (highest `createdAt`)
+- MUST preserve file encoding from the `after/` content (write bytes as-is)
+- If a file in `filesUpdated` does not exist locally, treat it as an add
+- If a file in `filesRemoved` does not exist locally, skip silently
+- If download or extraction fails, inform the user and offer to retry
+
+## Handle Missing Packages
+
+When the agent detects private or unavailable NuGet packages during assessment, a BLOCKING HITL task appears. Transformation will not proceed until resolved.
+
+**Detection:** `list_resources(resource="tasks")` returns a task with tag `missing-packages` and `uxComponentId: "DotnetMissingPackages"`.
+
+**Procedure:**
+
+1. Get task details to see which packages are missing:
+
+   ```python
+   get_resource(resource="task", workspaceId="<id>", jobId="<id>", taskId="<task-id>")
+   ```
+
+2. Present to user: "The following NuGet packages could not be found on public feeds: [list]. Please provide the .nupkg files, or let me know if any can be removed."
+
+3. For each .nupkg file the user provides, upload it:
+
+   ```python
+   complete_task(workspaceId="<id>", jobId="<id>", taskId="<task-id>",
+     filePath="/path/to/Package.1.0.0.nupkg",
+     action="SAVE_DRAFT")
+   # Returns uploadedArtifactId — save this for the final submission
+   ```
+
+4. After all packages are uploaded, submit the final response with all artifact IDs:
+
+   ```python
+   complete_task(workspaceId="<id>", jobId="<id>", taskId="<task-id>",
+     content='{"uploadedArtifactIds": [{"artifactId": "<id1>", "name": "Package1.nupkg", "lastModified": 0, "size": 0}, {"artifactId": "<id2>", "name": "Package2.nupkg", "lastModified": 0, "size": 0}]}',
+     action="APPROVE")
+   ```
+
+5. If user wants to remove a package from the missing list instead of uploading:
+
+   ```python
+   complete_task(workspaceId="<id>", jobId="<id>", taskId="<task-id>",
+     content='{"removedPackages": [{"name": "PackageName", "version": "1.0.0"}]}',
+     action="APPROVE")
+   ```
+
+**Rules:**
+
+- MUST collect all `uploadedArtifactId` values from each `SAVE_DRAFT` call for the final `APPROVE` submission
+- User uploads are stored under `CUSTOMER_INPUT` category
+- If only one package is missing, a single `complete_task` with `filePath` + `action="APPROVE"` is sufficient
+- Transformation remains blocked until this HITL is resolved
+
+**Upload packages anytime (outside the HITL):**
+
+If the user wants to upload private packages at any point during the job (e.g., after the HITL closes, or when a build fails due to a missing package):
+
+```python
+upload_artifact(workspaceId="<id>", jobId="<id>",
+  content="/path/to/Package.nupkg", fileType="ZIP",
+  categoryType="CUSTOMER_INPUT", fileName="Package.1.0.0.nupkg")
+
+send_message(workspaceId="<id>", jobId="<id>",
+  text="I uploaded the private package Package.1.0.0.nupkg. Please add it to the local feed and retry.")
+```
+
+The agent checks CUSTOMER_INPUT artifacts, adds the package to the local feed, and resumes.
+
+## Error Recovery
+
+```
+Job not progressing?
+├─ Check tasks → pending HITL? → present to user
+├─ Check messages → agent asked something? → respond via send_message
+├─ Check job status → FAILED? → offer restart or new job
+├─ Send status query → agent responds? → continue
+└─ None of above → offer restart
+```
+
+Key actions:
+- **Job creation fails:** Retry. If repeated, check auth and workspace.
+- **Upload fails:** Check file size, verify ZIP, retry.
+- **Job stuck:** Send status query via `send_message`. Check for hidden HITL tasks.
+- **Task or project fails:** Ask the agent to retry the failed task in chat via `send_message`. The agent can re-attempt the transformation for that project.
+- **Restart:** `control_job(action="stop")` then `control_job(action="start")`. Previously uploaded artifacts remain available.
+- **Delete and start over:** `delete_job()` then new `create_job()`.
+
+## Known Limitations
+
+- COM interop references require manual replacement
+- P/Invoke (native Windows DLL calls) need manual porting
+- Web Forms → Blazor conversion is partial — complex controls may need redesign
+- Windows Services → need manual conversion to BackgroundService
+- GAC dependencies must be replaced with NuGet packages manually

--- a/aws-transform/steering/workload-mainframe.md
+++ b/aws-transform/steering/workload-mainframe.md
@@ -1,0 +1,126 @@
+# Mainframe Modernization
+
+> **Last Updated:** 2026-04-01
+
+AWS Transform for mainframe accelerates the modernization of legacy zOS mainframe applications (COBOL, JCL, CICS, VSAM, Db2, IMS) into cloud-native services on AWS. It orchestrates analysis, documentation, business logic extraction, decomposition, code transformation, and testing through an AI-driven workflow with human-in-the-loop checkpoints. The agent proposes a plan based on your stated objective, executes each step, and pauses for your input when decisions or approvals are needed.
+
+## Capabilities Overview
+
+| # | Capability | Description | Eligible Files | Requires |
+|---|-----------|-------------|----------------|----------|
+| 1 | Analyze code | Classifies files, counts LOC, maps dependencies, identifies missing files and duplicates | All | — |
+| 2 | Data analysis | Data lineage (program/JCL → dataset mapping) and data dictionary (field-level metadata for copybooks and Db2) | All | Code analysis |
+| 3 | Activity metrics analysis | Analyzes SMF records (type 30 batch, type 110 CICS) for job frequency, resource usage, unused code identification | SMF records | Recommend code analysis first |
+| 4 | Generate technical documentation | PDF/JSON docs per file — summary or detailed functional specification with logic, flows, dependencies | COBOL, JCL | Code analysis + dependency analysis |
+| 5 | Extract business logic | Extracts business rules, process flows, and logic — application-level (grouped by transactions/jobs) or file-level | COBOL, JCL | Code analysis + dependency + entry point analysis |
+| 6 | Decompose code | Breaks codebase into functional domains using seed programs, produces dependency graphs | All | Code analysis. Recommend BRE first |
+| 7 | Migration wave planning | Sequenced migration plan based on decomposed domains with recommended modernization order | Domains | Decomposition |
+| 8 | Refactor code | Transforms COBOL → cloud-optimized Java. Configurable target DB, encoding, engine version | COBOL | Code analysis. Recommend decomposition + wave planning first |
+| 9 | Reforge code | LLM-powered post-refactor improvement — replaces COBOL-style Java with idiomatic Java patterns | Refactored Java | Refactor. Quota: 3M LOC/job, 50M LOC/user/month |
+| 10 | Plan test cases | Creates test plans from code analysis and scheduler paths, prioritizes by complexity, maps business rules | JCL, schedulers | Code analysis. Benefits from BRE |
+| 11 | Generate test data collection scripts | Produces JCL scripts to collect before/after test data from mainframe (Db2 unloads, VSAM REPRO, sequential datasets) | Test plan | Test planning |
+| 12 | Test automation script generation | Generates scripts to execute test cases on the modernized Java application with data setup and result comparison | Test plan | Test planning + test data collection |
+
+## Starting Workflow
+
+1. **Inventory** — Scan for COBOL (.cbl, .cob), JCL (.jcl), copybooks (.cpy), and VSAM definitions
+2. **Scope decision** — Ask user: full rewrite, partial modernization, or re-platform?
+3. **Complete analysis on AWS Transform** — Based on what the customer wants to do, run relevant agents in AWS Transform. Note: the agent always starts with a "Kick off modernization" step that requires connector setup and source code location before any analysis begins.
+4. **Build modernized applications with Kiro** — Based on scope, draft Kiro modernization requirements based on outputs from agents
+
+**Key question to ask user:** "Can you tell me what you are looking to accomplish today on your mainframe modernization project? Is this a full re-architecture to microservices, or a lift-and-shift to run COBOL on AWS?"
+
+## Agents & Transforms
+
+| Agent | How to Discover | Purpose |
+|-------|----------------|---------|
+| Mainframe agent | `list_resources` with `resource: "agents"` | End-to-end COBOL → Java/C# modernization |
+| AWS/comprehensive-codebase-analysis | CLI: `atx custom def exec` | Static analysis of COBOL programs |
+
+**Discover the agent dynamically** — do not hardcode the agent name:
+
+```python
+# First, discover available agents
+list_resources(resource="agents")
+# Or ask the chat agent
+send_message(workspaceId="...", text="What agents are available for mainframe modernization?")
+# Then create job — two approaches work:
+# Option A: using jobType enum (e.g. MAINFRAME_V2)
+create_job(workspaceId="...", jobName="...", jobType="MAINFRAME_V2", objective="...", intent="...")
+# Option B: using orchestratorAgent name
+create_job(workspaceId="...", jobName="...", orchestratorAgent="<discovered>", objective="...", intent="...")
+```
+
+## Supported File Types
+
+zOS: COBOL + copybooks, JCL + PROC, CSD, BMS, Db2, VSAM, IMS TM, PL/I (BRE and docs only — not refactoring).
+Fujitsu GS21: PSAM, ADL, NDB.
+
+## Assessment Signals (for local discovery)
+
+These patterns help identify mainframe assets during local workspace scanning, before the AWS Transform agent runs its own analysis:
+
+| File Pattern | What to Look For | Indicates |
+|-------------|-----------------|-----------|
+| `*.cbl`, `*.cob` | COBOL source | Mainframe COBOL programs |
+| `*.jcl` | JCL job cards, DD statements | Batch processing |
+| `*.cpy` | COBOL copybooks | Shared data structures |
+| `*.bms` | BMS maps | CICS screen definitions |
+| `EXEC CICS` in source | CICS API calls | Online transaction processing |
+| `EXEC SQL` in source | Embedded SQL | Database access (DB2/IMS) |
+
+## Example Requirements
+
+```
+## Requirement 1: COBOL to Java Conversion
+**User Story:** As a developer, I want COBOL batch programs converted to Java services
+so that we can run them on AWS without mainframe infrastructure.
+**Acceptance Criteria:**
+1. WHEN conversion is applied, ALL COBOL PERFORM logic SHALL be equivalent Java methods
+2. WHEN conversion is applied, VSAM file I/O SHALL be replaced with database calls
+3. WHEN the Java service runs, output SHALL match COBOL program output for test cases
+**Handled by:** AWS Transform Mainframe Agent
+```
+
+## Example Tasks
+
+```
+- [ ] 1. Inventory and dependency analysis
+  - [ ] 1.1 Scan COBOL sources and JCL
+  - [ ] 1.2 Map CALL chains and COPY dependencies
+- [ ] 2. Convert COBOL programs to Java (AWS Transform)
+  - [ ] 2.1 Start mainframe modernization job
+  - [ ] 2.2 Handle Collaborator Requests (data mapping decisions)
+  - [ ] 2.3 Review diffs — user approves converted code
+- [ ] 3. Migrate data stores
+  - [ ] 3.1 Convert VSAM to Aurora PostgreSQL schema
+  - [ ] 3.2 Migrate data
+- [ ] 4. Validation
+  - [ ] 4.1 Run test cases comparing COBOL vs Java output
+```
+
+## Known API Behaviors
+
+These are things that work differently through the MCP API vs the AWS Transform webapp.
+
+### Source Code Upload
+
+The agent requires source code as a **single .zip file** in S3. When the "Specify resource location" task appears, `assetLocation` must point to a `.zip` file.
+
+### Business Logic Extraction (BRE) Configuration
+
+When the "Configure settings" task appears for BRE (`MainframeBreInputComponent`), you MUST always populate the `userSelectedFiles` array — regardless of `reportScope`.
+
+- `applicationLevel` — produces a single application-wide business rules summary
+- `fileLevel` — produces per-file business rules reports
+
+Both scopes require the file list. The webapp auto-selects all files for `applicationLevel`, but the API does not — you must explicitly list them.
+
+## Known Limitations
+
+- Assembler programs (ASM) are not handled by AWS Transform agents — Kiro can analyze but not convert
+- PL/I is supported for BRE and documentation only — not for refactoring
+- CICS BMS screen conversion may need manual UI design decisions
+- Complex SORT/MERGE JCL steps may need manual review
+- Performance tuning of converted Java code is not automated
+- Reforge quota: 3M lines of code per job, 50M lines of code per user per month

--- a/aws-transform/steering/workload-sql.md
+++ b/aws-transform/steering/workload-sql.md
@@ -1,0 +1,788 @@
+# SQL Database Migration — IDE Steering File
+
+> **Last Updated:** 2026-04-13
+
+## Capabilities
+
+This domain handles **SQL database migration via the IDE** using the AWS Transform MCP server. It supports two workflows:
+
+1. **From-Scratch Workflow** — Start a new AWS Transform conversion job entirely from the IDE: authenticate, create a workspace/job, upload source SQL, monitor the conversion, review assessment results, and retrieve converted artifacts.
+2. **Handoff Workflow** — Pick up where an AWS Transform conversion job left off: download converted artifacts and the validation report, then interactively fix all critical and high-severity issues the AWS Transform agent could not fully resolve.
+
+Both workflows converge at the fix-application phase once converted artifacts and a validation report are available.
+
+```
+From-Scratch Workflow                    Handoff Workflow
+┌──────────────────────────┐            ┌──────────────────────────┐
+│ 1. Authenticate          │            │ 1. Collect job IDs       │
+│ 2. Create workspace/job  │            │ 2. Download artifacts    │
+│ 3. Upload source SQL     │            └───────────┬──────────────┘
+│ 4. Monitor conversion    │                        │
+│ 5. Read assessment       │                        │
+│ 6. Trigger schema conv.  │                        │
+│ 7. Retrieve artifacts    │                        │
+└───────────┬──────────────┘                        │
+            │         ┌─────────────────────────────┘
+            ▼         ▼
+┌──────────────────────────────────────────────────┐
+│ Common: Parse report → Fix critical/high issues  │
+│         → Validate → Upload → Deploy             │
+└──────────────────────────────────────────────────┘
+```
+
+## ⚠️ Agent Behavior Rules (READ FIRST)
+
+These rules are MANDATORY. Violating any of them is a failure.
+
+> **Cross-platform note.** Commands below are given in two variants where they differ: **macOS/Linux/Git Bash** (POSIX shell: `cp`, `sed`, `perl`, etc.) and **Windows (PowerShell)**. Detect the OS and pick one variant — do not mix. In all PowerShell examples, paths are written with forward slashes (`/`) for readability; PowerShell accepts `/` and `\` interchangeably, so real Windows paths like `C:\Users\alice\work` can be used verbatim without re-quoting.
+
+1. **Three-file workflow.** Keep the original source MSSQL file, the converted PG file (untouched), and a working copy of the converted PG file. ALL edits go to the working copy. NEVER modify the original source or the converted PG file.
+2. **Navigate before AND after every fix. Skipping navigation is a rule violation.**
+   - Detect the IDE from the environment: Kiro → `kiro --goto`, VS Code → `code --goto`, DBeaver → manual navigation.
+   - **Before showing a fix**, open the file at the exact line that will change:
+
+     ```
+     code --goto <working_copy>:<line_number>
+     ```
+
+   - **After applying a fix**, navigate back to the changed line so the user sees the result:
+
+     ```
+     code --goto <working_copy>:<line_number>
+     ```
+
+3. **For every fix, follow this exact sequence:**
+   a. **Navigate** to the line (rule 2 above). Do NOT skip this.
+   b. **Validate the proposed fix** — Before showing the fix to the user, execute a syntax check (e.g., `EXPLAIN` or parse-only) on the proposed SQL block. If invalid, revise and re-validate. Do NOT propose an invalid fix.
+   c. **Show in chat:** object name, line number, problem (from report), proposed before/after fix, and syntax validation result (✅ Passed).
+   d. **Ask** `Approve this fix? [Yes / No / Modify]` and **STOP**. Do NOT proceed until the user responds.
+   e. **After user approves**, apply the fix using `execute_bash` (NOT `fs_write`). Use `sed -i ''` or `perl -i -pe 's/old/new/g'` on macOS/Linux (Perl works cross-platform when available). On Windows without Git Bash, use PowerShell's literal-string `.Replace()` method (NOT `-replace`, which is a regex operator and will silently mis-match SQL tokens containing regex metacharacters like `[ ] . ( ) $ ^`). Write with `[System.IO.File]::WriteAllLines` and an explicit no-BOM UTF-8 encoding — `Set-Content -Encoding UTF8` on Windows PowerShell 5.1 prepends a UTF-8 BOM (`0xEF 0xBB 0xBF`) that Rule 10's ASCII verification step will flag. Wrap the `-Command` argument in **single quotes** so bash/Git Bash does not expand `$c` / `$false` before PowerShell parses them, and prepend `$ErrorActionPreference='Stop'` so intermediate failures surface instead of silently producing an empty working copy:
+
+   ```
+   powershell -Command '$ErrorActionPreference="Stop"; $c = (Get-Content "<working_copy>" -Encoding UTF8).Replace("old","new"); [System.IO.File]::WriteAllLines("<working_copy>", $c, [System.Text.UTF8Encoding]::new($false))'
+   ```
+
+   If regex matching is actually required, use `-replace [regex]::Escape("old"),"new"`. Note: `-replace`'s replacement string interprets `$1`, `$2`, `$$`, `$&`, etc. as regex substitution tokens, so if the replacement text contains literal `$` characters (common in PostgreSQL dollar-quoting like `$$`, `$BODY$`), double them: `-replace [regex]::Escape("old"), "new".Replace("$","$$")`.
+   f. **Navigate back** to the changed line (rule 2 above). Do NOT skip this.
+4. **Diff after every cluster.** After completing all fixes in a cluster, show a three-way diff comparing the original source MSSQL, the converted PG file, and the working copy.
+
+   **Empty-diff guard (used by every IDE branch below):** Before showing the second diff (converted PG vs working copy), check whether the two files are identical. If they are, skip the second diff and tell the user: "No fixes have been applied yet — the converted PG file and working copy are still identical."
+   - macOS/Linux/Git Bash: `diff --brief <converted_pg> <working_copy>` (exit 0 = identical)
+   - Windows (PowerShell): `powershell -Command "if ((Get-FileHash '<converted_pg>').Hash -eq (Get-FileHash '<working_copy>').Hash) { exit 0 } else { exit 1 }"` (exit 0 = identical)
+
+   - **VS Code:** Open two diffs side by side:
+     `code --diff <source_mssql> <converted_pg>`
+     Only if the converted PG file and working copy differ (empty-diff guard above):
+     `code --diff <converted_pg> <working_copy>`
+   - **Kiro:** Open two diffs side by side:
+     `kiro --diff <source_mssql> <converted_pg>`
+     Only if the converted PG file and working copy differ (empty-diff guard above):
+     `kiro --diff <converted_pg> <working_copy>`
+   - **DBeaver:** Use the SQL Compare feature or an external diff tool
+   - **Fallback:** If the IDE diff commands do not produce visible results, generate text-based diffs in chat.
+     - macOS/Linux/Git Bash:
+       `diff -u <source_mssql> <converted_pg>`
+       Only if the converted PG file and working copy differ (empty-diff guard above):
+       `diff -u <converted_pg> <working_copy>`
+     - Windows (PowerShell): use `Compare-Object`:
+       `powershell -Command "Compare-Object (Get-Content '<source_mssql>' -Encoding UTF8) (Get-Content '<converted_pg>' -Encoding UTF8)"`
+       Only if the converted PG file and working copy differ (empty-diff guard above):
+       `powershell -Command "Compare-Object (Get-Content '<converted_pg>' -Encoding UTF8) (Get-Content '<working_copy>' -Encoding UTF8)"`
+       Note: `Compare-Object` output is a side-indicator list (`<=` for left-only, `=>` for right-only) rather than unified-diff format. Show the output to the user as-is — it conveys the same information in a different layout.
+       If two diffs were shown, tell the user:
+   > "Two diff views have been opened: one comparing the source MSSQL with the converted PG file (showing what the conversion changed), and one comparing the converted PG file with the working copy (showing what fixes have been applied). You may need to arrange the diff tabs side by side."
+   > Then ask the user:
+   > "Cluster fixes applied. Would you like to upload the working copy to AWS Transform for re-validation before proceeding to the next cluster? [Yes / No]"
+   - If **Yes**: Prepare a ZIP artifact for re-validation:
+     1. Create the staging directory:
+        - macOS/Linux/Git Bash: `execute_bash: mkdir -p <working_directory>/zip_staging`
+        - Windows (PowerShell): `execute_bash: powershell -Command "New-Item -ItemType Directory -Force -Path '<working_directory>/zip_staging'"`
+     2. Copy the working copy as `postgres-completed-deployment.sql`:
+        - macOS/Linux/Git Bash: `execute_bash: cp <working_copy> <working_directory>/zip_staging/postgres-completed-deployment.sql`
+        - Windows (PowerShell): `execute_bash: powershell -Command "Copy-Item '<working_copy>' '<working_directory>/zip_staging/postgres-completed-deployment.sql'"`
+     3. Copy the custom rules file(s) from the working directory:
+        - macOS/Linux/Git Bash: `execute_bash: cp <working_directory>/<rule_file> <working_directory>/zip_staging/<rule_file>`
+        - Windows (PowerShell): `execute_bash: powershell -Command "Copy-Item '<working_directory>/<rule_file>' '<working_directory>/zip_staging/<rule_file>'"`
+     4. Create `manifest.json` in `zip_staging/` with database name, execution order (`file: "postgres-completed-deployment.sql"`, `type: "all"`, `object_count: <count of CREATE statements>`), and `"custom_rules"` listing the custom rules filenames
+     5. Create ZIP:
+        - macOS/Linux: `execute_bash: cd <working_directory>/zip_staging && rm -f ../IDE_CONVERTED_DB_ARTIFACT.zip && zip ../IDE_CONVERTED_DB_ARTIFACT.zip *`
+        - Windows: `execute_bash: powershell -Command "Compress-Archive -Path '<working_directory>/zip_staging/*' -DestinationPath '<working_directory>/IDE_CONVERTED_DB_ARTIFACT.zip' -Force"`
+     6. Clean up:
+        - macOS/Linux/Git Bash: `execute_bash: rm -rf <working_directory>/zip_staging`
+        - Windows (PowerShell): `execute_bash: powershell -Command "Remove-Item -Recurse -Force '<working_directory>/zip_staging'"`
+     7. Upload via `upload_artifact` with `content="<working_directory>/IDE_CONVERTED_DB_ARTIFACT.zip"`, `fileName="IDE_CONVERTED_DB_ARTIFACT"`, `fileType="ZIP"`, `categoryType="CUSTOMER_INPUT"`.
+     8. Send `send_message` with text "IDE agent completed all critical and high-severity fixes. Uploaded corrected file as IDE_CONVERTED_DB_ARTIFACT. Ready for re-validation through invoke_validation_after_ide with new artifact id:`<artifactId>`". Poll messages for "Validation complete", download new report, and present results. If new issues are found in this cluster, fix them before moving on.
+   - If **No**: Proceed to the next cluster.
+5. **No scripts.** Do NOT write Python, Bash, or any scripts to batch-process fixes.
+6. **Use `sed`, `perl`, or PowerShell for file edits, NOT `fs_write`.** Large SQL files (10K+ lines) cause the editor to freeze when using `fs_write`. Use `execute_bash` to edit the working copy directly on disk:
+   - macOS/Linux/Git Bash: `sed -i '' 's/old/new/g' <working_copy>` or `perl -i -pe 's/old/new/g' <working_copy>`
+   - Windows (PowerShell): use the literal-string `.Replace()` method (NOT `-replace`, which is a regex operator). Read with `Get-Content -Encoding UTF8` to avoid Windows PowerShell 5.1's ANSI code-page corruption, and write with `[System.IO.File]::WriteAllLines` + no-BOM UTF-8 (NOT `Set-Content -Encoding UTF8`, which prepends a UTF-8 BOM on PS 5.1 that Rule 10's ASCII verification will flag). Wrap the `-Command` argument in **single quotes** so bash/Git Bash does not expand `$c` / `$false` before PowerShell parses them, and prepend `$ErrorActionPreference='Stop'` so intermediate failures surface instead of silently producing an empty working copy: `powershell -Command '$ErrorActionPreference="Stop"; $c = (Get-Content "<working_copy>" -Encoding UTF8).Replace("old","new"); [System.IO.File]::WriteAllLines("<working_copy>", $c, [System.Text.UTF8Encoding]::new($false))'`. Use `-replace [regex]::Escape("old"),"new"` only if regex matching is actually required; when using `-replace`, also double any literal `$` in the replacement string (`"new".Replace("$","$$")`) because `-replace` interprets `$1`, `$$`, etc. as regex substitution tokens — which silently corrupts PostgreSQL dollar-quoting like `$$` and `$BODY$`.
+7. **No bulk operations.** Fix one object at a time.
+8. **No invented fixes.** Only apply fixes described in the validation report.
+9. **Report every fix in chat** with: object name, line number in working copy, problem (from report), proposed fix, and updated progress table.
+10. **Encoding safety before upload.** Before creating a ZIP for upload, sanitize non-ASCII characters that can corrupt during ZIP packaging and cause the validator to fail with `total_checks: 0`.
+
+**Sanitize and verify (cross-platform, using Perl):**
+
+```
+perl -i -CSD -pe "s/\x{2014}/--/g; s/\x{2013}/-/g; s/[\x{2018}\x{2019}]/'/g; s/[\x{201c}\x{201d}]/\"/g; s/\x{2026}/.../g; s/\x{a0}/ /g" <working_copy>
+perl -ne 'if(/[^\x00-\x7F]/){print "$ARGV:$.: $_"; $f++} END{exit !$f}' <working_copy> || echo "Clean: ASCII only"
+```
+
+Perl is available on macOS and Linux by default, and on Windows via Git Bash.
+
+**Windows alternative (PowerShell):**
+
+```
+powershell -Command "
+  $text = [IO.File]::ReadAllText('<working_copy>', [Text.Encoding]::UTF8);
+  $text = $text -replace '\u2014','--' -replace '\u2013','-' -replace '[\u2018\u2019]',\"'\" -replace '[\u201c\u201d]','\"' -replace '\u2026','...' -replace '\u00a0',' ';
+  $utf8NoBom = New-Object System.Text.UTF8Encoding $false;
+  [IO.File]::WriteAllText('<working_copy>', $text, $utf8NoBom);
+  if ($text -match '[^\x00-\x7F]') { Write-Host 'WARNING: non-ASCII characters remain' } else { Write-Host 'Clean: ASCII only' }
+"
+```
+
+Common offenders: em-dash (`—`), en-dash (`–`), smart quotes (`""''`). These appear in MSSQL-generated comment headers and corrupt from UTF-8 to Windows-1252 `0x97` during ZIP packaging.
+
+---
+
+## From-Scratch Workflow
+
+Use this workflow when starting a new MSSQL → PostgreSQL conversion entirely from the IDE. If you already have a completed AWS Transform job with artifacts, skip to the **Handoff Workflow** section.
+
+### Step 1: Authentication
+
+- **Cookie auth requires the Transform app URL** — Ask for the prod tenant URL:
+  - Prod: `https://722368900496189c6.transform.us-east-1.on.aws`
+- Do **not** use the SSO/IdC start URL (`https://d-xxx.awsapps.com/start`).
+- If the auth cookie has expired, ask the user for a new one.
+
+### Step 2: Create Workspace and Job
+
+- **Unless the user explicitly says to create a new workspace/job, always ask first:**
+  > "Do you have an existing AWS Transform workspace or job you'd like to reuse, or should I create new ones?"
+- **If reusing an existing workspace:** List all available workspaces so the user can see names and IDs, then ask which one to use. Then ask if they also have an existing job to reuse or need a new job in that workspace.
+- **If reusing an existing job:** List all jobs in the selected workspace so the user can see job names and IDs, then ask which one to use. Use artifact store tools to check what outputs the agent has already produced — the job may already be past the upload or assessment phase.
+- **If creating a new workspace:** Names must match `[a-zA-Z0-9]+(?:[-_\.][a-zA-Z0-9]+)*` — no spaces allowed.
+- **If creating a new job:** MSSQL to PostgreSQL conversion uses `WINDOWS_DATABASE` (SQL Server modernization) as the job type.
+- **Always choose MSSQL file upload (NOT the connect-to-database option) after starting the job.**
+
+### Step 3: SQL File Upload
+
+- The source SQL file can be either a `.sql` file or a `.zip` archive containing SQL files. Both formats are accepted by AWS Transform. **Upload the file as-is — do NOT zip a `.sql` file before uploading.**
+- If the ActiveFile is a mssql file, use that.
+- If not, ask for user's permission and search locally for files — use `fileSearch` to find `.sql` or `.zip` files on the user's machine instead of asking for the full path.
+- Upload the file as an artifact first using `upload_transform_task_artifact`.
+- Then send the artifact reference in chat using the URI format:
+
+  ```
+  aws-transform://workspaces/{workspaceId}/jobs/{jobId}/artifacts/{artifactId}
+  ```
+
+- **Don't send bare artifact IDs** — the agent won't recognize them. It needs the full `aws-transform://` URI.
+
+### Step 4: Interacting with the Agent
+
+- **Always use `send_transform_message` as the primary form of communication with the job agent.**
+- **Messages can have interaction buttons** — Agent messages include `SELECT` interactions with options. Respond by sending the option's `value` as a chat message.
+
+### Step 5: Monitoring Job Progress
+
+- The job is carried out by AWS Transform agents; all communication and updates are wired through them.
+- **Always check all three**: messages, worklogs, and HITL tasks.
+- **Worklogs** are the most granular progress indicator — they update more frequently than messages and show the agent's internal reasoning/actions step by step.
+- **Messages** show user-facing interactions with SELECT options (e.g. "MSSQL to PostgreSQL", "Upload DDL files").
+- **HITL tasks** may or may not appear — the agent can request input via chat messages instead.
+- **No HITL tasks doesn't mean no input needed** — The job can be in `AWAITING_HUMAN_INPUT` with no HITL tasks; input is expected via chat messages.
+- Jobs go through phases: `STARTING` → `PLANNING` → `AWAITING_HUMAN_INPUT` → active processing.
+- The `input_setup` step handles file ingestion before moving to `discovery`.
+- Planning can take a few minutes — no tasks or messages will appear until it completes.
+
+**Polling loop (mandatory throughout the job lifecycle):**
+
+After any action that triggers agent work (file upload, schema conversion, etc.), enter a polling loop:
+
+1. Use **mcp-sleep** to wait 10 seconds.
+2. Check messages, worklogs, and HITL tasks.
+3. **Format timestamps** — Worklog and message timestamps may be returned as epoch milliseconds or numeric values (e.g., `140638`). Always convert these to human-readable format (e.g., `2026-04-13 21:06:38 UTC`) before displaying to the user.
+4. If the agent sent a message requiring a response (SELECT options, questions, or `AWAITING_HUMAN_INPUT` status), respond or prompt the user.
+5. If the agent is still processing (no new actionable messages), go back to step 1.
+6. Continue polling until the current phase completes (e.g., assessment report is ready, schema conversion finishes, validation completes).
+
+Do NOT stop polling prematurely — always keep the loop running until there is a clear completion signal or user input is needed.
+
+### Step 6: Reading Assessment Results
+
+- Download the assessment report zip artifact.
+- Extract the zip file and review all contents — it typically contains PDF reports and CSV data files.
+- **PDF reports:**
+  - `assessment_summary.pdf` is a short document with a summary of the assessment.
+  - The other report PDF is a longer document with detailed findings of migration issues with the database.
+- **CSV files:** Contain structured data such as object inventories, issue lists, and migration action items. Read and present these to the user — they are useful for programmatic analysis and tracking.
+
+### Step 7: Schema Conversion
+
+- When the user is ready to proceed towards schema conversion, send this intent to the agent.
+- **Custom transformation rules:** During conversion, the AWS Transform agent may ask about custom transformation rules. **Do NOT assume default rules.** Always ask the user:
+  > "The conversion agent is asking about custom transformation rules. Do you have custom rules to upload, or should I proceed with default rules?"
+  > Only proceed with defaults if the user explicitly confirms.
+- Schema conversion is a long-running process — expect to poll for job progress (see Step 5).
+- After the schema conversion report is available, review it with the user. **Do NOT skip ahead to downloading the converted PostgreSQL file** — it is not available yet.
+- The converted PostgreSQL SQL file is only produced after the **target DB deployment workflow** completes. After reviewing the conversion report, continue interacting with the AWS Transform agent to proceed through the deployment workflow (see Step 8).
+
+### Step 8: Target DB Deployment
+
+- After schema conversion and report review, the AWS Transform agent will guide the workflow toward deploying the converted schema to the target PostgreSQL database.
+- Continue polling and responding to the agent's messages through this phase (see Step 5).
+- **Do NOT assume the user already has a target database cluster.** The deployment flow requires setting up a DB connector first.
+
+**DB Connector Setup:**
+
+The AWS Transform agent will issue a HITL task to set up a DB connector. Before creating a new one, check if the workspace already has a connector configured:
+
+1. **List existing connectors** in the workspace first. If connectors exist, present them to the user:
+   > "This workspace already has the following DB connector(s) configured:
+   >
+   > - `<connector name>` — `<connection details>`
+   >
+   > Would you like to use an existing connector, or set up a new one?"
+2. **If the user picks an existing connector**, use that and skip connector creation.
+3. **If a new connector is needed**, the HITL task will require details from the user. Ask for:
+   - AWS Account ID
+   - Any other connection parameters the HITL task requests (e.g., database endpoint, credentials, VPC details)
+
+   Do NOT guess or assume any of these values — always ask the user.
+
+- **The converted PostgreSQL SQL file (`ATX_CONVERTED_DB_ARTIFACT` or `postgres-completed-deployment.sql`) is only available as an artifact after the deployment workflow completes.** Do NOT attempt to download it before this point — it won't exist yet.
+- Once deployment finishes, proceed to retrieve the artifacts (see Step 9).
+
+### Step 9: Retrieving Conversion Artifacts
+
+```
+# List all artifacts from the completed AWS Transform job
+list_resources resource="artifacts" workspaceId="<workspaceId>" jobId="<jobId>"
+```
+
+Scan the returned list for matching artifact names/labels. AWS Transform MCP does not support filtering by label — you must list all, then match.
+
+- **Scan for converted database artifacts:** Look for all artifacts with `fileMetadata.path` starting with `ATX_CONVERTED_DB_ARTIFACT`. Each artifact represents a converted database, with the database name as the suffix: `ATX_CONVERTED_DB_ARTIFACT_<dbName>`.
+
+  Extract the database names and present them to the user:
+  > "Converted artifacts are available for **N** database(s):
+  >
+  > 1. `OrdersDB`
+  > 2. `InventoryDB`
+  > 3. `AuditDB`
+  >
+  > Which database would you like to work on?"
+
+  Wait for the user to choose. Then download the selected artifact:
+
+  ```
+  get_resource resource="artifact" workspaceId="<workspaceId>" jobId="<jobId>" artifactId="<matched-id>" savePath="/local/path/ATX_CONVERTED_DB_ARTIFACT_<dbName>.zip"
+  ```
+
+  Extract the ZIP — contains: `sourcesql/`, `targetsql/`, `validationreport/`. Read `targetsql/manifest.json` to discover the converted SQL files and custom rules — file paths in the manifest are relative to `targetsql/`.
+
+- **Fallback (single artifact):** If no `ATX_CONVERTED_DB_ARTIFACT_*` artifacts are found, look for a single `ATX_CONVERTED_DB_ARTIFACT` (no suffix) and use it directly.
+
+- **Fallback (individual artifacts):** If no ZIP artifacts found, look for:
+  - `postgres-completed-deployment.sql` → converted PG file
+  - `Schema Conversion Report` → validation report
+  - Then ask user for the source SQL file path
+
+Once artifacts are retrieved, proceed to the **Common Workflow** section below.
+
+---
+
+## Handoff Workflow
+
+Use this workflow when an AWS Transform conversion job has already completed and you need to pick up the remaining fixes in the IDE.
+
+### Why IDE Handover
+
+The IDE agent complements the AWS Transform agentic flow by providing capabilities that a managed batch pipeline cannot:
+
+- **Interactive fixing** — Apply a fix, show the user the exact change, wait for approval or adjustment, then proceed.
+- **Cross-object awareness** — The IDE has the full converted file open and can cross-reference across procedures, views, and tables while editing.
+- **Granular human-in-the-loop** — Pause at every individual object for user approval instead of coarse-grained job checkpoints.
+- **Local tooling** — Run PostgreSQL syntax validation locally, show diffs, and use language intelligence for SQL editing.
+- **Long-tail remediation** — Remaining broken objects each have unique issues requiring case-by-case judgment.
+- **Full transparency** — Every fix is reported in chat with what changed and why.
+
+### What AWS Transform Handles vs What the IDE Agent Handles
+
+| Responsibility                     | AWS Transform Transform Agent | IDE Agent (this steering)                     |
+| ---------------------------------- | ----------------------------- | --------------------------------------------- |
+| Schema conversion (DDL)            | ✅                            | —                                             |
+| Bulk stored proc rewrite           | ✅                            | Fix remaining broken procs flagged in report  |
+| Data type mapping                  | ✅                            | Fix type mapping violations flagged in report |
+| View creation                      | ✅                            | Resolve failed views flagged in report        |
+| Index migration                    | ✅                            | Re-create missing indexes flagged in report   |
+| Validation report generation       | ✅                            | Parse and act on report                       |
+| Critical/high-severity remediation | —                             | ✅                                            |
+| Application code changes           | —                             | Out of scope (flag for user)                  |
+
+### Step 1: Collect AWS Transform Job Context
+
+Prompt user for AWS Transform job identifiers:
+
+- `workspaceId` — The AWS Transform workspace where the conversion job ran
+- `jobId` — The AWS Transform job that performed the MSSQL → PostgreSQL conversion
+- `agentInstanceId` — The agent instance that produced the conversion artifacts
+
+### Step 2: Retrieve Artifacts from AWS Transform
+
+Once the user provides identifiers, list all job artifacts and match by name/label:
+
+```
+# List all artifacts
+list_resources resource="artifacts" workspaceId="<workspaceId>" jobId="<jobId>"
+```
+
+- **Scan for converted database artifacts:** Look for all artifacts with `fileMetadata.path` starting with `ATX_CONVERTED_DB_ARTIFACT`. Each artifact represents a converted database: `ATX_CONVERTED_DB_ARTIFACT_<dbName>`.
+
+  Extract the database names and present them:
+  > "This job has converted artifacts for **N** database(s):
+  >
+  > 1. `OrdersDB`
+  > 2. `InventoryDB`
+  >
+  > Which database would you like to fix?"
+
+  Wait for the user to choose. Then download:
+
+  ```
+  get_resource resource="artifact" workspaceId="<workspaceId>" jobId="<jobId>" artifactId="<matched-id>" savePath="/local/path/ATX_CONVERTED_DB_ARTIFACT_<dbName>.zip"
+  ```
+
+  Extract the ZIP — contains: `sourcesql/`, `targetsql/`, `validationreport/`. Read `targetsql/manifest.json` to discover the converted SQL files and custom rules — file paths in the manifest are relative to `targetsql/`.
+
+- **Fallback (single artifact):** If no `ATX_CONVERTED_DB_ARTIFACT_*` found, look for a single `ATX_CONVERTED_DB_ARTIFACT` (no suffix) and use it directly.
+
+- **Fallback (individual artifacts):** If no ZIP artifacts found, scan for:
+  - `postgres-completed-deployment.sql` → converted PG file
+  - `Schema Conversion Report` → validation report
+  - Ask user for the source SQL file separately
+
+- **Fallback (no artifacts):** If no artifacts found or AWS Transform job not referenced, ask user for local file paths to:
+  - Original source SQL file (T-SQL / SQL Server)
+  - Converted PostgreSQL SQL file
+  - Conversion validation report (HTML or text)
+
+Once artifacts are retrieved, proceed to the **Common Workflow** section below.
+
+---
+
+## Common Workflow (Both Paths Converge Here)
+
+Once you have the source SQL, converted PostgreSQL SQL, and validation report — regardless of whether you arrived via the from-scratch or handoff path — follow these steps.
+
+### Step 1: Check PostgreSQL Extension
+
+Verify the user has a PostgreSQL extension installed in their IDE. If not installed, ask:
+
+> "A PostgreSQL extension is required to validate fixes before applying them. Please install one:
+>
+> - **VS Code:** Install `ms-ossdata.vscode-postgresql` or `ckolkman.vscode-postgres` from the Extensions marketplace
+> - **Kiro:** Install the PostgreSQL extension from the Extensions panel
+> - **DBeaver:** Built-in — no additional install needed
+>
+> Once installed, configure a connection profile for the target Aurora PostgreSQL cluster and let me know the profile name."
+
+### Step 2: Set Fix Autonomy Mode
+
+Ask the user:
+
+> "How should I handle fix approvals?
+>
+> - **per-fix** (default) — I propose each fix and wait for your approval before applying it
+> - **per-cluster** — I show proposed fixes for the first 2–3 issues in a cluster so you can review the approach, then apply all fixes in the cluster after your approval. A cluster diff is shown after applying.
+> - **autonomous** — I apply all critical/high fixes end-to-end and present a full diff and summary at the end
+>
+> Choose [per-fix / per-cluster / autonomous]:"
+
+Store the chosen mode for the session. The user can switch mid-session by saying e.g. `"Switch to per-cluster mode"`. Mode affects approval behavior:
+
+- `per-fix` — Rule 2d (approval prompt before every fix) is enforced.
+- `per-cluster` — Rule 2d is skipped. The agent shows proposed before/after fixes for the first 2–3 issues as a preview, asks for approval, then applies all fixes in the cluster. Rule 3 (cluster diff) is shown after applying.
+- `autonomous` — Rules 2d and 3 approval prompts are skipped. Fixes are still logged in chat (Rule 8) and a final summary is shown.
+
+### Step 3: Present Available Commands
+
+Before starting fixes, inform the user:
+
+> "Before we begin, here's what you can ask me to do at any time:
+>
+> - **Show diff** — Display a diff of all changes made so far (three-way diff of source MSSQL, converted PG, and working copy). The converted PG vs working copy diff is skipped if the files are still identical.
+> - **Run validation** — Upload the working copy to AWS Transform for functional re-validation and get a new report
+> - **Show progress** — Print the current progress table with cluster statuses
+> - **Switch autonomy mode** — Change fix approval mode (per-fix / per-cluster / autonomous)
+> - **Skip cluster** — Skip the current cluster and move to the next one
+> - **Revert cluster** — Undo all fixes in the current cluster
+> - **Fix a medium/low item** — Ask me to fix a specific advisory item
+> - **I'm done** — End the session, upload the final file to AWS Transform, and optionally deploy
+>
+> Let's start."
+
+### Step 4: Parse Report and Prioritize
+
+1. **Parse the Issue Clusters table** — Each row has a severity emoji (🔴🟠🟡🟢), a description, and a score deduction.
+2. **Filter to critical and high** — Only 🔴 Critical and 🟠 High clusters are in scope for auto-fixing.
+3. **For each in-scope cluster, read "What Needs Immediate Attention"** — Contains affected objects, risk description, and recommended SQL fixes.
+4. **For medium/low clusters** — Present as advisory items. Do not auto-fix unless user explicitly requests.
+5. **For info/warning items** — Note in summary but take no action.
+6. **Separate load failures from conversion defects** — Schema Loading Notes distinguish objects that failed to load due to missing dependencies vs true migration issues.
+7. **Read the custom rules file** — Parse the custom rules JSON from `targetsql/` (listed in `manifest.json`'s `custom_rules` array). Understand the current type mappings, extensions, and naming conventions. This context is needed when applying fixes — if a fix contradicts or extends these rules, you'll update the custom rules file in Step 6 (and verify in Step 7).
+
+### Step 5: Set Up Three-File Workflow
+
+1. **Ensure the working directory is trusted** — Ask the user:
+   > "Which directory should I use for the working files? It should be a directory already open and trusted in your IDE. This avoids permission prompts that can freeze the chat."
+
+2. Read `targetsql/manifest.json` to identify the converted SQL file(s) from `execution_order` and the custom rules file(s) from `custom_rules`. File paths in the manifest are relative to `targetsql/`.
+3. Copy the converted PG file (the first `file` in `execution_order`) to a working copy (e.g., `postgres-deployment-fixing.sql`). Keep the original converted PG file as a read-only reference. All fixes go to the working copy only.
+4. Copy the custom rules file(s) to the working directory. All custom rules edits go to this working copy — the original in `targetsql/` stays untouched.
+   - macOS/Linux/Git Bash: `cp <targetsql>/<rule_file> <working_directory>/<rule_file>`
+   - Windows (PowerShell): `powershell -Command "Copy-Item '<targetsql>/<rule_file>' '<working_directory>/<rule_file>'"`
+5. Open the source SQL, converted PG file, and working copy in the editor:
+   - **Kiro:** `kiro <sourcesql/source.sql>` then `kiro --reuse-window <targetsql/converted.sql>` then `kiro --reuse-window <working_copy>`
+   - **VS Code:** `code <sourcesql/source.sql> <targetsql/converted.sql> <working_copy>`
+   - **DBeaver:** Open all files via File → Open
+6. Tell the user:
+   > "I've opened three files: the source MSSQL, the converted PG file, and the working copy. You can arrange them side by side. The source MSSQL and converted PG files are for reference only — all fixes go to the working copy."
+
+### Step 6: Apply Fixes in Priority Order
+
+Apply fixes in dependency order to avoid cascading failures:
+
+1. **Prerequisites** — Extensions, schemas, and any infrastructure the report identifies as missing
+2. **Type/column fixes** — Data type corrections flagged as critical or high
+3. **Views** — Resolve dependency issues, then re-create failed views in order
+4. **Stored procedures and functions** — Apply each fix pattern described in the report
+5. **Indexes** — Re-create missing indexes
+6. **Validate** — Confirm syntax validity and that all critical/high items are addressed
+
+**Custom rules — update as you go:** When a fix establishes a reusable conversion pattern (type mapping, extension, naming), update the custom rules file immediately:
+
+- **Overwriting an existing rule** (e.g., changing `BIT → BOOLEAN` to `BIT → NUMERIC`) → **ask the user for confirmation** before modifying. Do NOT overwrite silently.
+- **Adding a new rule** → In per-fix mode, ask confirmation. In per-cluster/autonomous mode, just inform the user and add it.
+
+This keeps custom rules in sync with the actual conversion. Validation uses these rules to score — inaccurate rules cause false positives.
+
+### Step 7: Verify Custom Rules
+
+**Why this matters:** The validation sub-agent uses the custom rules file to score the conversion. If the custom rules don't reflect the actual type mappings and patterns used in the converted SQL, validation will flag false positives and lower the score. Keeping custom rules accurate ensures validation results are meaningful.
+
+Before uploading, verify that the custom rules file reflects all conversion patterns applied during this session:
+
+1. **Review changes made** — For each fix that changed a type mapping, added an extension, or established a naming pattern, confirm the custom rules file was updated during Step 6.
+2. **Check for missed updates** — If any fixes were applied that should have updated custom rules but didn't (e.g., you changed a `BIT` column to `NUMERIC` but the rules still say `BIT → BOOLEAN`), update them now following the rules below.
+3. **Confirm with user if overwriting** — If any rule was modified (not just added), confirm the user approved the change during Step 6. If not, ask now.
+
+**Custom rules file format:**
+
+```json
+{
+  "extensions": {
+    "base_extensions": ["citext", "uuid-ossp", "pgcrypto"],
+    "additional_extensions": []
+  },
+  "type_mappings": [
+    {
+      "rule-id": "<unique_id>",
+      "rule-name": "",
+      "source-type": "<MSSQL_TYPE>",
+      "target-type": "<POSTGRESQL_TYPE>",
+      "precision": null,
+      "scale": null
+    }
+  ],
+  "naming": {
+    "casing": "lowercase",
+    "schema_mappings": {},
+    "strip_schema_prefixes": []
+  }
+}
+```
+
+**What to update:**
+
+- **Type mapping fixes** → Add or modify entries in `type_mappings`. Use a descriptive `rule-id` (e.g., "bit", "money").
+- **Extension requirements** → Add to `extensions.additional_extensions` if a fix requires a PostgreSQL extension not in `base_extensions`.
+- **Naming conventions** → Update `naming.schema_mappings` or `naming.casing` if applicable.
+
+Save the updated custom rules file to the working directory. It will be included in the next upload ZIP (Step 8 uses the updated version).
+
+### Step 8: Upload Fixed File to AWS Transform
+
+#### Copy working copy and upload to artifact store
+
+- macOS/Linux/Git Bash:
+
+  ```
+  execute_bash: cp <working_copy> <working_directory>/postgres-completed-deployment.sql
+  ```
+
+- Windows (PowerShell):
+
+  ```
+  execute_bash: powershell -Command "Copy-Item '<working_copy>' '<working_directory>/postgres-completed-deployment.sql'"
+  ```
+
+```
+upload_artifact(
+  workspaceId="<workspaceId>",
+  jobId="<jobId>",
+  content="<working_directory>/postgres-completed-deployment.sql",
+  fileName="IDE_CONVERTED_DB_ARTIFACT",
+  fileType="TXT",
+  categoryType="CUSTOMER_INPUT"
+)
+```
+
+#### Notify the AWS Transform job chat
+
+```
+send_message(
+  workspaceId="<workspaceId>",
+  jobId="<jobId>",
+  text="IDE agent completed all critical and high-severity fixes. Uploaded corrected file as IDE_CONVERTED_DB_ARTIFACT. Ready for re-validation through invoke_validation_after_ide with new artifact id:<artifactId>"
+)
+```
+
+### Step 9: Monitor Validation and Continue
+
+Poll AWS Transform job messages for validation status updates:
+
+```
+list_resources(
+  resource="messages",
+  workspaceId="<workspaceId>",
+  jobId="<jobId>"
+)
+```
+
+Filter for messages containing "validation". Display matching messages to show progress. Re-poll every 10 seconds until a message containing **"Validation complete"** appears. Use the **mcp-sleep** tool between polls.
+
+When "Validation complete" is found, extract the artifact ID from the message and download the new report:
+
+```
+get_resource(
+  resource="artifact",
+  workspaceId="<workspaceId>",
+  jobId="<jobId>",
+  artifactId="<artifactId from validation complete message>",
+  savePath="<working_directory>/validation_report_latest.html"
+)
+```
+
+Prompt the user:
+
+> "Validation is complete. New report downloaded.
+>
+> Would you like to:
+>
+> 1. **Review & fix** — Parse the new report and apply another round of fixes
+> 2. **Deploy** — Accept the current state and deploy to the target database
+>
+> Choose [1] or [2]:"
+
+- **If 1:** Go back to Step 4 (Parse Report and Prioritize).
+- **If 2:** Prepare and upload the final converted artifact before deployment:
+  1. Prepare a ZIP bundle in a staging directory:
+     - Create the staging directory:
+       - macOS/Linux/Git Bash: `execute_bash: mkdir -p <working_directory>/zip_staging`
+       - Windows (PowerShell): `execute_bash: powershell -Command "New-Item -ItemType Directory -Force -Path '<working_directory>/zip_staging'"`
+     - Copy working copy as `postgres-completed-deployment.sql`:
+       - macOS/Linux/Git Bash: `execute_bash: cp <working_copy> <working_directory>/zip_staging/postgres-completed-deployment.sql`
+       - Windows (PowerShell): `execute_bash: powershell -Command "Copy-Item '<working_copy>' '<working_directory>/zip_staging/postgres-completed-deployment.sql'"`
+     - Copy the custom rules file(s) from the working directory:
+       - macOS/Linux/Git Bash: `execute_bash: cp <working_directory>/<rule_file> <working_directory>/zip_staging/<rule_file>`
+       - Windows (PowerShell): `execute_bash: powershell -Command "Copy-Item '<working_directory>/<rule_file>' '<working_directory>/zip_staging/<rule_file>'"`
+     - Create `manifest.json` with database name, execution order (`file: "postgres-completed-deployment.sql"`, `type: "all"`, `object_count: <count of CREATE statements>`), and `"custom_rules"` listing the custom rules filenames
+  2. Create ZIP:
+     - macOS/Linux: `execute_bash: cd <working_directory>/zip_staging && rm -f ../IDE_CONVERTED_DB_ARTIFACT.zip && zip ../IDE_CONVERTED_DB_ARTIFACT.zip *`
+     - Windows: `execute_bash: powershell -Command "Compress-Archive -Path '<working_directory>/zip_staging/*' -DestinationPath '<working_directory>/IDE_CONVERTED_DB_ARTIFACT.zip' -Force"`
+  3. Clean up:
+     - macOS/Linux/Git Bash: `execute_bash: rm -rf <working_directory>/zip_staging`
+     - Windows (PowerShell): `execute_bash: powershell -Command "Remove-Item -Recurse -Force '<working_directory>/zip_staging'"`
+  4. Upload via `upload_artifact` with `fileName="IDE_CONVERTED_DB_ARTIFACT"`, `fileType="ZIP"`, `categoryType="CUSTOMER_INPUT"`.
+  5. Send a message to the AWS Transform job with the artifact ID:
+
+     ```
+     send_message(
+       workspaceId="<workspaceId>",
+       jobId="<jobId>",
+       text="IDE agent completed all fixes. Final converted artifact uploaded as IDE_CONVERTED_DB_ARTIFACT (artifactId: <artifactId>). Ready for deployment."
+     )
+     ```
+
+  6. Proceed with deployment via AWS Transform job or IDE PostgreSQL extension if the user prefers.
+
+---
+
+## Report Structure
+
+The validation report follows this general structure:
+
+| Section                        | What It Contains                                                                                                             | How to Use                                                            |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| Executive Summary              | Quantitative Score, Expert Assessment, production readiness grade                                                            | Determine overall severity — 🔴 NOT READY means critical issues exist |
+| Migration Overview table       | Per-category counts (Tables, Views, Procs, Triggers, Columns, Constraints, Indexes, Type Mappings) with Pass/Warn/Fail rates | Identify which categories have failures                               |
+| Issue Clusters table           | Severity (🔴🟠🟡🟢), cluster description, score deduction                                                                    | Prioritize fixes — work critical clusters first                       |
+| Schema Loading Notes           | Objects that failed to load due to missing dependencies vs true migration issues                                             | Distinguish load failures from conversion defects                     |
+| What Needs Immediate Attention | Detailed per-cluster breakdown with affected objects, risk description, and recommended SQL fixes                            | Primary source of fix instructions                                    |
+| Recommended Action Plan        | Ordered steps: 🔴 Before testing → 🟡 Before go-live → 🟢 Post-migration                                                     | Follow this sequence when applying fixes                              |
+| What We Could Not Verify       | Items not tested (runtime correctness, data accuracy, performance, collation)                                                | Flag as remaining risks after fixes                                   |
+
+---
+
+## Progress Reporting
+
+Maintain a two-tier progress display: a summary table for overall status, plus an active context block.
+
+### Progress Table
+
+```
+## Conversion Progress
+
+| # | Severity | Cluster | Status |
+|---|----------|---------|--------|
+| 1 | 🔴 Crit  | <cluster description> (<N> objects) | ✅ Fixed |
+| 2 | 🟠 High  | <cluster description> (<N> objects) | 🔄 M/N |
+| 3 | 🟠 High  | <cluster description> (<N> objects) | ⏳ Pending |
+| 4 | 🟡 Med   | <cluster description> (<N> objects) | ℹ Advisory |
+
+### Currently fixing:
+`<schema.object_name>` — <brief description of the fix being applied>
+
+### Last completed:
+`<schema.object_name>` — <brief description of what was fixed>
+```
+
+### Status Values
+
+| Status                       | Meaning                                                   |
+| ---------------------------- | --------------------------------------------------------- |
+| `⏳ Pending`                 | Cluster not yet started                                   |
+| `🔄 M/N`                     | In progress — M of N objects fixed so far                 |
+| `✅ Fixed`                   | All objects in cluster resolved                           |
+| `⚠ Partial (M/N, K skipped)` | Some objects could not be fixed — requires user attention |
+| `ℹ Advisory`                 | Medium/low severity — presented to user, not auto-fixed   |
+
+### Per-Fix Chat Response
+
+For every individual fix, the chat response MUST include:
+
+**1. Fix summary with line reference:**
+
+```
+✅ Fixed `schema.object_name` (line N in working copy)
+Problem: <description from the report>
+Fix applied: <one-line summary of what was changed>
+Syntax validation: ✅ Passed (validated via PostgreSQL extension)
+```
+
+**2. Updated progress table** (as shown above).
+
+**3. Approval prompt — STOP and wait:**
+
+```
+Approve this fix? [Yes / No / Modify]
+```
+
+Do NOT proceed to the next fix until the user responds.
+
+After all critical/high clusters are done, print a final summary:
+
+```
+🔴 Critical: X/X done · 🟠 High: Y/Y done · Overall: Z/Z clusters resolved
+```
+
+---
+
+## Known Limitations
+
+- The IDE agent applies fixes based on the report's recommendations — it does not independently discover new issues
+- Runtime correctness of fixed procedures cannot be verified without production-equivalent test data
+- Application code changes (e.g., cursor-based result sets, connection strings) are outside scope — flag for user
+- Collation differences (MSSQL case-insensitive vs PostgreSQL case-sensitive) need separate testing
+- Performance validation requires production-equivalent load testing
+- CLR stored procedures, linked server queries, and SSIS packages require architectural changes beyond SQL file fixes
+
+---
+
+## Example Requirements
+
+```
+## Requirement 1: Fix All Critical Issues
+
+**User Story:** As a DBA, I want all critical-severity issues from the validation report
+resolved in the PostgreSQL file so that the schema is safe for production.
+**Acceptance Criteria:**
+
+1. WHEN fixes are applied, ALL 🔴 critical clusters from the report SHALL be resolved
+2. WHEN fixes are applied, the PostgreSQL file SHALL be syntactically valid
+3. WHEN fixes are applied, previously converted logic SHALL NOT be altered
+
+## Requirement 2: Fix All High-Severity Issues
+
+**User Story:** As a developer, I want all high-severity issues from the validation report
+resolved so that runtime failures are eliminated.
+**Acceptance Criteria:**
+
+1. WHEN fixes are applied, ALL 🟠 high clusters from the report SHALL be resolved
+2. WHEN fixes are applied, semantic behavior SHALL match the original source SQL
+3. WHEN fixes are applied, the fix SHALL follow the report's recommended approach
+```
+
+## Example Tasks
+
+```
+### From-Scratch Tasks
+
+- [ ] 1. Authenticate and set up AWS Transform job
+  - [ ] 1.1 Authenticate to AWS Transform using cookie auth
+  - [ ] 1.2 Create workspace and job (or use existing)
+  - [ ] 1.3 Upload source SQL artifact (.sql or .zip as-is)
+  - [ ] 1.4 Send artifact URI to agent via chat
+- [ ] 2. Monitor conversion and review assessment
+  - [ ] 2.1 Poll messages, worklogs, and HITL tasks for progress
+  - [ ] 2.2 Download and review assessment report PDFs and CSVs
+  - [ ] 2.3 Trigger schema conversion when user is ready
+  - [ ] 2.4 Poll for conversion completion
+  - [ ] 2.5 Retrieve conversion artifacts (ZIP or individual files)
+
+### Handoff Tasks
+
+- [ ] 1. Collect AWS Transform job context and inputs
+  - [ ] 1.1 Prompt user for workspaceId, jobId, and agentInstanceId
+  - [ ] 1.2 List all artifacts from AWS Transform job
+  - [ ] 1.3 Download ATX_CONVERTED_DB_ARTIFACT ZIP or individual artifacts
+  - [ ] 1.4 If no artifacts found, ask user for local file paths
+
+### Common Tasks (both workflows)
+
+- [ ] 3. Check PostgreSQL extension prerequisite
+- [ ] 4. Parse report and prioritize
+  - [ ] 4.1 Extract all issue clusters by severity
+  - [ ] 4.2 Identify critical and high-severity clusters
+  - [ ] 4.3 Separate load failures from true migration defects
+  - [ ] 4.4 Create working copy of converted PG file
+- [ ] 5. Apply critical-severity fixes
+  - [ ] 5.1 For each 🔴 critical cluster, validate proposed fix via PostgreSQL extension, then apply
+- [ ] 6. Apply high-severity fixes
+  - [ ] 6.1 For each 🟠 high cluster, validate proposed fix via PostgreSQL extension, then apply
+- [ ] 7. Present advisory items
+  - [ ] 7.1 Summarize 🟡 medium and 🟢 low clusters for user review
+- [ ] 8. Validate and upload
+  - [ ] 8.1 Confirm all critical and high clusters are addressed
+  - [ ] 8.2 Present diff of all changes
+  - [ ] 8.3 Create ZIP and upload to AWS Transform artifact store
+- [ ] 9. Monitor validation and continue
+  - [ ] 9.1 Poll AWS Transform job messages for validation progress
+  - [ ] 9.2 Download new validation report
+  - [ ] 9.3 Ask user: apply another round of fixes or deploy
+```

--- a/aws-transform/steering/workload-vmware-containerization.md
+++ b/aws-transform/steering/workload-vmware-containerization.md
@@ -1,0 +1,398 @@
+# VMware Containerization
+
+> **Last Updated:** 2026-05-10
+
+## Capabilities
+
+Containerize applications from VMware environments for deployment on Amazon ECS or Amazon EKS using AWS Transform's AI-powered agent. Analyzes source code, generates Docker artifacts, builds and publishes container images, and generates Infrastructure as Code for container orchestration platforms.
+
+- Source code analysis → Dockerfiles + configuration files (AI-generated)
+- Container image building → Amazon ECR (with automated vulnerability scanning)
+- Infrastructure as Code generation → Amazon EKS (Helm charts) or Amazon ECS (Terraform modules)
+- Private dependency support → AWS CodeArtifact (Maven, PyPI, npm) + private ECR base images
+- Iterative test deployment → validate before production cutover
+- Standalone containerization or end-to-end VMware migration with containerize strategy
+
+### Access Path
+
+Containerization is accessed through a VMware migration job. Two modes:
+
+| Mode | When to Use |
+|------|-------------|
+| **Standalone containerization** | Containerize source code without a full VMware migration |
+| **End-to-end migration with containerization** | Full VMware migration with `containerize` strategy assigned to one or more waves |
+
+### Prerequisites
+
+| Prerequisite | Required | Notes |
+|-------------|----------|-------|
+| AWS Transform workspace | Yes | See Getting Started |
+| Application source code | Yes | Git repo via AWS CodeConnections, or zip upload. Individual files ≤ 1 GB, total ≤ 8 GB. |
+| Amazon ECR repository | Optional | Can configure later in workflow when ready to publish |
+| Amazon EKS cluster | For EKS deployments | Existing cluster or permissions to create infrastructure |
+| Amazon ECS permissions | For ECS deployments | Permissions to create ECS clusters, services, and related resources |
+
+---
+
+## Workflow
+
+The containerization workflow is a 9-step sequence. The AWS Transform agent guides the user through each step in the chat interface.
+
+**When presenting the workflow to the user, show it as a sequential numbered list:**
+
+```
+1. Review security disclaimer
+2. Clone source code
+3. Containerize (AI analysis → Docker artifacts)
+4. Review Docker artifacts and code changes
+5. Publish images to Amazon ECR
+6. Generate Infrastructure as Code (EKS Helm charts or ECS Terraform)
+7. Deploy test infrastructure
+8. Clean up test infrastructure
+9. Deploy cutover infrastructure (production)
+```
+
+### Step 1: Review Security Disclaimer
+
+- Agent presents security disclaimer
+- User must review and accept before proceeding
+
+### Step 2: Clone Source Code
+
+- User provides application source code
+- Accepted formats: Git repository (via AWS CodeConnections) or zip file upload
+- Individual files must not exceed 1 GB; total source code must not exceed 8 GB
+- **Git flow:** Create connector via API (see Connector Setup), complete the HITL task with connector ID, then provide repo name. The agent will ask for the CodeBuild execution role deployment before cloning.
+- **Zip flow:** Upload via `upload_artifact` with `categoryType: "CUSTOMER_INPUT"`
+
+### Step 3: Containerize
+
+- AI agent analyzes source code
+- Generates Docker artifacts (Dockerfiles, related configuration files)
+- This is the core AI-driven analysis step
+- **Before starting analysis, the agent asks about preferences. Present them clearly:**
+  - Show the defaults that will be used if the user just proceeds:
+    1. Base image: Amazon Linux 2023
+    2. Scope: Process all applications in the repository
+    3. Dockerfiles: Reuse existing if present (with minor modifications if needed)
+  - Show the optional customizations available:
+    - Enable private CodeArtifact dependencies (Maven, PyPI, npm)
+    - Enable private ECR base images
+    - Always generate a new Dockerfile (ignore existing ones)
+  - Ask: "Would you like to proceed with defaults, or customize any of these?"
+
+### Step 4: Review Docker Artifacts and Code Changes
+
+- Agent presents generated Dockerfiles and configuration
+- User reviews and approves code changes before proceeding
+- **GATE:** User must approve artifacts before continuing
+
+### Step 5: Publish Images
+
+- Builds container images using AI-driven Docker builds
+- Publishes images to Amazon ECR
+- Automated vulnerability scanning runs on published images
+- Private dependencies (CodeArtifact, private ECR base images) resolved if configured
+
+### Step 6: Generate Infrastructure as Code
+
+- **MANDATORY GATE:** You MUST ask the user which deployment target they want BEFORE proceeding. NEVER assume or infer from earlier context. ECS and EKS are completely different target platforms — do not guess.
+- Ask: "Where do you want to deploy your containerized application? Amazon ECS (Terraform modules) or Amazon EKS (Helm charts)?"
+- Wait for explicit user response before telling the agent which platform to generate IaC for.
+- **EKS:** Generates Helm charts with automated validation and security scanning
+- **ECS:** Generates Terraform modules with automated validation and security scanning
+
+### Step 7: Deploy Test Infrastructure
+
+- The agent creates a HITL task with an infrastructure configuration form
+- The form contains fields with dropdown options (VPCs, subnets, security groups, IAM roles) pulled from the user's AWS account
+- **MANDATORY PRESENTATION FORMAT:** When presenting the infrastructure configuration form:
+  1. First show a **summary table** listing ALL fields, whether each is required or optional, the input type (text, select, multiselect), and a brief description
+  2. Then show each field as a **separate section** with its complete list of ALL available options — never truncate, summarize, or say "see list below"
+  3. For IAM roles: show recognizable/relevant roles in full, then note the count of remaining generic roles grouped by prefix (e.g., "plus 16 StackSet-aws-open-ports roles, 20 migration-factory-test roles")
+  4. If two fields share the same options list (e.g., task_security_group_ids and alb_security_group_ids), you may say "Same options as [field name] above" ONLY after showing the full list for the first field
+  5. **After presenting all options, ask the user for their choice ONE FIELD AT A TIME.** Do not ask for all values at once. Start with the first required field, wait for the answer, then ask for the next.
+- After the user provides all values, submit the form via `complete_task`
+- Deploys test infrastructure for validation
+- User validates the deployment before production cutover
+
+### Step 8: Clean Up Test Infrastructure
+
+- Tears down test resources after validation
+- Ensures no lingering test infrastructure remains
+
+### Step 9: Deploy Cutover Infrastructure
+
+- Deploys finalized production infrastructure
+- Completes the containerization workflow
+- **IMPORTANT: After the agent confirms deployment success, it will show a "Proceed" button. You MUST send "Proceed" to finalize the job.** The job remains in `EXECUTING` status until this acknowledgment is sent. Without it, the job never transitions to `COMPLETE` in the console.
+- After sending "Proceed", verify the agent responds with a completion message (e.g., "The migration job has been marked as complete")
+- Only then is the workflow truly finished
+
+---
+
+## Agents & Transforms
+
+| Agent | How to Discover | Purpose |
+|-------|----------------|---------|
+| VMware Migration Agent (orchestrator) | `list_resources` with `resource: "agents"` | Orchestrates containerization workflow within a VMware migration job |
+| Containerization sub-agent | _(invoked by orchestrator)_ | Source code analysis, Docker artifact generation, image building, IaC generation |
+
+**Discover the agent dynamically:**
+
+```python
+list_resources(resource="agents")
+# Find the VMware migration orchestrator from results
+# Then create job with discovered orchestratorAgent
+create_job(
+  workspaceId="<workspace-id>",
+  jobName="VMware Containerization <timestamp>",
+  objective="Containerize application source code for deployment on ECS/EKS",
+  orchestratorAgent="<discovered>"
+)
+```
+
+**Selection criteria:** Choose the agent whose description mentions "VMware migration" — containerization runs within the VMware migration job context. The orchestrator invokes the containerization sub-agent as needed.
+
+### Job Creation
+
+To start a containerization job:
+
+1. Create a VMware migration job in the workspace
+2. Choose standalone containerization or end-to-end migration with containerize strategy
+3. The agent guides through the 9-step workflow
+
+---
+
+## Connector Setup (Reference)
+
+When the user chooses Git repository in Step 2, the agent creates a HITL task (`GeneralConnector` component, title "Set up Containerization Connector") requesting connector configuration. To complete it programmatically instead of directing the user to the web UI:
+
+### 1. Check for Existing Connector
+
+```python
+list_resources(resource="connectors", workspaceId="<workspace-id>")
+# Filter for connectorType="vmware_migration|containerization|2"
+```
+
+- **If an ACTIVE containerization connector exists** — ask the user: "There's already a containerization connector configured (`<name>`, region `<region>`). Would you like to use it, or create a new one?"
+- **If no containerization connector exists** — proceed to create one.
+
+### 2. Resolve CodeConnections ARN (if user doesn't have it)
+
+```bash
+aws codeconnections list-connections --region <target-region> --query 'Connections[?ConnectionStatus==`AVAILABLE`].[ConnectionName,ConnectionArn]' --output table
+```
+
+- **One connection** — use it.
+- **Multiple connections** — ask the user which one to use.
+- **No connections** — tell the user to create one in the AWS Console: [Developer Tools → Settings → Connections](https://console.aws.amazon.com/codesuite/settings/connections). They must install the GitHub App and grant access to the target repositories.
+
+### 3. Create the Connector (if needed)
+
+```python
+create_connector(
+  workspaceId="<workspace-id>",
+  connectorName="containerization-<region>",
+  connectorType="vmware_migration|containerization|2",
+  configuration={"codeConnectionArn": "<codeconnections-arn>"},
+  awsAccountId="<account-id>",
+  targetRegions=["<target-region>"]
+)
+```
+
+**Key rules:**
+
+- `targetRegions` — **top-level parameter**, NOT inside `configuration`
+- `encryptionKeyArn` — NOT supported for this connector type. Do not pass it.
+- `configuration` cannot be empty — at least `codeConnectionArn` or `mapAgreementId` is required.
+
+### 4. Approve the Connector
+
+Connector approval is human-gated. Present the verification link to the user. Do NOT auto-poll. When user confirms → verify status once via `get_resource(resource="connector")`. Must be ACTIVE before proceeding.
+
+### 5. Complete the HITL Task
+
+Submit the connector ID to bind it to the job:
+
+```python
+complete_task(
+  workspaceId="<workspace-id>",
+  jobId="<job-id>",
+  taskId="<connector-task-id>",
+  content={"connectorId": "<connector-id>"}
+)
+```
+
+Get the task ID from `list_resources(resource="tasks")` — look for title "Set up Containerization Connector".
+
+### After Connector is Accepted
+
+The agent may ask the user to deploy a **CodeBuild execution role** via a CloudFormation stack (skipped if already deployed from a previous job). This is human-gated — present the link and wait for confirmation.
+
+Then the agent asks for the repository name:
+
+- Format: `owner/repo-name` (e.g., `evgenyka/classDemo`)
+- **Do NOT specify a branch** unless certain it exists. Omitting the branch uses the repository's default branch.
+- Repository names are case-sensitive.
+
+### Known Limitations (Connector)
+
+- `targetRegions` must be a top-level parameter — passing `targetRegion` inside `configuration` returns `400: unsupported connector properties`
+- `encryptionKeyArn` is NOT supported for this connector type
+- `configuration` cannot be empty — API rejects it without at least one valid property
+- Agent does not auto-detect existing connectors in a fresh job — must complete the HITL task with the connector ID
+- CodeConnections must have the GitHub App installed with access to the target repositories — a connection in AVAILABLE status without the app installed will fail at clone time
+
+---
+
+## Decision Points
+
+| Step | Question to Ask User | Options |
+|------|---------------------|---------|
+| Mode | "Do you want standalone containerization or end-to-end migration with containerization?" | Standalone / End-to-end migration |
+| Source code | "How would you like to provide your source code?" | Git repository (CodeConnections) / Zip upload |
+| Artifact review | "Do the generated Docker artifacts look correct?" | Approve / Request changes |
+| Private dependencies | "Does your application use private dependencies?" | Configure CodeArtifact / Configure private ECR base images / No private dependencies |
+| Deployment target | "Where do you want to deploy your containerized application?" | Amazon EKS (Helm charts) / Amazon ECS (Terraform modules) |
+| Test validation | "Has the test deployment been validated successfully?" | Proceed to cutover / Re-deploy test / Modify configuration |
+| Cutover | "Ready to deploy production infrastructure?" | Deploy cutover / Go back to test |
+
+---
+
+## Assessment Signals
+
+| File Pattern | What to Look For | Indicates |
+|-------------|-----------------|-----------|
+| `Dockerfile`, `docker-compose.yml` | Existing container configuration | Already partially containerized |
+| `pom.xml`, `build.gradle` | Java build files | Java application — Maven/Gradle build |
+| `package.json` | Node.js project | Node.js application — npm/yarn build |
+| `requirements.txt`, `pyproject.toml`, `setup.py` | Python dependencies | Python application — pip build |
+| `*.csproj`, `*.sln` | .NET project files | .NET application |
+| `.mvn/`, `mvnw` | Maven wrapper | Self-contained Maven build |
+| `Procfile` | Process declarations | Application entry points defined |
+| `application.yml`, `application.properties` | Spring Boot config | Spring Boot application |
+| `web.xml`, `WEB-INF/` | Java EE/Servlet config | Traditional Java web application |
+
+---
+
+## Example Requirements
+
+```
+## Requirement 1: Source Code Containerization
+**User Story:** As a platform engineer, I want my VMware-hosted application containerized
+so that it can run on Amazon EKS or Amazon ECS.
+**Acceptance Criteria:**
+1. WHEN containerization completes, a Dockerfile SHALL be generated for each application component
+2. WHEN containerization completes, container images SHALL be published to Amazon ECR
+3. WHEN containerization completes, vulnerability scanning SHALL report no critical findings
+**Handled by:** AWS Transform VMware Migration Agent (Containerization sub-agent)
+
+## Requirement 2: Infrastructure as Code Generation
+**User Story:** As a DevOps engineer, I want deployment infrastructure generated
+so that I can deploy containerized applications to my target platform.
+**Acceptance Criteria:**
+1. WHEN IaC generation completes for EKS, Helm charts SHALL be generated with security scanning passed
+2. WHEN IaC generation completes for ECS, Terraform modules SHALL be generated with validation passed
+3. WHEN IaC generation completes, deployment templates SHALL include all required service configurations
+**Handled by:** AWS Transform VMware Migration Agent (Containerization sub-agent)
+
+## Requirement 3: Test and Cutover Deployment
+**User Story:** As an operations engineer, I want to validate containerized deployments
+before production cutover so that I can confirm application behavior.
+**Acceptance Criteria:**
+1. WHEN test deployment completes, application SHALL be accessible and functional
+2. WHEN test infrastructure is cleaned up, no orphaned resources SHALL remain
+3. WHEN cutover deployment completes, production infrastructure SHALL match validated test configuration
+**Handled by:** AWS Transform VMware Migration Agent (Containerization sub-agent) + User validation
+```
+
+---
+
+## Example Tasks
+
+```
+- [ ] 1. Setup (AWS Transform)
+  - [ ] 1.1 Create VMware migration job
+  - [ ] 1.2 Select containerization mode (standalone or end-to-end)
+  - [ ] 1.3 Review and accept security disclaimer
+- [ ] 2. Source code provisioning
+  - [ ] 2.1 Provide source code (Git repo or zip upload)
+  - [ ] 2.2 Configure private dependencies (if applicable)
+- [ ] 3. Containerization (AWS Transform)
+  - [ ] 3.1 AI agent analyzes source code
+  - [ ] 3.2 Review generated Docker artifacts
+  - [ ] 3.3 Approve code changes
+- [ ] 4. Image publishing
+  - [ ] 4.1 Build container images
+  - [ ] 4.2 Publish to Amazon ECR
+  - [ ] 4.3 Review vulnerability scan results
+- [ ] 5. Infrastructure as Code generation
+  - [ ] 5.1 Select deployment target (EKS or ECS)
+  - [ ] 5.2 Generate IaC (Helm charts or Terraform modules)
+  - [ ] 5.3 Review generated infrastructure templates
+- [ ] 6. Test deployment
+  - [ ] 6.1 Deploy test infrastructure
+  - [ ] 6.2 Validate application behavior
+  - [ ] 6.3 Clean up test infrastructure
+- [ ] 7. Production cutover
+  - [ ] 7.1 Deploy cutover infrastructure
+  - [ ] 7.2 Verify production deployment
+  - [ ] 7.3 Confirm migration complete
+```
+
+---
+
+## Approvals (Web UI Required)
+
+Certain steps require manual approval through the AWS Transform web console. These are `TOOL_APPROVAL` category tasks that cannot be completed via the MCP API.
+
+**Steps that require web UI approval:**
+
+- Step 5: Publish images to ECR
+- Step 7: Deploy test infrastructure
+- Step 8: Clean up test infrastructure
+- Step 9: Deploy cutover infrastructure
+
+**How to construct the approval URL:**
+
+The console approval URL follows this pattern:
+
+```
+<origin>/workspaces/<workspaceId>/jobs/<jobId>/approvals
+```
+
+Where:
+
+- `<origin>` is the Transform application URL from the auth configuration (get via `get_status().fes.origin`)
+- `<workspaceId>` is the current workspace ID
+- `<jobId>` is the current job ID
+
+Example:
+
+```
+https://7223639b0ed85fd08.transform.us-east-1.on.aws/workspaces/285f85b9-b109-459a-9aeb-f83542addc0b/jobs/d1800414-458b-4016-9d11-9881319a9954/approvals
+```
+
+**When presenting an approval to the user:**
+
+1. **NEVER preemptively tell the user an approval is needed.** Only present the approval link AFTER you have confirmed the agent has actually requested it (by seeing a message containing "approval" or "approve" from the agent).
+2. Call `get_status()` to get the `origin` URL
+3. Construct the full URL: `<origin>/workspaces/<workspaceId>/jobs/<jobId>/approvals`
+4. Present the direct link to the user
+5. Tell the user which specific approval is pending (e.g., "Publish 2 images to Amazon ECR")
+6. Wait for the user to confirm they've approved, or check messages to verify
+7. Then check for new messages to confirm the agent has proceeded
+
+---
+
+## Known Limitations
+
+- Containerization is accessed through a VMware migration job — cannot be started independently outside that context
+- Individual source files must not exceed 1 GB; total source code must not exceed 8 GB
+- Private dependencies require pre-configured AWS CodeArtifact repositories or private ECR base images
+- EKS deployments require an existing cluster or permissions to create one
+- Vulnerability scanning may flag issues that require Dockerfile modifications before proceeding
+- AI-generated Dockerfiles may need manual tuning for complex multi-stage builds or non-standard application structures
+- The agent handles Docker artifact generation — do not attempt manual Dockerfile creation within this workflow
+- **TOOL_APPROVAL tasks cannot be approved via the MCP API.** Steps that require `TOOL_APPROVAL` (image publishing, infrastructure deployment, cleanup) must be approved in the web UI. The `complete_task` API returns `HTTP 400: TOOL_APPROVAL tasks cannot submit human artifacts` for these tasks.

--- a/aws-transform/steering/workload-vmware-landing-zone.md
+++ b/aws-transform/steering/workload-vmware-landing-zone.md
@@ -1,0 +1,456 @@
+# Landing Zone
+
+> **Last Updated:** 2026-05-10
+
+## Capabilities
+
+Build an AWS landing zone as the foundation for your migration project. AWS Transform analyzes your migration inventory and business requirements to recommend an Organizational Unit (OU) and account structure, apply Service Control Policies (SCPs), and generate or deploy the infrastructure as code (IaC).
+
+The landing zone agent operates in two phases:
+
+1. **Foundation setup** — Establish the core landing zone: AWS Control Tower, foundational OUs (Security, Infrastructure, Sandbox, Workloads), and core accounts (Log Archive, Audit).
+2. **Workload account design** — Design and create workload OUs and accounts based on migration waves, business units, and environment separation requirements.
+
+AWS Transform supports both **greenfield** (no existing landing zone) and **brownfield** (existing OUs and accounts already deployed) environments. In brownfield scenarios, AWS Transform detects the existing organization structure and recommends only the changes needed to fill gaps against AWS best practices.
+
+## Starting Workflow
+
+1. **Connector setup** — Create a target AWS account connector pointing to the organization management account in the Control Tower home Region
+2. **Confirm organization context** — AWS Transform retrieves the connector configuration and presents the management account ID and target Region for confirmation
+3. **Foundation setup** — Design and deploy (or generate IaC for) the core OU structure, Control Tower initialization, and SCPs
+4. **Workload account design** — Answer discovery questions; AWS Transform proposes OU and account structure based on migration waves and business requirements
+5. **Workload deployment** — Deploy workload OUs, accounts, and SCPs, or download IaC artifacts
+
+**Key questions to ask user:**
+
+- "Do you already have AWS Control Tower or AWS Organizations set up (brownfield), or are we starting from scratch (greenfield)?"
+- "What is your Control Tower home Region? This must match your IAM Identity Center Region."
+- "What email prefix and domain should AWS Transform use to generate account email addresses (for example, `aws-admin` and `acme.com`)?"
+- "How many business units or teams will use AWS, and do they need separate accounts?"
+- "Do you have compliance requirements (HIPAA, PCI-DSS, SOC2, FedRAMP) that affect account isolation?"
+- "Do you have migration planning data (wave plans, server-to-application mappings) already in AWS Transform?"
+
+---
+
+## Agent Monitoring Behavior
+
+Throughout the entire landing zone flow, the agent MUST proactively pull status and report progress to the user after every significant action. Do not wait for the user to ask.
+
+**Rules:**
+
+- **After triggering any operation** (connector creation, Control Tower initialization, OU/account creation, SCP application, deployment submission) — immediately begin polling and report status updates as they arrive
+- **After each poll** — present a concise status summary: what completed, what is in progress, what is blocked, and what the next step is
+- **During long-running operations** (Control Tower initialization, CloudFormation stack deployment, account creation) — poll on a regular cadence and proactively surface progress
+- **When a deployment approval is required** — surface it immediately, inform the user it is pending, and wait for the user to confirm approval has been granted. Then verify once.
+- **When a HITL task appears** — surface it immediately, do not wait for the user to notice
+- **When an error or failure occurs** — surface it immediately with the failure reason and suggested resolution
+
+**Per-step monitoring expectations:**
+
+| Step | What to Poll | What to Report |
+|------|-------------|----------------|
+| Connector setup | Connector status | Connector ACTIVE, management account ID and Region confirmed |
+| Control Tower initialization | CloudFormation stack status | Stack creation complete, Control Tower initialized |
+| Foundation OU/account creation | Deployment job status | OUs created, Log Archive and Audit accounts provisioned |
+| SCP application | SCP assignment status | SCPs applied, updated organization tree |
+| Workload OU/account creation | Deployment job status | OUs and accounts created in correct locations |
+| IaC generation | Artifact availability | Artifacts ready for download, checksum provided |
+| Deployment approval | Approval task status | Approved → deployment proceeds; Denied → surface reason and offer to resubmit |
+
+---
+
+## Prerequisites
+
+Before starting landing zone setup, the following must be in place:
+
+- **Target AWS account connector** — A connector configured for the organization management account. The connector Region must match the Control Tower home Region and the IAM Identity Center Region.
+- **Management account** — The AWS Organizations root account. All OUs and accounts are created under this account.
+- **Email convention** — A prefix and domain for plus-addressed account emails (for example, `aws-admin+<account-name>@acme.com`). AWS Transform derives all account emails automatically from this convention.
+
+> **IAM Identity Center Region dependency** — The connector Region must match both the Control Tower home Region and the IAM Identity Center Region. If IAM Identity Center is already configured in your organization, Control Tower initialization will fail if the connector targets a different Region.
+
+> In brownfield scenarios, AWS Transform inspects existing account emails to infer the plus-addressing convention already in use and offers to continue with the same pattern.
+
+---
+
+## Connector Setup
+
+The landing zone agent requires a target AWS account connector to provision resources in the organization management account.
+
+The connector has permissions to:
+
+- Set up AWS Control Tower
+- Create organizational units and accounts
+- Configure Service Control Policies (SCPs)
+
+Permissions are scoped to resources tagged with `CreatedBy: AWSTransform` and `ATWorkspace: {workspace-id}` where applicable, and cover:
+
+- S3 bucket operations for buckets starting with `transform-vmware-landing-zone-`
+- CloudFormation stack deployments and change set management
+- AWS Control Tower operations (managing landing zones, enabling baselines and controls)
+- AWS Organizations management (creating and managing OUs, creating accounts, moving accounts)
+- SCP management via AWS Control Tower
+- AWS Service Catalog provisioning artifact management
+
+The connector requires a real KMS key ARN — resolve it before creating:
+
+```bash
+aws kms describe-key --key-id alias/aws/s3 --region <control-tower-home-region> --query 'KeyMetadata.Arn' --output text
+```
+
+```python
+create_connector(
+  workspaceId="<workspace-id>",
+  connectorName="landing-zone-connector",
+  connectorType="<landing-zone-connector-type>",   # discover via list_resources
+  configuration={"encryptionKeyArn": "<real-kms-key-arn>"},
+  awsAccountId="<management-account-id>",
+  targetRegions=["<control-tower-home-region>"]
+)
+# → Present verification link to user for approval via AWS Console
+# → Connector approval is human-gated — do NOT auto-poll
+# → When user confirms approval, verify status once via get_resource(resource="connector")
+```
+
+Always use the verification link to approve — this creates a fresh IAM role with the correct permissions. Reusing a role from a deleted connector may have permissions on the wrong key.
+
+---
+
+## Workflow
+
+### Phase 1: Foundation Setup
+
+#### Step 1: Design Foundation Structure
+
+AWS Transform recommends the following foundation OU structure based on AWS best practices. The user can customize it before creation.
+
+**Recommended foundation OUs:**
+
+| OU | Purpose | Accounts |
+|----|---------|----------|
+| Security | Centralized audit logging and monitoring. Isolates audit trail from workload teams. | Audit, Log Archive |
+| Infrastructure | Shared networking (Transit Gateway, VPN), DNS, and common services. | None (created empty) |
+| Sandbox | Developer experimentation with spending limits and restricted access. | Sandbox |
+| Workloads | Contains Production, Non-Production, and optionally Regulated sub-OUs. Populated in Phase 2. | None (created empty) |
+
+> The Security OU with Audit and Log Archive accounts is created as part of the Control Tower foundation setup. Infrastructure, Sandbox, and Workloads OUs are created separately after the user confirms the structure.
+
+> **The Security OU is managed by Control Tower.** You cannot add accounts, SCPs, or any resources to it through the landing zone agent.
+
+**In brownfield scenarios:** AWS Transform compares the existing foundation against this recommended structure and reports only the gaps. For example: "Your foundation has Security and Infrastructure OUs but no Sandbox OU."
+
+#### Step 2: Control Tower Initialization
+
+AWS Transform checks whether AWS Control Tower is already initialized.
+
+**If Control Tower is not yet initialized:**
+
+- AWS Transform provides a link to the AWS Transform console page
+- Generating the operation in the link creates a CloudFormation stack to bootstrap Control Tower in the target Region
+- After the stack creation completes, AWS Transform continues with the deployment
+
+**What Control Tower provisions automatically:**
+
+- Root — top-level parent containing all OUs
+- Security OU — with Log Archive account (centralized, immutable logging) and Audit account (read-only access for security and compliance review)
+- Mandatory guardrails — preventive and detective controls applied across the organization; cannot be disabled
+- IAM Identity Center directory — cloud-native directory with preconfigured groups and SSO access
+
+> Control Tower uses CloudFormation StackSets to deploy and manage resources consistently across all accounts and Regions. Do not modify or delete Control Tower managed resources outside of supported methods.
+
+#### Step 3: Account Email Convention
+
+AWS Transform uses plus addressing to generate unique account emails from a single mailbox.
+
+**Format:** `prefix+account-name@domain`
+
+The user provides a prefix (for example, `aws-admin`) and a domain (for example, `acme.com`). AWS Transform derives all account emails automatically:
+
+- Audit account: `aws-admin+audit@acme.com`
+- Log Archive account: `aws-admin+log-archive@acme.com`
+- Sandbox account: `aws-admin+sandbox@acme.com`
+
+#### Step 4: Service Control Policies (SCPs) — Foundation
+
+SCPs set the maximum permissions for all accounts in an OU. They don't grant access — they define boundaries that no one in the account can exceed, even account administrators.
+
+Control Tower applies baseline guardrails automatically. AWS Transform also recommends additional SCPs based on AWS best practices for a minimum viable landing zone.
+
+SCPs can be applied to the Infrastructure, Sandbox, and Workloads OUs. **The Security OU cannot be targeted by SCPs through this tool.**
+
+**In brownfield scenarios:** AWS Transform checks which SCPs are already applied and only recommends ones that fill gaps.
+
+#### Step 5: Foundation Deployment
+
+After the foundation design is confirmed, the user chooses how to deploy:
+
+| Option | Description |
+|--------|-------------|
+| Deploy for me | AWS Transform deploys the foundation OUs, accounts, and SCPs to the AWS Organization |
+| I'll deploy on my own | AWS Transform generates IaC artifacts for download (CDK or LZA — see IaC Formats) |
+| Design workload accounts first | Skip deployment and continue to Phase 2; deploy everything together later |
+
+> All deployment requests require explicit approval. See Deployment Approvals below.
+
+---
+
+### Phase 2: Workload Account Design
+
+#### Step 6: Migration Planning Context
+
+Before asking discovery questions, check the artifact store for migration planning outputs from a prior job in the same workspace. Migration planning artifacts contain wave plans and server-to-application mappings that drive the workload account structure.
+
+```python
+# 1. List artifacts scoped to migration planning outputs
+list_resources(resource="artifacts",
+  workspaceId="<workspace-id>",
+  pathPrefix="migration-planning/")
+
+# 2. If artifacts are found, download the relevant ones
+get_resource(resource="artifact",
+  workspaceId="<workspace-id>",
+  artifactId="<artifact-id>",
+  savePath="/tmp/migration-plan.json"   # or .csv/.zip depending on artifact type
+)
+```
+
+**If migration planning artifacts are found:** Display a summary of the wave plan and server-to-application mappings, then ask the user to confirm or adjust before proceeding to workload structure design.
+
+**If no migration planning artifacts are found:** Proceed directly to Step 7 (Discovery) and ask the discovery questions to gather the same information manually.
+
+> Migration planning artifacts are produced by the VMware migration planning phase. If the user ran discovery and wave planning in a separate job or workspace, ask them to confirm the workspace ID so the correct artifacts can be retrieved.
+
+#### Step 7: Discovery
+
+AWS Transform asks questions to understand workload requirements. Any question can be skipped. Topics include:
+
+- Number of business units or teams using AWS
+- Industry and applicable compliance frameworks (HIPAA, PCI-DSS, SOC2, FedRAMP)
+- Whether workloads handle sensitive data (PII, PHI, financial)
+- Environment separation preferences (dev/test/staging/prod as separate accounts or shared)
+- Workload isolation requirements
+- Business applications and their purposes
+- Server grouping into applications
+- Cost tracking and allocation needs (by business unit, project, environment)
+- Expected growth in the next 12–24 months
+- Account strategy preference (single app per account, grouped, or environment-based)
+
+#### Step 8: Proposed Workload Structure
+
+Based on discovery answers and migration planning data, AWS Transform proposes an OU and account structure under the Workloads OU, including the reasoning behind each design decision.
+
+**Design principles AWS Transform follows:**
+
+| Principle | Detail |
+|-----------|--------|
+| Wave integrity | All servers in a migration wave go to the same account — waves cannot be split across accounts (rehost limitation during wave execution) |
+| Environment isolation | If isolated environments are requested, AWS Transform creates `Workloads/Production` and `Workloads/Non-Production` sub-OUs |
+| Compliance isolation | If applicable frameworks are identified, AWS Transform creates `Workloads/Regulated` and `Workloads/Standard` sub-OUs |
+| Business unit separation | If multiple business units require different governance, AWS Transform creates business-unit-specific OUs under Workloads |
+| Sensitive data isolation | Critical or sensitive-data applications get a single app per account — may require iterating on the wave plan |
+| Dependency grouping | Tightly coupled applications with shared dependencies are grouped in one account |
+
+Each proposed account includes: name, purpose, target OU, and business unit. AWS Transform shows the naming convention in use (for example, `<business-unit>-<environment>-<workload>`).
+
+The user can review and modify the proposed structure before AWS Transform applies changes. After applying, the user can iterate — making additional changes until satisfied.
+
+#### Step 9: Workload SCPs
+
+After the workload structure is created, AWS Transform presents available SCPs and asks if any should be applied to workload OUs. The user selects which SCPs to apply and to which OUs. AWS Transform applies the SCPs and shows the updated organization tree with an SCP summary table.
+
+#### Step 10: Workload Deployment
+
+After the workload design is confirmed, the user chooses how to deploy:
+
+| Option | Description |
+|--------|-------------|
+| Deploy for me | AWS Transform deploys the workload OUs, accounts, and SCPs to the AWS Organization |
+| I'll deploy on my own | AWS Transform generates IaC artifacts for download (CDK or LZA — see IaC Formats) |
+
+> All deployment requests require explicit approval. See Deployment Approvals below.
+
+---
+
+## IaC Formats
+
+When the user chooses self-deployment, AWS Transform generates IaC artifacts in the following formats:
+
+| Format | Description |
+|--------|-------------|
+| AWS CDK | TypeScript project for programmatic infrastructure deployment |
+| Landing Zone Accelerator (LZA) | Configuration YAML files based on LZA Universal Configuration version 1.1.0. Works with the Landing Zone Accelerator on AWS to establish multi-account environments with pre-configured governance, organization structure, and networking aligned to AWS best practices |
+
+> When deploying via the LZA pipeline, the AWS Transform account and LZA installation must be in the same AWS Organization. Deployment will fail if there is a mismatch between the Organizations IDs used in AWS Transform and LZA.
+
+**Verifying downloaded artifacts:**
+
+```bash
+openssl dgst -sha256 -binary <file.zip> | base64
+```
+
+Compare the output to the checksum provided by AWS Transform to verify the file hasn't been corrupted or tampered with.
+
+---
+
+## Deployment Approvals
+
+When the user selects AWS Transform-managed deployment:
+
+1. **Submission** — Power confirms deployment intent; AWS Transform submits CloudFormation templates for review
+2. **Routing** — Request routes automatically to authorized approvers via the AWS Transform Approvals tab
+3. **Review** — Approvers validate CloudFormation templates and landing zone configurations against security standards
+4. **Decision** — Approver approves or denies:
+   - **Approved** → deployment proceeds automatically
+   - **Denied** → inform user, suggest contacting approver for required modifications
+5. **Audit** — All approval decisions are tracked for audit purposes
+
+Only users with the **Admin** or **Approver** role in AWS Transform can approve deployment requests. Each submission triggers a new review cycle.
+
+**Power behavior during approval:**
+
+- After submission, inform the user that the deployment requires approval
+- Deployment approval is human-gated — do NOT auto-poll. Present the pending status and wait for the user to confirm approval has been granted, then verify once.
+- If denied, present the denial to the user and offer to modify the landing zone design and resubmit
+
+**Rollback:** Once OUs and accounts are deployed, they cannot be removed through the landing zone agent. Account structure decisions are difficult to reverse — validate in non-production environments first. Manual deletion via the AWS Console or CLI is required if changes need to be undone.
+
+---
+
+## Reversing Changes
+
+Only non-deployed elements can be removed. Once an OU or account is deployed, it cannot be removed through the landing zone agent.
+
+When removing elements, order matters:
+
+1. Remove accounts first (by email)
+2. Remove SCPs from OUs
+3. Remove child OUs — an OU cannot be removed if it still has accounts or nested OUs
+
+---
+
+## Resource Tagging
+
+AWS Transform automatically tags all generated resources:
+
+| Tag | Value |
+|-----|-------|
+| `CreatedBy` | `AWSTransform` |
+| `ATWorkspace` | Workspace identifier |
+
+> If the migration is part of the AWS Migration Acceleration Program (MAP 2.0), the MAP tag (`map-migrated: migMPE_ID`) can be included. It is requested during connector setup and applied during landing zone deployment.
+
+---
+
+## Agents & Transforms
+
+| Agent | How to Discover | Purpose |
+|-------|----------------|---------|
+| Landing zone agent | `list_resources` with `resource: "agents"` | Foundation setup, workload account design, SCP configuration, IaC generation |
+
+**Discover the agent dynamically:**
+
+```python
+list_resources(resource="agents")
+# Or ask the chat agent
+send_message(workspaceId="...", text="What agents are available for landing zone setup?")
+# Then create job with discovered orchestratorAgent
+create_job(workspaceId="...", jobName="Landing Zone Setup",
+  objective="Build AWS landing zone foundation and workload account structure",
+  orchestratorAgent="<discovered>")
+```
+
+---
+
+## Decision Points
+
+| Decision | Options | When to Ask |
+|----------|---------|-------------|
+| Greenfield vs brownfield | Greenfield (new) / Brownfield (existing OUs/accounts) | Start — determines what gaps to fill |
+| Deployment method | Deploy for me / I'll deploy on my own / Design workload accounts first | Phase 1 Step 5 |
+| Deployment method (workload) | Deploy for me / I'll deploy on my own | Phase 2 Step 10 |
+| IaC format (if self-deploying) | AWS CDK / Landing Zone Accelerator (LZA) | When user selects "I'll deploy on my own" |
+| Foundation OU customization | Accept recommended structure / Customize OUs and accounts | Phase 1 Step 1 |
+| SCP selection | Which SCPs to apply and to which OUs | Phase 1 Step 4 and Phase 2 Step 9 |
+| Account strategy | Single app per account / Grouped / Environment-based | Phase 2 Step 7 discovery |
+| Environment separation | Separate accounts per env / Shared accounts | Phase 2 Step 7 discovery |
+| Compliance sub-OUs | Regulated / Standard separation | Phase 2 Step 8 — if frameworks identified |
+
+---
+
+## Example Requirements
+
+```
+## Requirement 1: Foundation Setup
+**User Story:** As a cloud platform engineer, I want the core landing zone foundation deployed
+so that governance controls, centralized logging, and account isolation are in place before any workloads arrive.
+**Acceptance Criteria:**
+1. WHEN foundation setup completes, Control Tower SHALL be initialized with Security OU, Log Archive account, and Audit account
+2. WHEN foundation setup completes, Infrastructure, Sandbox, and Workloads OUs SHALL exist in the organization
+3. WHEN SCPs are applied, member accounts SHALL be unable to exceed the boundaries defined by the SCPs
+**Handled by:** AWS Transform Landing Zone Agent
+
+## Requirement 2: Workload Account Structure
+**User Story:** As a cloud platform engineer, I want workload OUs and accounts designed around my migration waves
+so that servers can be migrated into correctly isolated accounts without splitting waves.
+**Acceptance Criteria:**
+1. WHEN workload structure is proposed, ALL servers in a migration wave SHALL map to the same target account
+2. WHEN environment isolation is required, Workloads/Production and Workloads/Non-Production sub-OUs SHALL be created
+3. WHEN sensitive-data applications are identified, they SHALL each receive a dedicated account
+**Handled by:** AWS Transform Landing Zone Agent
+
+## Requirement 3: IaC Generation
+**User Story:** As a platform engineer, I want IaC artifacts generated for the landing zone
+so that I can review, version-control, and deploy the infrastructure through my own pipeline.
+**Acceptance Criteria:**
+1. WHEN IaC generation completes, artifacts SHALL be available in CDK (TypeScript) or LZA (YAML) format
+2. WHEN artifacts are downloaded, a checksum SHALL be provided to verify file integrity
+3. WHEN LZA format is selected, the generated YAML SHALL be compatible with LZA Universal Configuration version 1.1.0
+**Handled by:** AWS Transform Landing Zone Agent
+```
+
+---
+
+## Example Tasks
+
+```
+- [ ] 1. Connector setup
+  - [ ] 1.1 Create target AWS account connector for the management account
+  - [ ] 1.2 Confirm connector Region matches Control Tower home Region and IAM Identity Center Region
+  - [ ] 1.3 Approve connector via AWS Console verification link
+  - [ ] 1.4 Confirm management account ID and target Region presented by AWS Transform
+- [ ] 2. Foundation design (Phase 1, Steps 1–4)
+  - [ ] 2.1 Review recommended foundation OU structure (Security, Infrastructure, Sandbox, Workloads)
+  - [ ] 2.2 Customize OU structure if needed
+  - [ ] 2.3 Confirm email prefix and domain for plus-addressed account emails
+  - [ ] 2.4 Review and select SCPs to apply to foundation OUs
+- [ ] 3. Foundation deployment (Phase 1, Step 5)
+  - [ ] 3.1 Choose deployment method (deploy / self-deploy / design workload accounts first)
+  - [ ] 3.2 If Control Tower not initialized: follow link to create bootstrap CloudFormation stack
+  - [ ] 3.3 Submit deployment for approval; wait for Admin approval
+  - [ ] 3.4 Confirm Log Archive and Audit accounts created in Security OU
+  - [ ] 3.5 Confirm Infrastructure, Sandbox, and Workloads OUs created
+- [ ] 4. Workload account design (Phase 2, Steps 6–9)
+  - [ ] 4.1 Check artifact store for migration planning artifacts (`pathPrefix="migration-planning/"`)
+  - [ ] 4.2 If found: display wave plan summary and confirm or adjust with user; if not found: proceed to discovery questions
+  - [ ] 4.3 Answer discovery questions (business units, compliance, environment separation, account strategy)
+  - [ ] 4.4 Review proposed workload OU and account structure
+  - [ ] 4.5 Iterate on structure until satisfied
+  - [ ] 4.6 Review and select SCPs to apply to workload OUs
+- [ ] 5. Workload deployment (Phase 2, Step 10)
+  - [ ] 5.1 Choose deployment method (deploy / self-deploy)
+  - [ ] 5.2 If self-deploying: select IaC format (CDK or LZA), download artifacts, verify checksum
+  - [ ] 5.3 If deploying via AWS Transform: submit for approval; wait for Admin approval
+  - [ ] 5.4 Confirm all workload OUs and accounts created in correct locations
+```
+
+---
+
+## Known Limitations
+
+- Once an OU or account is deployed, it cannot be removed through the landing zone agent — account structure decisions are difficult to reverse
+- The Security OU is managed by Control Tower — accounts, SCPs, and resources cannot be added to it through the landing zone agent
+- All servers in a migration wave must go to the same account — waves cannot be split across accounts during rehost execution
+- The connector Region must match the Control Tower home Region and the IAM Identity Center Region — mismatches cause Control Tower initialization to fail
+- LZA deployment requires the AWS Transform account and LZA installation to be in the same AWS Organization
+- SCPs cannot grant permissions — they only restrict what IAM policies allow
+- Brownfield environments may require remediation before Control Tower can be initialized — AWS Transform reports gaps but does not automatically fix pre-existing misconfigurations

--- a/aws-transform/steering/workload-vmware-network.md
+++ b/aws-transform/steering/workload-vmware-network.md
@@ -1,0 +1,463 @@
+# VMware Network Migration
+
+> **Last Updated:** 2026-05-05
+
+## Capabilities
+
+Migrate on-premises network infrastructure to AWS. Translates source environment configuration into AWS-equivalent network resources — VPCs, subnets, security groups, NAT gateways, transit gateways, elastic IPs, routes, and route tables.
+
+- Network segments → AWS VPCs + subnets
+- Firewall rules → AWS Security Groups
+- Routing → AWS Transit Gateway (Hub and Spoke) or VPC route tables (Isolated)
+- Review and modify generated network configuration before deployment
+- VPC operations: rename, resize, merge, split, delete, exclude/include, change IP address
+- Subnet operations: resize, delete, change IP address
+- Security group referencing (within-VPC and cross-VPC/cross-account)
+- IP migration: keep existing ranges or update to new CIDRs, static or DHCP assignment
+- Guided network recommendations (naming, right-sizing, consolidation, security review)
+- Creates network diagrams (PNG and Mermaid)
+- Custom tags, MAP 2.0 tags, and automatic launch/replication tags
+- Deploy the network using AWS CloudFormation with approval workflow
+- Run reachability analysis on deployed VPCs
+- Delete deployed network resources (rollback)
+- Generates CloudFormation, CDK (TypeScript), Terraform, or Landing Zone Accelerator IaC
+
+### Supported Source Formats
+
+| Format | Produces |
+|--------|----------|
+| VMware NSX export (.zip) | VPCs + subnets + security groups |
+| Cisco ACI | VPCs + subnets + security groups |
+| Palo Alto Networks | VPCs + subnets + security groups |
+| Fortinet FortiGate | VPCs + subnets + security groups |
+| RVTools (.xlsx/.zip) | VPCs + subnets only (no security groups) |
+| modelizeIT | VPCs + subnets + security groups (hybrid environments) |
+
+### Topology Options
+
+| Topology | When to use |
+|----------|-------------|
+| **Hub and Spoke** | Multi-tier apps, cross-VPC traffic, shared services, centralized egress/ingress. Creates Transit Gateway + Inspection/Outbound/Inbound VPCs. |
+| **Isolated VPCs** | Independent workloads with no cross-VPC communication. Each VPC gets its own internet gateway. |
+
+### Security Group Strategies
+
+| Strategy | When to use |
+|----------|-------------|
+| **MAP** | Static IP environments. Translates source firewall rules to SGs with IP-based rules. |
+| **MAP_DHCP** | Dynamic IP / DHCP environments. Produces broader rules to accommodate IP changes. Use with Transit Gateway. |
+| **SKIP** | Manual SG configuration post-migration. Use when source rules are too complex or need redesign. |
+
+---
+
+## Workflow
+
+The network migration workflow is one sequence across three phases — Phase 1's 5 steps, Phase 2's 9 steps, and Phase 3's 4 steps run in order (18 steps total). Each phase's numbering restarts at 1, but the phases execute sequentially without gaps.
+
+### Phase 1: Target Account Setup
+
+1. Select "Network Migration" workflow
+2. Confirm plan → "Proceed"
+3. Select migration type: Single-account or Multi-account
+4. MAP agreement (optional)
+5. Configure connector (HITL task) — must include `connectorType` in payload
+
+### Phase 2: Network Migration
+
+1. Upload source file (NSX export, RVTools, etc.) — requires `planStepId` in `upload_artifact`
+2. Select topology: Hub and Spoke or Isolated VPCs
+3. Select security group strategy: MAP, MAP_DHCP, or SKIP
+4. Agent presents configuration summary — **this is NOT the mapping step**
+5. User confirms → mapping actually begins (2-5 min)
+6. Guided Modernization or Direct Edits
+7. Apply changes → IaC regeneration
+8. Done with network design
+9. Network diagram generation (image + Mermaid)
+
+### Confirmation Before Mapping
+
+After the user selects topology and security group strategy, the agent presents a configuration summary and asks for confirmation before starting the actual network mapping. Do NOT tell the user that mapping has started until the user confirms and the agent explicitly begins the mapping process.
+
+The sequence is:
+
+1. Select topology → agent acknowledges
+2. Select security group strategy → agent presents **configuration summary** with all selections
+3. User confirms "Yes, start network mapping" → mapping actually begins (2-5 min)
+
+The summary step is NOT the mapping step. Do not conflate them.
+
+### Polling and Waiting
+
+Network-specific polling cadence: every 30 seconds for machine-gated steps (mapping, job processing, agent responses). For general polling principles, see `workload-vmware.md` → Agent Monitoring Behavior.
+
+### Phase 3: Deployment
+
+1. Tagging (optional)
+2. Deployment strategy: self-deploy or AWS Transform deploy
+3. Additional IaC format selection (CDK, Terraform, LZA)
+4. Download artifacts
+
+### Artifact Handling
+
+The job generates several artifact types. Each has different download behavior:
+
+| Artifact | Location | Download Behavior |
+|----------|----------|-------------------|
+| **Network diagram** (PNG, Mermaid) | Managed artifact store | **Always download automatically** — use `get_resource(resource="artifact", savePath=...)` to save to the user's Downloads directory (full absolute path). Never send the user to the web console for diagrams. |
+| **IaC files** (CloudFormation, Terraform, CDK, LZA) | Connector S3 bucket (`code_generation/` prefix) | **Ask the user** — present the S3 console link, then ask if they want a local copy. If yes, run `aws s3 cp` recursively to a local directory (full absolute path). |
+| **Checksums** | Inline in agent message (text) | **No download needed** — checksums are presented as text in the agent's response. Present them to the user as-is. |
+
+**Diagram download (mandatory, via `aws-transform-mcp`):**
+
+> Note: `get_resource` is an `aws-transform-mcp` wrapper tool — not the platform's native `create_artifact_download_url` + `download_artifact` flow. It accepts `savePath` (full file path), not `output_dir`.
+
+```python
+get_resource(resource="artifact", artifactId="<id>", savePath="/Users/<username>/Downloads/network_diagram.png")
+```
+
+**IaC download (user choice):**
+
+```bash
+aws s3 cp s3://<bucket>/<prefix>code_generation/ ~/Downloads/network-iac/ --recursive --region us-east-1
+```
+
+Extract the bucket name and prefix from the S3 link in the agent's response. Requires AWS CLI configured with access to the target account.
+
+### Connector Setup
+
+The VMware Migration Agent creates a HITL task requesting connector configuration. Two steps are needed:
+
+**Step A: Create the connector** (via `aws-transform-mcp` server's `create_connector` tool):
+
+> Note: `aws-transform-mcp` is a wrapper MCP server that provides a unified interface over the platform's customer-facing and agentic APIs. Tool names and parameters may differ from the underlying platform tools.
+
+```python
+create_connector(
+  workspaceId="<workspace-id>",
+  connectorName="network-migration-connector",
+  connectorType="vmware_migration|infra_provisioning|2",  # Registered partner type in ConnectorTypeConfigurationProvider; not in base enum (S3|CODE_CONNECTION). Do not use arbitrary values.
+  configuration={"encryptionKeyArn": "<kms-key-arn>"},  # MCP wrapper accepts encryptionKeyArn (rejects kmsKeyArn); maps to platform's KMS_KEY_ARN_KEY internally
+  awsAccountId="<account-id>",
+  targetRegions=["us-east-1"]
+)
+```
+
+Resolve the KMS key ARN beforehand:
+
+```bash
+aws kms describe-key --key-id alias/aws/s3 --region us-east-1 --query 'KeyMetadata.Arn' --output text
+```
+
+After creation, the user must approve via the verification link returned in the response. This creates an IAM role with correct permissions. Once the user confirms approval, verify status via `get_resource(resource="connector")`.
+
+**Prerequisites for approval:** The user must be logged into the target AWS account in their browser before opening the verification link. If not logged in, the console will redirect to a sign-in page.
+
+**Connector approval is human-gated** — do NOT auto-poll. Instead:
+
+1. Present the verification link to the user
+2. Ask the user to confirm once they've approved
+3. When user confirms → check status once via `get_resource(resource="connector")`
+4. If `ACTIVE` → proceed. If still `PENDING` → remind them to approve. If `REJECTED` → report error.
+
+**Step B: Complete the HITL task** (via `complete_task`):
+
+- Submit the connector ID and `connectorType: "vmware_migration|infra_provisioning|2"` in the task payload
+
+### File Upload
+
+Upload the source file (NSX export, RVTools, etc.) via the `aws-transform-mcp` server's `upload_artifact` tool with the `planStepId` parameter. The `planStepId` ties the artifact to the correct plan step so the agent can find it.
+
+**CRITICAL: The `planStepId` parameter is REQUIRED in the `upload_artifact` call. Without it, the file uploads but the agent cannot find it.**
+
+**CRITICAL: Resolve ALL paths to absolute form BEFORE calling `upload_artifact`.** The tool does NOT expand `~` or shell variables. `~/file.zip` will fail silently — use `/Users/<username>/file.zip` instead.
+
+> Note: `upload_artifact` is an `aws-transform-mcp` wrapper tool that combines the platform's 3-step flow (`create_artifact_upload_url` → `upload_artifact` → `complete_artifact_upload`) into a single call.
+
+```python
+upload_artifact(
+  workspaceId="<workspace-id>",
+  jobId="<job-id>",
+  content="/Users/<username>/Downloads/<filename>.zip",  # MUST be absolute — no ~ or relative paths
+  fileName="<filename>.zip",
+  fileType="ZIP",
+  categoryType="CUSTOMER_INPUT",
+  planStepId="<upload-source-file-step-id>"  # REQUIRED — get from list_resources(resource="plan")
+)
+```
+
+Get the `planStepId` from `list_resources(resource="plan")` — find the step for "Upload source file."
+
+**Path resolution (all tools):** Always resolve `~` and relative paths to their full absolute form before passing to any MCP tool parameter (`content`, `savePath`, etc.). Tools do NOT expand `~` or shell variables — they treat paths as raw strings.
+Example: `~/Downloads/file.zip` → `/Users/<username>/Downloads/file.zip`
+
+⚠️ **Without `planStepId`**, the file uploads successfully but the agent cannot find it in "User Uploads." The `planStepId` is required for the mapping engine to access the file.
+
+---
+
+## Agents & Transforms
+
+| Agent | How to Discover | Purpose |
+|-------|----------------|---------|
+| VMware Migration Agent (orchestrator) | `list_resources` with `resource: "agents"` | Orchestrates full workflow, invokes NMA sub-agent |
+| Network Migration Agent (NMA) | _(sub-agent, invoked by orchestrator)_ | File processing, mapping, modernization, IaC generation |
+| MGN Backend | _(external service)_ | Runs `StartNetworkMigrationMapping` and code generation |
+
+**Discover the orchestrator agent dynamically** — do not hardcode agent names:
+
+```python
+list_resources(resource="agents")
+# Find the VMware network migration orchestrator from results
+```
+
+**Selection criteria** when multiple VMware agents exist: choose the agent whose `description` mentions "network migration" or "infra provisioning." Prefer the highest version number if multiple matches exist. Ignore agents marked as deprecated in their description. Present the matched agent to the user for confirmation before creating a job.
+
+### Job Creation
+
+**Discover the agent dynamically:**
+
+```python
+list_resources(resource="agents")
+# Find the VMware network migration orchestrator from results
+# Then create job with discovered orchestratorAgent
+create_job(
+  workspaceId="<workspace-id>",
+  jobName="Network Migration <timestamp>",
+  objective="Migrate on-premises network to AWS",
+  intent="Migrate on-premises network to AWS VPC",
+  orchestratorAgent="<discovered>"
+)
+```
+
+### Monitoring
+
+```python
+# Check for agent messages (primary signal)
+list_resources(resource="messages", workspaceId="...", jobId="...")
+
+# Check for HITL tasks
+list_resources(resource="tasks", workspaceId="...", jobId="...")
+
+# Check plan step status
+list_resources(resource="plan", workspaceId="...", jobId="...")
+```
+
+---
+
+## Decision Points
+
+| Step | Question to Ask User | Options |
+|------|---------------------|---------|
+| Topology | "Do your workloads need cross-VPC communication?" | Hub and Spoke / Isolated VPCs |
+| Security groups | "How should security groups be created?" | MAP (static IPs) / MAP_DHCP (dynamic IPs) / SKIP (manual setup) |
+| Modernization | "Would you like guided optimization or direct control?" | Guided Modernization / Direct Edits / Skip |
+| Naming | "What naming convention do you use for cloud resources?" | User provides pattern (e.g., `{env}-{workload}-{type}`) or skip |
+| Deployment | "Do you want AWS Transform to deploy, or deploy yourself?" | Let AWS Transform deploy / I'll deploy myself |
+| IaC format | "Which additional IaC format do you need?" | CDK Project / Terraform / LZA / None |
+
+### Guided Modernization Recommendations
+
+When user selects Guided Modernization, present each recommendation and ask:
+
+- Rename VPCs → user provides new names or skips
+- Right-sizing (resize CIDRs) → user approves or skips
+- Security posture review → informational, user acknowledges
+- Remove unused subnets → user approves or keeps
+
+After all recommendations: "Apply all staged changes" → wait for IaC regeneration → "Done with network design"
+
+---
+
+## Known Limitations
+
+<!-- TODO: remove items after corresponding MCP fixes are deployed and verified -->
+1. **File upload requires `planStepId`** — `upload_artifact` without `planStepId` uploads successfully but the agent can't find the file. Always include the plan step ID for the "Upload source file" step. <!-- TODO: remove after MCP fix to auto-associate uploads -->
+2. **Connector KMS validation** — `create_connector` accepts invalid KMS key ARNs without validation. Fails silently at mapping time. <!-- TODO: remove after MCP fix for KMS validation -->
+3. **MCP requires `encryptionKeyArn`** — Cannot create connector without it, even though webapp doesn't require it. <!-- TODO: remove after MCP fix to make encryptionKeyArn optional -->
+4. **No artifact deletion** — Cannot delete or overwrite files in User Uploads via MCP. <!-- TODO: remove after MCP fix for artifact deletion -->
+5. **Connector role reuse** — Reusing a role from a deleted connector may have KMS permissions on the wrong key. Always use the verification link. <!-- TODO: remove after MCP fix for connector role handling -->
+6. **Existing mapping definitions** — If a previous job created a mapping in the same workspace, agent asks "existing vs new configuration."
+
+---
+
+## Troubleshooting
+
+<!-- TODO: remove rows corresponding to fixed MCP issues -->
+| Symptom | Likely Cause | Resolution |
+|---------|-------------|------------|
+| Mapping fails silently after connector setup | Invalid KMS key ARN passed to `create_connector` | Resolve real ARN via `aws kms describe-key --key-id alias/aws/s3` and recreate connector |
+| Agent can't find uploaded source file | `upload_artifact` called without `planStepId` | Re-upload with `planStepId` from `list_resources(resource="plan")` — find the "Upload source file" step |
+| Connector status stuck on PENDING | User hasn't approved via verification link | Present verification link again — approval creates IAM role with correct permissions |
+| "Existing configuration found" prompt | Previous job created a mapping in same workspace | Ask user: reuse existing or start new configuration |
+| Deployment fails with Organization ID mismatch | LZA deployment account not in same AWS Organization | Verify Organization membership or choose a different IaC format |
+| Reachability analysis shows no connectivity | Security groups or route tables missing rules | Review generated SGs and route tables; check Transit Gateway route table associations |
+| Deployment approval denied | Approver rejected CloudFormation templates | Contact approver for required modifications, update network design, resubmit |
+| Connector creation fails with validation error | Wrong configuration key name | Use `encryptionKeyArn` (not `kmsKeyArn`) in the `configuration` parameter |
+| Cannot replace uploaded file | MCP has no artifact deletion/overwrite | Create a new job or upload with a different filename; existing uploads cannot be removed via MCP |
+
+---
+
+## Hub and Spoke Architecture
+
+When the user selects Hub and Spoke topology, the agent generates:
+
+### Generated VPCs
+
+| VPC | Purpose |
+|-----|---------|
+| **Spoke VPCs** | One per detected source network segment. Connected to Transit Gateway. |
+| **Inspection VPC** | Routes all cross-VPC traffic through this VPC for inspection. User must deploy a firewall appliance (e.g., AWS Network Firewall) here post-migration. TGW attachment uses appliance mode (symmetric routing). |
+| **Inbound VPC** | Handles public internet → workload traffic (north-south inbound). Includes internet gateway + public subnets across AZs. |
+| **Outbound VPC** | Handles workload → public internet traffic (north-south outbound). Includes internet gateway + NAT gateways with elastic IPs per AZ. |
+
+### Transit Gateway Route Tables
+
+| Route Table | Associated With | Routes | Purpose |
+|-------------|----------------|--------|---------|
+| **Uninspected** | Spoke VPCs, Inbound VPC, Outbound VPC | `0.0.0.0/0` → Inspection VPC attachment | Default association table. Forces all traffic through inspection. |
+| **Inspected** | Inspection VPC | Propagated routes from all spoke VPCs | Default propagation table. Lets inspected traffic reach destinations. |
+
+### Traffic Flow
+
+1. Spoke VPC → Transit Gateway (default route `0.0.0.0/0`)
+2. Uninspected route table → Inspection VPC
+3. Inspection VPC forwards traffic back to Transit Gateway (firewall appliance inspects here if deployed)
+4. Inspected route table → destination spoke VPC (via propagated routes)
+
+Outbound internet: Inspected table routes to Outbound VPC → NAT gateway → internet gateway.
+Inbound internet: Internet gateway → Inbound VPC → same inspection path → spoke VPC.
+
+**Note:** Cross-VPC traffic routes through Inspection VPC but is not inspected until the user deploys a firewall appliance (e.g., AWS Network Firewall) there.
+
+For multi-account deployments, Transit Gateway is shared across accounts via AWS Resource Access Manager (RAM).
+
+---
+
+## VPC and Subnet Operations
+
+Operations available during the review and optimization phase (Guided Modernization or Direct Edits).
+
+### VPC Operations
+
+| Operation | What It Does | Constraints |
+|-----------|-------------|-------------|
+| **Rename** | Change VPC name | — |
+| **Resize** | Change CIDR prefix length | Must be /16–/28. Subnets must fit within new CIDR. SG rules matching old CIDR auto-update. |
+| **Change IP** | Change base IP, keep prefix length | Subnets shift by same offset. SG rules matching old CIDR auto-update. |
+| **Merge** | Combine two VPCs into one | No subnet CIDR overlap. Merged result must be /16 or smaller (i.e., prefix ≥ /16). Same account (multi-account). |
+| **Split** | Divide VPC into two | Exactly two CIDRs, no overlap, each /16–/28. Every subnet must fit entirely within exactly one of the two new CIDRs (split is blocked if any subnet spans the boundary). SG rules NOT auto-updated (manual review required). |
+| **Delete** | Permanently remove | Cannot undo. |
+| **Exclude** | Temporarily remove from migration | Can re-include later. |
+| **Include** | Re-add excluded VPC | — |
+
+### Subnet Operations
+
+| Operation | What It Does | Constraints |
+|-----------|-------------|-------------|
+| **Resize** | Change CIDR prefix length | Must be /16–/28. No overlap with other subnets in same VPC. Must fit within parent VPC CIDR. |
+| **Delete** | Permanently remove | Cannot undo. Does not affect parent VPC. |
+| **Change IP** | Change base IP, keep prefix length | — |
+
+**Note:** After each operation (except Split), security group referencing is re-evaluated — CIDR-based rules may convert to SG references or vice versa. Split requires manual SG review since rules are not auto-updated.
+
+**Appliance VPC restrictions:** For Inspection, Inbound, and Outbound VPCs in Hub and Spoke, only Change IP address is supported.
+
+---
+
+## Multi-Account Considerations
+
+| Aspect | What the Power Needs to Know |
+|--------|------------------------------|
+| **Migration type selection** | User chooses Single-account or Multi-account during target account setup. Present via AskUserQuestion. |
+| **Cross-account IAM roles** | Must be configured before starting network migration. Agent handles setup guidance. |
+| **AWS Organizations** | Required for multi-account. LZA deployment requires same Organization as the AWS Transform account. |
+| **Transit Gateway sharing** | In Hub and Spoke, TGW is shared across accounts via RAM. Agent configures this. |
+| **VPC merge constraint** | Both VPCs must be assigned to the same account. Present this constraint if user attempts cross-account merge. |
+| **Security group referencing** | Cross-account ingress rules use SG references (Hub and Spoke). Cross-account egress uses CIDR-based rules. |
+
+---
+
+## Deployment Approvals
+
+When the user selects AWS Transform-managed deployment:
+
+1. **Submission** — Power confirms deployment intent, agent submits CloudFormation templates for review
+2. **Routing** — Request routes automatically to authorized approvers via the AWS Transform Approvals tab
+3. **Review** — Approvers validate CloudFormation templates and network configurations against security standards
+4. **Decision** — Approver approves or denies:
+   - **Approved** → deployment proceeds automatically
+   - **Denied** → inform user, suggest contacting approver for required modifications
+5. **Audit** — All approval decisions are tracked for audit purposes
+
+**Power behavior during approval:**
+
+- After submission, inform user that deployment requires approval
+- Inform user that approval is pending — when user confirms approval has been granted, check job status once
+- If denied, present the denial to the user and offer to modify the network design and resubmit
+
+**Rollback:** After deployment completes, resources can be deleted (requires separate approval). If resources were modified after deployment, automatic deletion is not available — user must delete manually via Console or CLI.
+
+---
+
+## Example Requirements
+
+```
+## Requirement 1: Network Mapping
+**User Story:** As a network engineer, I want my on-premises network configuration
+translated to AWS VPC infrastructure so that workload connectivity is preserved after migration.
+**Acceptance Criteria:**
+1. WHEN mapping completes, EACH source network segment SHALL map to a distinct AWS VPC
+2. WHEN mapping completes, source firewall rules SHALL be translated to AWS Security Groups
+3. WHEN mapping completes, routing between segments SHALL be preserved via Transit Gateway or VPC route tables
+**Handled by:** AWS Transform VMware Migration Agent (NMA sub-agent)
+
+## Requirement 2: Network Optimization
+**User Story:** As a cloud architect, I want to review and optimize the generated network
+before deployment so that it follows our naming conventions and right-sizing standards.
+**Acceptance Criteria:**
+1. WHEN optimization completes, ALL VPCs SHALL follow the organization's naming convention
+2. WHEN optimization completes, VPC CIDRs SHALL be right-sized for actual subnet usage
+3. WHEN optimization completes, unused subnets SHALL be removed with user approval
+**Handled by:** AWS Transform VMware Migration Agent (Guided Modernization) + Kiro (presenting recommendations)
+
+## Requirement 3: Network Deployment
+**User Story:** As an infrastructure engineer, I want the approved network configuration
+deployed to my AWS account so that VPCs are ready for VM migration.
+**Acceptance Criteria:**
+1. WHEN deployment completes, ALL VPCs, subnets, and security groups SHALL exist in the target account
+2. WHEN reachability analysis runs, cross-VPC connectivity SHALL be confirmed
+3. WHEN deployment completes, IaC templates SHALL be available for download in the selected format
+**Handled by:** AWS Transform VMware Migration Agent (CloudFormation deployment)
+```
+
+---
+
+## Example Tasks
+
+```
+- [ ] 1. Target account setup (AWS Transform)
+  - [ ] 1.1 Select migration type (single-account or multi-account)
+  - [ ] 1.2 MAP agreement (if applicable)
+  - [ ] 1.3 Configure connector (KMS key + verification link approval)
+  - [ ] 1.4 Verify connector status = ACTIVE
+- [ ] 2. Network mapping (AWS Transform)
+  - [ ] 2.1 Upload source file (`upload_artifact` with `planStepId`)
+  - [ ] 2.2 Select topology (Hub and Spoke or Isolated VPCs)
+  - [ ] 2.3 Select security group strategy (MAP / MAP_DHCP / SKIP)
+  - [ ] 2.4 Review configuration summary and confirm → mapping begins
+  - [ ] 2.5 Wait for mapping to complete (2-5 min)
+- [ ] 3. Network optimization
+  - [ ] 3.1 Review generated VPCs and subnets
+  - [ ] 3.2 Guided Modernization or Direct Edits
+  - [ ] 3.3 Apply changes → IaC regeneration
+  - [ ] 3.4 Confirm "Done with network design"
+- [ ] 4. Deployment
+  - [ ] 4.1 Configure custom tags
+  - [ ] 4.2 Select deployment strategy (AWS Transform deploy or self-deploy)
+  - [ ] 4.3 If self-deploy: select additional IaC format (CDK / Terraform / LZA)
+  - [ ] 4.4 If AWS Transform deploy: wait for approval → deployment → reachability analysis
+  - [ ] 4.5 Download artifacts
+- [ ] 5. Validation
+  - [ ] 5.1 Review reachability analysis results
+  - [ ] 5.2 Verify network diagram matches expected topology
+  - [ ] 5.3 Confirm VPCs ready for VM migration waves
+```

--- a/aws-transform/steering/workload-vmware-server.md
+++ b/aws-transform/steering/workload-vmware-server.md
@@ -1,0 +1,597 @@
+# Server Migration
+
+> **Last Updated:** 2026-05-10
+
+## Capabilities
+
+Rehost VMware servers to Amazon EC2 using AWS Application Migration Service (MGN). AWS Transform orchestrates the full wave-based migration lifecycle — wave setup, inventory validation, replication agent deployment, data replication monitoring, test instance launch, and production cutover. This workload covers VMware-sourced servers only; for VMware infrastructure (vSphere networking, vSAN storage, vCenter) see `workload-vmware.md`.
+
+- VMware servers → Amazon EC2 instances (rehost/lift-and-shift via MGN)
+- Continuous block-level data replication via AWS Replication Agent
+- Automated replication agent installation via MGN connector (SSH/WinRM) — reusable across waves and target accounts
+- Multi-wave migration with per-wave configuration
+- Single-account and multi-account migration support
+- Test instance launch and validation before production cutover
+- Selective or full-wave cutover with finalization
+
+## Starting Workflow
+
+1. **Confirm prerequisites** — target AWS accounts ready, VPCs/subnets/security groups deployed and tagged, inventory file prepared with wave assignments
+2. **Configure execution defaults** — EC2 recommendation preferences and default launch settings (apply to all target accounts)
+3. **Set up migration wave** — configure target account, migration mode (single vs multi-account), IP assignment strategy, verify resource tags. If the target account and migration mode were already provided earlier in the conversation, use that data without asking again.
+4. **Validate inventory** — review and confirm server-to-EC2 mapping, licensing options, and network configuration before loading into MGN
+5. **Deploy replication agents** — choose installation method (organization tools, MGN connector, or manual), deploy to all servers in the wave
+6. **Monitor replication** — track initial sync and continuous replication until all servers reach Ready for testing. Individual servers that reach Ready for testing can be progressed to test or cutover independently, without waiting for the rest of the wave.
+7. **Test** — obtain approval before launching test instances, then launch, validate, mark applications ready for cutover. Can be done per-server or for the full wave.
+8. **Cutover** — obtain approval before launching cutover instances, then launch, verify, finalize (stops replication), optionally archive source servers. Can be done per-server or for the full wave — a server that has completed testing can be cut over even while other servers in the wave are still replicating.
+
+---
+
+## Agent Monitoring Behavior
+
+Throughout the entire migration flow, the agent MUST proactively pull status and report progress to the user after every significant action. Do not wait for the user to ask.
+
+**Rules:**
+
+- **After triggering any operation** (wave setup, inventory import, agent deployment, replication start, test launch, cutover launch) — immediately begin polling and report status updates as they arrive
+- **After each poll** — present a concise status summary: what completed, what is in progress, what is blocked, and what the next step is
+- **During long-running phases** (initial sync, agent deployment across many servers) — poll on a regular cadence and proactively surface progress (e.g., "12 of 20 servers have completed initial sync")
+- **When a server changes state** — surface it immediately without waiting for the user to ask (e.g., "Server web-01 has reached Ready for testing — do you want to proceed with testing now?")
+- **When a HITL task appears** — surface it immediately, do not wait for the user to notice
+- **When an error or failure occurs** — surface it immediately with the failure reason and suggested resolution
+
+**Per-step monitoring expectations:**
+
+| Step | What to Poll | What to Report |
+|------|-------------|----------------|
+| Wave setup | Connector status, MGN initialization | Connector ACTIVE, MGN initialized per account |
+| Inventory import | Import job status | Import complete, source server records created in MGN |
+| Agent deployment | Per-server deployment status | Servers connected, INITIATING/INITIAL_SYNC state confirmed |
+| Data replication | Per-server replication state and lag | Progress count, servers reaching Ready for testing |
+| Test launch | Per-server test instance status | Instance IDs, test instance running |
+| Cutover launch | Per-server cutover instance status | Instance IDs, cutover instance running |
+| Finalization | Per-server lifecycle state | Replication stopped, lifecycle locked |
+
+---
+
+## Prerequisites
+
+Before starting rehost migration, the following must be in place:
+
+- **Target accounts** — AWS account IDs where servers will be migrated. Use AWS Transform landing zone or other tools to set up infrastructure.
+- **Network infrastructure** — VPCs, subnets, and security groups deployed and configured. Use AWS Transform network migration or other tools.
+- **Inventory file** — Prepared with server details, wave assignments, target account information, and EC2 instance type preferences. Use AWS Transform migration planning to generate this file.
+
+> VPCs and subnets created by the AWS Transform network migration agent are automatically tagged. If you set up your own VPCs and subnets, you must manually apply these tags to the **replication staging area VPC and subnet** — this is the minimum required for migration to proceed:
+>
+> - `CreatedFor: AWSTransform`
+> - `ATWorkspace: <workspace_id>`
+
+### Migration Execution Defaults
+
+Before starting wave execution, configure default settings that apply to all target accounts. These define how EC2 instances are launched and how the general migration is configured. Defaults can be overridden at the wave level during wave setup.
+
+**EC2 recommendation preferences** — AWS Transform provides EC2 instance type recommendations based on source VM utilization. Recommendations can also incorporate input from Migration Evaluator, AWS OLA, or an AWS Transform assessment job.
+
+**Default launch settings** — Configured via the Application Migration Service console.
+
+---
+
+## Workflow
+
+### Step 1: Set Up Migration Wave
+
+AWS Transform prepares the migration wave by:
+
+- Configuring the target account
+- Verifying service permissions
+- Setting up resource tags
+- Adding networking data to inventory
+- Configuring replication and launch settings
+
+**Migration modes:**
+
+| Mode | Description |
+|------|-------------|
+| Single-account | All servers in the wave migrate to the same target account configured in the connector |
+| Multi-account | Servers migrate to different target accounts specified in the inventory file — requires `mgn:account-id` column |
+
+AWS Transform confirms the target account and verifies that Application Migration Service is initialized in each target account. This check runs for every wave. If not yet initialized, AWS Transform provides initialization instructions. During initialization, MGN creates required IAM service roles for replication and launch operations, including cross-account roles for multi-account migrations.
+
+**Resource tagging verification** — AWS Transform verifies all required resources are properly tagged:
+
+- **Source servers:** `CreatedBy: AWSTransform` and `ATWorkspace: <workspace_id>` — required only if the user started replication on source servers prior to working with AWS Transform and wants to bring those servers into the current migration. Not required for new servers.
+- **VPCs and subnets:** `CreatedFor: AWSTransform` and `ATWorkspace: <workspace_id>` — the replication staging area VPC and subnet are mandatory and must be tagged. For the remaining network resources (target subnets, security groups), the user has two options:
+  - **Auto-tag** — use the tagging link provided by AWS Transform to tag all resources automatically
+  - **Provide in inventory** — specify the target subnet and security group per server directly in the inventory file during the Validate and Confirm Inventory step (Step 2)
+
+**Add networking data to inventory** — AWS Transform maps servers to target subnets and security groups based on the network configuration from the migrate network phase.
+
+**IP assignment strategy:**
+
+| Strategy | Description |
+|----------|-------------|
+| Static IP | Source server IP is maintained; CIDR transformation applied automatically if needed |
+| Dynamic IP (DHCP) | Each server is assigned a new IP from the subnet's pool |
+
+> IP assignment options depend on the security group mapping strategy chosen during network migration:
+>
+> - **MAP** — static IP only. MAP translates source firewall rules to IP-based SG rules, so IPs must remain stable.
+> - **MAP_DHCP** — static IP or DHCP. MAP_DHCP generates broader SG rules that accommodate IP changes.
+> - **SKIP** — static IP or DHCP. SGs are configured manually post-migration, so no IP constraint applies.
+
+---
+
+### Step 2: Validate and Confirm Inventory
+
+AWS Transform prepares the inventory file for review before loading into MGN. Available in CSV or XLSX format.
+
+**Required inventory fields:**
+
+| Field | Description |
+|-------|-------------|
+| Server information | Server name, VMID, source specifications |
+| Wave assignment | Migration wave grouping |
+| Application grouping | Logical application associations |
+| Target configuration | Target account, Region, EC2 instance type |
+| Network configuration | Target subnet and security groups |
+
+The inventory file can be modified to adjust EC2 configurations, change OS licensing options (`BYOL` or `License Included` via `mgn:launch:placement:operating-system-licensing`), and update tenancy settings (`mgn:launch:placement:tenancy`).
+
+After review, accept as-is or upload a modified version. AWS Transform then loads the data into MGN, which creates source server records for each server in the wave.
+
+> Do not remove columns or change column headers — AWS Transform requires the original file structure.
+> AWS Transform allows one import to a given target AWS account and Region at a time. If working on more than one wave simultaneously, wait for an import to finish before starting another in a different wave or job.
+
+---
+
+### Step 3: Deploy Replication Agents
+
+Install the AWS Replication Agent on each source server. Three installation methods:
+
+| Method | Description |
+|--------|-------------|
+| Organization tools | Use existing deployment tools (SCCM, Ansible, Chef) with silent install flags: `--no-prompt`, `--aws-access-key-id`, `--aws-secret-access-key`, `--aws-session-token` |
+| MGN connector | Automates agent installation over SSH (Linux) or WinRM (Windows). Reusable across waves and target accounts |
+| Manual installation | Direct installation on each server — full control, requires direct access |
+
+#### MGN Connector Setup
+
+The AWS Transform MGN connector is a lightweight client deployed on a dedicated Linux machine in the on-premises environment. It connects to source servers over SSH/WinRM to install replication agents.
+
+**Connector machine requirements:**
+
+| Requirement | Details |
+|-------------|---------|
+| OS | Supported Linux OS (see MGN connector prerequisites) |
+| Network access | Must reach all source servers (SSH for Linux, WinRM for Windows) |
+| Internet connectivity | Outbound HTTPS (443) to AWS endpoints (SSM, Secrets Manager, MGN) |
+| Disk space | Minimum 200 MB free |
+| Permissions | Root or sudo access |
+
+> The connector must be installed on a Linux machine, but can deploy agents to both Linux and Windows source servers.
+
+**Setup process:**
+
+1. **Connector configuration** — Provide a name (or use auto-generated). Can be installed on management account or delegated administrator account.
+2. **AWS resource setup** — AWS Transform opens a setup page in the browser using your AWS credentials. Automatically creates:
+   - `AWSApplicationMigrationConnectorManagementRole`
+   - `AWSApplicationMigrationConnectorSharingRole_<ACCOUNT-ID>`
+   - SSM Hybrid Activation (30-day expiration)
+
+   > Keep the setup page open until installation is complete. Closing it requires restarting the process. All credentials exist only in the browser and are not stored by AWS Transform.
+
+3. **Connector installation** — Copy the installation link, SSH into the Linux machine, paste and execute. Typically takes 2–3 minutes.
+4. **Attach source servers** — AWS Transform automatically attaches all source servers in the current wave to the connector.
+5. **Configure credentials** — Provide AWS Secrets Manager ARNs for source server credentials:
+
+| Option | Description |
+|--------|-------------|
+| Single secret for Linux | One shared secret (SSH keys or username/password) for all Linux servers |
+| Single secret for Windows | One shared secret (username/password) for all Windows servers |
+| Multiple per-server secrets | Different secrets per server or group — AWS Transform generates a pre-populated CSV to fill in `secret_arn` per server |
+
+> Linux and Windows single-secret options can be combined. Per-server secrets option is mutually exclusive with single-secret options.
+
+**Credential secret format:**
+
+```json
+{
+  "WinConnectionProtocol": "HTTPS",
+  "WinUserName": "windows_username",
+  "WinPassword": "windows_password",
+  "LinuxUserName": "linux_username",
+  "LinuxPrivateKey": "linux_private_key",
+  "LinuxHostKeyValidation": false
+}
+```
+
+**Agent deployment process per server:**
+
+1. AWS Transform sends deployment commands to the connector via SSM
+2. Connector retrieves credentials from Secrets Manager
+3. Connector connects to source server
+4. Connector validates prerequisites
+5. Connector installs and configures the replication agent
+6. Connector verifies successful installation and connectivity
+
+Deployment progress is tracked in real-time with per-server status, current step, elapsed time, and estimated time remaining. Failed servers can be retried individually while successful servers proceed independently.
+
+**Connector reuse:**
+
+| State | Behavior |
+|-------|----------|
+| Active | Hybrid Activation still valid — AWS Transform verifies IAM roles and proceeds to credential configuration |
+| Expired | Activation cannot be renewed — must select a different connector or create a new one |
+
+> SSM Hybrid Activations expire after 30 days. Once the connector is installed, it can continue deploying agents even after activation expires. A new connector is only needed if installing on a new machine.
+
+#### Manual Agent Installation
+
+**Credential options:**
+
+- **Temporary credentials (recommended)** — Create IAM role with `AWSApplicationMigrationAgentInstallationPolicy`, use `aws sts assume-role`
+- **Permanent credentials** — Create IAM user with `AWSApplicationMigrationAgentInstallationPolicy` and generate access key
+
+**Linux installation:**
+
+```bash
+wget -O ./aws-replication-installer-init \
+  https://aws-application-migration-service-{region}.s3.{region}.amazonaws.com/latest/linux/aws-replication-installer-init
+sudo chmod +x aws-replication-installer-init
+sudo ./aws-replication-installer-init --region {region} --user-provided-id {server-identifier}
+```
+
+**Windows installation (PowerShell as Administrator):**
+
+```powershell
+Invoke-WebRequest -Uri "https://aws-application-migration-service-{region}.s3.{region}.amazonaws.com/latest/windows/AwsReplicationWindowsInstaller.exe" `
+  -OutFile "C:\AwsReplicationWindowsInstaller.exe"
+C:\AwsReplicationWindowsInstaller.exe --region {region} --user-provided-id {server-identifier}
+```
+
+> `--user-provided-id` is required. Use the exact value from the `mgn:server:user-provided-id` column in the inventory file. This links the physical server to its MGN source server record.
+
+After installation, AWS Transform verifies all agents are connected by checking that servers show replication state `INITIATING` or `INITIAL_SYNC`.
+
+> AWS Transform does not support MGN agentless replication.
+> All servers in a wave must have the replication agent installed. Servers without an agent can be removed from the wave, or disconnected (`disconnect-from-service`) and archived (`mark-as-archived`). The archive command only works for servers in `DISCONNECTED` lifecycle state.
+
+---
+
+### Step 4: Data Replication
+
+After replication agents are installed, data replication begins automatically using continuous block-level replication.
+
+**Replication phases:**
+
+| Phase | Description |
+|-------|-------------|
+| Initial sync | Complete copy of source server data to AWS, stored as EBS snapshots in the target account. Duration depends on data volume and network bandwidth |
+| Continuous replication | Ongoing synchronization of changed blocks with minimal impact on source server performance |
+
+Replication servers are temporary EC2 instances in the staging area subnet, automatically managed by MGN.
+
+**AWS Transform monitors and provides:**
+
+- Replication status per server
+- Replication lag (time difference between source and replicated data)
+- Bandwidth usage
+
+**Server replication states:**
+
+| State | Meaning |
+|-------|---------|
+| Not ready | Undergoing initial sync — not yet ready for testing |
+| Ready for testing | Data replication started — test or cutover instances can be launched |
+
+Once all servers in the wave have progressed beyond `NOT_READY`, the data replication phase is complete.
+
+**Replication controls:**
+
+- **Pause** — Temporarily pause replication for specific servers or the entire wave
+- **Resume** — Resume previously paused replication
+- **Stop** — Permanently stop replication (can be restarted, but begins from initial sync)
+
+---
+
+### Step 5: Testing
+
+After servers reach the Ready for testing state, obtain approval before launching test instances. Once approved, launch test instances to validate migrated servers before final cutover.
+
+**Testing options:**
+
+| Option | Description |
+|--------|-------------|
+| Full wave testing | Launch test instances for all servers in the wave |
+| Selective testing | Launch test instances for specific servers by user-provided IDs from the inventory file |
+
+> Servers do not need to be at the same replication stage. A server that has reached Ready for testing can be tested immediately while others in the wave are still in initial sync.
+
+AWS Transform launches EC2 instances from replicated data and provides instance IDs for connection and validation.
+
+**After testing:**
+
+- Proceed to cutover if testing is successful
+- Launch new test instances to retest
+- Terminate test instances and address issues before retesting
+
+#### Step 5b: Mark Applications as Ready for Cutover
+
+After testing is complete, mark applications as ready for cutover. AWS Transform reviews replication status of each application and resolves any replication alerts before allowing progression. Only applications with a clean replication status can be marked for cutover.
+
+---
+
+### Step 6: Cutover
+
+Final migration step where production workloads move to AWS. Approval is required before launching cutover instances.
+
+**Cutover options:**
+
+| Option | Description |
+|--------|-------------|
+| Full wave cutover | Cutover all servers in the wave |
+| Selective cutover | Cutover specific servers by user-provided IDs |
+
+> Per-server cutover is independent of wave progress. A server that has completed testing can be cut over while other servers in the same wave are still replicating or in test.
+
+**Cutover process:**
+
+1. **Launch cutover instances** — AWS Transform launches EC2 instances from the latest replicated data and provides instance IDs
+2. **Verify cutover instances** — Connect to launched instances and verify they are functioning correctly
+3. **Finalize cutover** — Confirm cutover to stop source machine replication. Can finalize all servers or select specific ones. Finalization:
+   - Stops replication agents from sending data
+   - Removes replication agents from source servers
+   - Locks the server lifecycle state
+
+   > This action cannot be easily undone. Verify cutover instances before finalizing.
+
+4. **Archive source servers (optional)** — Mark source servers as archived after finalization to free up source server quota
+
+> Downtime occurs between source shutdown and cutover instance availability. Plan the cutover window accordingly.
+
+---
+
+## Server Lifecycle States
+
+| State | Description |
+|-------|-------------|
+| Not ready | Undergoing initial sync — not ready for testing |
+| Ready for testing | Data replication started — test or cutover instances can be launched |
+| Test in progress | A test instance is currently being launched |
+| Ready for cutover | Server has been tested and is ready for cutover |
+| Cutover in progress | A cutover instance is currently being launched |
+| Cutover complete | Server has been cutover — all data migrated to AWS cutover instance |
+| Disconnected | Server has been disconnected from MGN |
+
+---
+
+## Status Queries
+
+At any point during the migration, the user can request a status summary of their wave. When asked, the agent SHALL immediately fetch the latest state and present a summary table showing each server's migration lifecycle state, replication status, and recommended next step.
+
+**Example natural language queries:**
+
+- "What is the status of my servers?"
+- "What's the status of my wave?"
+- "What's the status of the step that I'm currently in?"
+- "Give me a summary of the wave"
+
+During wave migration, users can instruct AWS Transform to advance a specific server to the next stage independently of the rest of the wave. For example, if a single server has reached Ready for testing while others are still in initial sync, the user can instruct the agent to launch a test instance for that server immediately, then proceed to cutover once validated — all while the remaining servers continue replicating. The agent handles per-server progression without requiring the full wave to be at the same stage.
+
+---
+
+## Connector Setup
+
+Before deploying replication agents via the MGN connector method, the connector must be created and activated via the MCP API.
+
+**Important:** `create_connector` accepts invalid KMS key ARNs without validation — it fails silently at agent deployment time. Always resolve a real KMS key ARN before creating the connector:
+
+```bash
+aws kms describe-key --key-id alias/aws/s3 --region us-east-1 --query 'KeyMetadata.Arn' --output text
+```
+
+```python
+create_connector(
+  workspaceId="<workspace-id>",
+  connectorName="server-migration-connector",
+  connectorType="vmware_migration|server_migration|2",
+  configuration={"encryptionKeyArn": "<real-kms-key-arn>"},
+  awsAccountId="<account-id>",
+  targetRegions=["<target-region>"]
+)
+# → Present verification link to user for approval via AWS Console
+# → Connector approval is human-gated — do NOT auto-poll
+# → When user confirms approval, verify status once via get_resource(resource="connector")
+```
+
+Always use the verification link to approve — this creates a fresh IAM role with the correct KMS and MGN permissions. Reusing a role from a deleted connector may have KMS permissions on the wrong key — always use the verification link for a fresh role.
+
+> `encryptionKeyArn` is required by MCP validation even though the webapp does not require it. Always resolve and pass a real ARN.
+
+**Connector reuse across waves:** An active connector can be reused for multiple waves and target accounts. Check connector status before each wave:
+
+| State | Action |
+|-------|--------|
+| ACTIVE | Reuse — verify IAM roles and proceed to credential configuration |
+| PENDING | Present verification link again — user has not yet approved |
+| EXPIRED | SSM Hybrid Activation expired — create a new connector on a new machine |
+
+> SSM Hybrid Activations expire after 30 days. Once installed, the connector continues deploying agents even after activation expires. A new connector is only needed when installing on a new machine.
+
+---
+
+## Multi-Account Considerations
+
+| Aspect | What the Power Needs to Know |
+|--------|------------------------------|
+| **Migration mode selection** | Decision point at Step 1: Single-account or Multi-account. Present via AskUserQuestion. |
+| **Inventory file** | Multi-account requires `mgn:account-id` column in the inventory file — one row per server with its target account ID |
+| **Cross-account IAM roles** | MGN creates cross-account roles during initialization. Verify MGN is initialized in each target account before starting the wave. |
+| **AWS Organizations** | Required for multi-account migrations. Each target account must be part of the same AWS Organization as the source account. |
+| **MGN initialization per account** | If MGN is not yet initialized in a target account, AWS Transform provides initialization instructions. MGN creates `AWSServiceRoleForApplicationMigrationService` in each account. |
+| **Connector scope** | A single connector can deploy agents to servers targeting different accounts — account routing is handled via the inventory file, not the connector. |
+| **Parallel wave imports** | Only one inventory import to a given target account and Region is allowed at a time. Sequence imports across accounts if running multiple waves simultaneously. |
+
+---
+
+## Deployment Approvals
+
+Some migration operations require explicit approval before execution. AWS Transform routes these requests to authorized approvers through the Approvals tab.
+
+1. **Submission** — Power confirms the operation (e.g., cutover launch), agent submits the request for review
+2. **Routing** — Request routes automatically to authorized approvers via the AWS Transform Approvals tab
+3. **Review** — Approvers validate the operation against migration plan and security standards
+4. **Decision** — Approver approves or denies:
+   - **Approved** → operation proceeds automatically
+   - **Denied** → inform user, suggest contacting approver for required modifications
+5. **Audit** — All approval decisions are tracked for audit purposes
+
+Only users with the **Admin** or **Approver** role in AWS Transform can approve deployment requests. Deployments proceed only after receiving confirmation.
+
+**Power behavior during approval:**
+
+- After submission, inform user that the operation requires approval
+- Deployment approval is human-gated — do NOT auto-poll. Present the pending status and wait for the user to confirm approval has been granted, then verify once.
+- If denied, present the denial to the user and offer to address the blocker and resubmit
+
+---
+
+## Agents & Transforms
+
+| Agent | How to Discover | Purpose |
+|-------|----------------|---------|
+| Server Migration Agent | `list_resources` with `resource: "agents"` | Wave setup, inventory validation, agent deployment, replication monitoring, testing, cutover |
+| AWS Application Migration Service (MGN) | External | Actual server replication, testing, and cutover execution |
+| AWS Migration Hub | External | Migration tracking and orchestration |
+
+**Discover the agent dynamically:**
+
+```python
+list_resources(resource="agents")
+# Or ask the chat agent
+send_message(workspaceId="...", text="What agents are available for server migration?")
+# Then create job with discovered orchestratorAgent
+create_job(workspaceId="...", jobName="Server Migration",
+  objective="Migrate VMware servers to EC2 using MGN", orchestratorAgent="<discovered>")
+```
+
+---
+
+## Decision Points
+
+| Decision | Options | When to Ask |
+|----------|---------|-------------|
+| Migration mode | Single-account / Multi-account | Step 1 — wave setup. Skip if already known from earlier in the conversation. |
+| IP assignment strategy | Static IP / Dynamic IP (DHCP) | Step 1 — wave setup |
+| Agent installation method | Organization tools / MGN connector / Manual | Step 3 — before agent deployment |
+| Credential configuration | Single secret (Linux) / Single secret (Windows) / Per-server secrets | Step 3 — connector setup |
+| Testing scope | Full wave / Selective | Step 5 — before launching test instances |
+| Cutover scope | Full wave / Selective | Step 6 — before launching cutover instances |
+
+---
+
+## Example Requirements
+
+```
+## Requirement 1: Wave Setup and Inventory Validation
+**User Story:** As an infrastructure engineer, I want each migration wave configured and validated
+so that servers are correctly mapped to target accounts, subnets, and EC2 instance types.
+**Acceptance Criteria:**
+1. WHEN wave setup completes, EACH server SHALL have a target account, subnet, security group, and EC2 instance type assigned
+2. WHEN inventory is validated, required resource tags SHALL be verified (CreatedBy: AWSTransform, ATWorkspace: <id>)
+3. WHEN inventory is loaded, MGN SHALL create source server records for each server in the wave
+**Handled by:** AWS Transform Server Migration Agent
+
+## Requirement 2: Replication Agent Deployment
+**User Story:** As an operations engineer, I want replication agents deployed to all source servers
+so that continuous block-level replication to AWS begins automatically.
+**Acceptance Criteria:**
+1. WHEN agents are deployed, ALL servers in the wave SHALL show replication state INITIATING or INITIAL_SYNC
+2. WHEN initial sync completes, ALL servers SHALL reach Ready for testing state
+3. WHEN a server fails agent installation, the failure reason SHALL be displayed and retry SHALL be available
+**Handled by:** AWS Transform Server Migration Agent
+
+## Requirement 3: Testing and Cutover
+**User Story:** As an operations engineer, I want to validate migrated servers before cutover
+so that production workloads are moved to AWS with verified functionality.
+**Acceptance Criteria:**
+1. WHEN test instances are launched, instance IDs SHALL be provided for each server
+2. WHEN test instances are launched, the EC2 launch template ID SHALL be taken from the default version of the specific EC2 launch template ID configured in the target account launch settings
+3. WHEN all applications are marked ready for cutover, replication alerts SHALL be resolved
+4. WHEN cutover is finalized, source machine replication SHALL stop and lifecycle state SHALL be locked
+5. WHEN cutover completes, downtime SHALL be limited to the window between source shutdown and cutover instance availability
+**Handled by:** AWS Transform Server Migration Agent
+```
+
+---
+
+## Example Tasks
+
+```
+- [ ] 1. Prerequisites verification
+  - [ ] 1.1 Confirm target AWS accounts are ready
+  - [ ] 1.2 Verify VPC, subnets, and security groups are deployed and tagged
+  - [ ] 1.3 Confirm inventory file is prepared with wave assignments and EC2 preferences
+  - [ ] 1.4 Configure migration execution defaults (EC2 recommendation preferences, launch settings)
+- [ ] 2. Wave setup (Step 1)
+  - [ ] 2.1 Configure migration mode (single-account or multi-account)
+  - [ ] 2.2 Verify MGN is initialized in target accounts
+  - [ ] 2.3 Verify resource tagging
+  - [ ] 2.4 Add networking data to inventory
+  - [ ] 2.5 Configure IP assignment strategy
+- [ ] 3. Inventory validation (Step 2)
+  - [ ] 3.1 Download and review inventory file (CSV/XLSX)
+  - [ ] 3.2 Adjust EC2 instance types, licensing options, tenancy if needed
+  - [ ] 3.3 Upload modified inventory or accept as-is
+  - [ ] 3.4 Confirm MGN source server records created
+- [ ] 4. Deploy replication agents (Step 3)
+  - [ ] 4.1 Choose installation method (organization tools / MGN connector / manual)
+  - [ ] 4.2 Set up MGN connector if selected (configure, install, attach servers, configure credentials)
+  - [ ] 4.3 Deploy agents to all servers in the wave
+  - [ ] 4.4 Verify all agents show INITIATING or INITIAL_SYNC state
+- [ ] 5. Data replication (Step 4)
+  - [ ] 5.1 Monitor initial sync progress per server
+  - [ ] 5.2 Confirm all servers reach Ready for testing state
+- [ ] 6. Testing (Step 5)
+  - [ ] 6.1 Launch test instances (full wave or selective)
+  - [ ] 6.2 Validate test instances — connectivity, application health
+  - [ ] 6.3 Terminate test instances after validation
+  - [ ] 6.4 Mark applications as ready for cutover
+- [ ] 7. Cutover (Step 6)
+  - [ ] 7.1 Launch cutover instances within maintenance window
+  - [ ] 7.2 Verify cutover instances are functioning correctly
+  - [ ] 7.3 Finalize cutover (stops replication, locks lifecycle state)
+  - [ ] 7.4 Archive source servers (optional)
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Resolution |
+|---------|-------------|------------|
+| Connector status stuck on PENDING | User hasn't approved via verification link | Present verification link again — approval creates IAM role with correct MGN and KMS permissions |
+| Agent installation fails on all servers | Connector can't reach source servers | Verify network access: SSH (port 22) for Linux, WinRM (port 5985/5986) for Windows |
+| Agent installation fails on specific servers | Wrong credentials or per-server secret ARN incorrect | Check Secrets Manager ARN for the affected server; verify secret format matches expected JSON structure |
+| Servers stuck in NOT_READY after agent install | Initial sync still in progress | Monitor replication lag — large disks or low bandwidth extend initial sync duration |
+| MGN not initialized in target account | First-time use of MGN in that account | Follow AWS Transform initialization instructions — MGN creates required IAM service roles automatically |
+| Inventory import fails | Duplicate import in progress for same account/Region | Wait for the active import to finish before starting another in the same target account and Region |
+| Inventory import fails | Column headers modified or columns removed | Restore original file structure — AWS Transform requires unmodified column headers |
+| Test instance launch fails | Server not in Ready for testing state | Verify replication state is not NOT_READY; check for replication alerts |
+| Cutover finalization blocked | Replication alerts on one or more servers | Resolve replication alerts before marking applications ready for cutover |
+| Source server not found in MGN after import | `mgn:server:user-provided-id` mismatch | Ensure the value passed to `--user-provided-id` during agent install exactly matches the inventory file value |
+| Dynamic IP (DHCP) assignment unavailable | MAP security groups strategy used during network migration | MAP supports static IP only — to enable DHCP, redo network migration with MAP_DHCP or SKIP strategy |
+
+---
+
+## Known Limitations
+
+- Agentless replication is not supported — the AWS Replication Agent must be installed on all servers in a wave
+- Servers without a replication agent can be removed from the wave, or disconnected and archived to free up source server quota
+- SSM Hybrid Activations for the MGN connector expire after 30 days — a new connector is required if installing on a new machine after expiration
+- Only one inventory import to a given target account and Region is allowed at a time — parallel wave imports to the same account must be sequenced
+- IP assignment is constrained by the security group mapping strategy: MAP supports static IP only; MAP_DHCP and SKIP support both static and DHCP
+- Only the replication staging area VPC and subnet must be tagged with `CreatedFor: AWSTransform` and `ATWorkspace: <workspace_id>` if not created by AWS Transform network migration — other network resources can be tagged via the tagging link or specified per-server in the inventory file
+- Deployment approvals require Admin or Approver role in AWS Transform — non-admin/non-approver users cannot approve cutover operations
+- Downtime is unavoidable between source shutdown and cutover instance availability — plan maintenance windows accordingly

--- a/aws-transform/steering/workload-vmware.md
+++ b/aws-transform/steering/workload-vmware.md
@@ -1,0 +1,429 @@
+# VMware Migration
+
+> **Last Updated:** 2026-05-10
+
+## Capabilities
+
+Migrate VMware environments to AWS using generative AI-driven planning and execution. AWS Transform orchestrates the full migration lifecycle — discovery, migration planning, landing zone setup, network migration, and server rehosting to EC2. Supports Windows and Linux servers on supported operating systems (see [MGN supported OS list](https://docs.aws.amazon.com/mgn/latest/ug/Supported-Operating-Systems.html)).
+
+- VMware VMs → Amazon EC2 instances (rehost/lift-and-shift via MGN)
+- AI-driven conversion of VMware network configuration → AWS VPC architecture (VPCs, subnets, security groups, Transit Gateway)
+- AI-driven migration plan generation — application grouping and wave planning
+- Three discovery options: AWS Application Discovery Service collectors, Export for vCenter tool, or independently collected data import
+- Landing zone setup for target AWS accounts
+- Multi-wave migration with per-wave configuration
+- Single-account and multi-account migration support
+
+For detailed execution guidance see:
+
+- `workload-vmware-server.md` — replication agent deployment, data replication, testing, cutover
+- `workload-vmware-network.md` — network mapping, topology, IaC generation, deployment
+- `workload-vmware-landing-zone.md` — landing zone foundation and workload account design
+- `workload-vmware-containerization.md` — source code containerization, Docker artifacts, ECR publishing, EKS/ECS IaC
+
+---
+
+## Job Types
+
+AWS Transform offers the following VMware migration job types. Steps can be dynamically added or removed at any time to customize the workflow.
+
+| Job Type                                        | Steps Included                                                                                                              |
+| ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| **End-to-end migration**                        | Perform discovery → Build migration plan → Connect target accounts → Build landing zone → Migrate network → Migrate servers |
+| **Discovery and migration planning**            | Perform discovery → Build migration plan                                                                                    |
+| **Network migration**                           | Connect target accounts → Migrate network                                                                                   |
+| **Landing zone**                                | Connect target accounts → Build landing zone                                                                                |
+| **Landing zone, network, and server migration** | Connect target accounts → Build landing zone → Migrate network → Migrate servers                                            |
+| **Migration planning and server migration**     | Perform discovery → Build migration plan → Connect target accounts → Migrate servers                                        |
+| **Source code containerization**                | Connect target accounts → Containerize applications → Publish to ECR → Deploy to EKS/ECS                                    |
+
+> One target AWS Region per VMware migration job. To migrate to different Regions, create multiple jobs.
+
+---
+
+## Starting Workflow
+
+**Before starting:** Confirm job type — determine which steps are in scope based on what the user already has (existing network, existing landing zone, etc.)
+
+1. **Perform discovery** — identify VM count, OS types, resource usage (CPU, memory, storage), and network dependencies using one of the three discovery options
+2. **Build migration plan** — AI-driven application grouping, wave planning, and right-sizing recommendations
+3. **Connect target accounts** — configure target AWS accounts and verify permissions
+4. **Build landing zone** — set up AWS account structure, IAM roles, and baseline infrastructure in target accounts
+5. **Migrate network** — translate VMware network configuration to AWS VPC architecture; deploy via CloudFormation
+6. **Migrate servers** — deploy replication agents, replicate data, test, and cut over wave by wave
+
+   **Separate job type (not part of end-to-end migration):**
+
+7. **Containerize applications** — AI-driven Docker artifact generation, ECR publishing, EKS/ECS IaC and deployment (standalone or with containerize strategy assigned to waves)
+
+**Key questions to ask user:**
+
+- "Do you already have a landing zone and network set up in the target account(s), or do we need to build those?"
+- "Which discovery method do you have available — ADS collectors, Export for vCenter, or an existing data export?"
+- "Are any of your workloads candidates for containerization (EKS/ECS), or is this purely lift-and-shift to EC2?"
+
+---
+
+## Agent Monitoring Behavior
+
+Throughout the entire VMware migration flow, the agent MUST proactively pull status and report progress to the user after every significant action. Do not wait for the user to ask.
+
+**Rules:**
+
+- **After triggering any operation** (discovery, migration plan generation, landing zone deployment, network deployment, wave setup, agent deployment, replication, test launch, cutover) — immediately begin polling and report status updates as they arrive
+- **After EVERY job interaction** (send_message, complete_task, upload_artifact) — always read the latest messages back from the job and surface any agent response or question to the user immediately. Do not assume silence means the agent is still processing — it may have already responded.
+- **After each poll** — present a concise status summary: what completed, what is in progress, what is blocked, and what the next step is
+- **During long-running phases** (discovery, initial sync, CloudFormation deployment) — poll on a regular cadence and proactively surface progress
+- **When a step completes** — surface it immediately and prompt the user for the next decision
+- **When a HITL task appears** — surface it immediately, do not wait for the user to notice
+- **When an error or failure occurs** — surface it immediately with the failure reason and suggested resolution
+
+**Polling priority** — check in this order every poll cycle:
+
+1. **Messages** (agent chat responses and questions) — check first, this is the primary communication channel
+2. **Tasks** (formal HITL tasks awaiting human input)
+3. **Worklogs** (agent activity and progress)
+
+**Target account operations — always delegate to the agent:**
+
+When the user asks about resources in the target AWS account (subnets, VPCs, security groups, instances, IAM roles, etc.), do NOT attempt to query the target account directly via AWS CLI or SDK. The Power does not have cross-account permissions. Instead, forward the request to the agent via `send_message` — the agent has connector-based access to the target account and can query and report back.
+
+Examples:
+
+- "What subnets are available?" → `send_message(text="List available subnets in the target account")`
+- "Show me the security groups" → `send_message(text="List security groups in the target account")`
+- "What VPCs are tagged?" → `send_message(text="Show tagged VPCs in the target account")`
+
+Never run `aws ec2 describe-subnets` or similar CLI commands targeting the customer's account — they will fail with permissions errors or return results from the wrong account.
+
+**Console link presentation — guided handoff:**
+
+When a step requires the user to complete an action in the AWS Console (IAM role setup, CloudFormation deployment, connector approval, MGN initialization):
+
+1. **Explain what needs to happen** — don't just present a link. State what the action does, why it's needed, and what the user should see when it's complete.
+2. **Provide the direct link** — full URL, not a relative path or internal reference.
+3. **State what to do after** — tell the user to confirm when done (e.g., "Let me know once you've approved the connector").
+4. **Verify the result** — after user confirms, check the status once (connector ACTIVE, MGN initialized, stack deployed) and report back.
+5. **Never leave the user hanging** — if verification fails, explain what went wrong and what to retry.
+6. **Never construct console URLs yourself** — always use links provided by the agent in its messages or HITL tasks. Console URLs are dynamically generated and scoped to specific connectors, workspaces, and accounts. Constructing generic URLs will produce incorrect links. If the agent hasn't provided a link, ask it via `send_message` rather than guessing the URL format.
+
+**Polling types:**
+
+- **Machine-gated steps** (mapping, job processing, replication, deployments, IaC generation) — poll automatically and silently. Only surface results to the user (completion, error, or progress update). Do NOT ask permission to poll.
+- **Human-gated steps** (connector approval, deployment approval, web UI approvals) — do NOT auto-poll. Present the action needed (link, instructions) and wait for the user to confirm when done. When user confirms → verify status once. If not yet complete → remind them what's needed.
+
+**Per-step monitoring expectations:**
+
+| Step                    | What to Poll                                                       | What to Report                                                                            |
+| ----------------------- | ------------------------------------------------------------------ | ----------------------------------------------------------------------------------------- |
+| Discovery               | Job status, messages                                               | Discovery complete, VM count, dependency map summary                                      |
+| Migration plan          | Job status, messages                                               | Wave groupings, right-sizing recommendations ready for review                             |
+| Connect target accounts | MGN initialization status per account                              | Accounts connected, MGN initialized                                                       |
+| Landing zone            | Deployment job status                                              | OUs and accounts created, approval status                                                 |
+| Network migration       | Deployment job status, connector status                            | Network deployed, VPCs/subnets ready                                                      |
+| Server migration        | Per-server replication state, test/cutover status                  | Progress per wave — delegate to server migration monitoring rules                         |
+| Containerization        | Artifact generation status, TOOL_APPROVAL tasks, deployment status | Docker artifacts ready for review, images published, IaC generated, test/cutover deployed |
+
+---
+
+## Prerequisites
+
+- **Target AWS accounts** — account IDs where servers will be migrated
+- **Discovery data** — VM inventory with OS types, CPU/memory/storage, and network dependencies
+- **AWS Transform workspace** — determines the AWS Region for jobs and discovery data. Target Region can differ from workspace Region.
+
+---
+
+## Workflow
+
+### Step 1: Perform Discovery
+
+Three options for collecting VMware environment data:
+
+| Method                                       | Description                                                           |
+| -------------------------------------------- | --------------------------------------------------------------------- |
+| AWS Application Discovery Service collectors | Automated discovery via ADS agents deployed in the VMware environment |
+| Export for vCenter tool                      | Open-source tool that exports VM inventory directly from vCenter      |
+| Independent data import                      | Import previously collected discovery data (CSV or supported format)  |
+
+Discovery produces VM inventory with resource utilization, OS details, and network dependency mapping used for migration planning.
+
+---
+
+### Step 2: Build Migration Plan
+
+AWS Transform analyzes discovery data and generates:
+
+- **Application grouping** — logical grouping of VMs by application or workload
+- **Migration waves** — prioritized wave assignments based on dependencies and risk
+- **Right-sizing recommendations** — EC2 instance type recommendations per VM based on utilization data
+
+The user reviews and adjusts groupings and wave assignments before proceeding.
+
+---
+
+### Step 3: Connect Target Accounts
+
+Configure the target AWS account(s) where servers will be migrated. AWS Transform verifies permissions and initializes required services (MGN, IAM roles) in each target account.
+
+For multi-account migrations, each target account must be part of the same AWS Organization.
+
+---
+
+### Step 4: Build Landing Zone
+
+Set up the baseline AWS infrastructure in target accounts — account structure, IAM roles, VPCs for management, and baseline security controls. AWS Transform guides landing zone configuration and deployment.
+
+---
+
+### Step 5: Migrate Network
+
+Translate VMware network configuration to AWS VPC architecture. See `workload-vmware-network.md` for full details including:
+
+- Topology selection (Hub and Spoke or Isolated VPCs)
+- Security group strategy (MAP / MAP_DHCP / SKIP)
+- Network optimization and IaC generation
+- CloudFormation deployment with approval workflow
+
+> The security group mapping strategy chosen here determines IP assignment options in server migration: MAP = static IP only; MAP_DHCP and SKIP = static or DHCP.
+
+---
+
+### Step 6: Migrate Servers
+
+Rehost VMware servers to EC2 using MGN. See `workload-vmware-server.md` for full details including:
+
+- Wave setup and inventory validation
+- Replication agent deployment (organization tools, MGN connector, or manual)
+- Data replication monitoring
+- Test instance launch (requires approval)
+- Production cutover (requires approval)
+- Per-server progression — servers can advance to test and cutover independently of the rest of the wave
+
+---
+
+### Step 7: Containerize Applications
+
+Containerize applications for deployment on Amazon EKS or Amazon ECS. See `workload-vmware-containerization.md` for full details including:
+
+- AI-driven source code analysis and Docker artifact generation
+- Container image building and publishing to Amazon ECR (with vulnerability scanning)
+- Infrastructure as Code generation (EKS Helm charts or ECS Terraform modules)
+- Test deployment and production cutover
+- TOOL_APPROVAL tasks require web UI approval
+
+---
+
+## Multi-Account Considerations
+
+| Aspect                             | What the Power Needs to Know                                                                                                                                                       |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Job type selection**             | Confirm whether single-account or multi-account at job creation                                                                                                                    |
+| **AWS Organizations**              | Required for multi-account migrations. Each target account must be in the same Organization.                                                                                       |
+| **Cross-account IAM roles**        | MGN creates cross-account roles during initialization. Verify MGN is initialized in each target account.                                                                           |
+| **MGN initialization per account** | If MGN is not yet initialized in a target account, AWS Transform provides initialization instructions. MGN creates `AWSServiceRoleForApplicationMigrationService` in each account. |
+| **Connector scope**                | A single connector can deploy agents to servers targeting different accounts — account routing is handled via the inventory file, not the connector.                               |
+| **Target Region**                  | One Region per job. Workspace Region and target Region can differ — data transfers across Regions if they differ.                                                                  |
+| **Landing zone scope**             | Landing zone setup applies to all target accounts in the job                                                                                                                       |
+
+---
+
+## Deployment Approvals
+
+Some migration operations require explicit approval before execution. AWS Transform routes these requests to authorized approvers through the Approvals tab.
+
+1. **Submission** — Power confirms the operation, agent submits for review
+2. **Routing** — Request routes automatically to authorized approvers via the Approvals tab
+3. **Review** — Approvers validate against migration plan and security standards
+4. **Decision** — Approver approves or denies:
+   - **Approved** → operation proceeds automatically
+   - **Denied** → inform user, suggest contacting approver for required modifications
+5. **Audit** — All approval decisions are tracked for audit purposes
+
+Only users with the **Admin** or **Approver** role in AWS Transform can approve deployment requests. Deployments proceed only after receiving confirmation.
+
+**Power behavior during approval:**
+
+- After submission, inform user that the operation requires approval
+- Deployment approval is human-gated — do NOT auto-poll. Present the pending status and wait for the user to confirm approval has been granted, then verify once.
+- If denied, present the denial to the user and offer to address the blocker and resubmit
+
+---
+
+## Agents & Transforms
+
+| Agent                                                   | How to Discover                            | Purpose                                                                                              |
+| ------------------------------------------------------- | ------------------------------------------ | ---------------------------------------------------------------------------------------------------- |
+| VMware Migration Agent v2 (`vmware-migration-agent-v2`) | `list_resources` with `resource: "agents"` | End-to-end orchestration: discovery, planning, network migration, server migration, containerization |
+| Server Migration Agent                                  | `list_resources` with `resource: "agents"` | Wave setup, replication agent deployment, replication monitoring, testing, cutover                   |
+| Landing Zone Agent                                      | `list_resources` with `resource: "agents"` | Foundation setup, workload account design, SCP configuration, IaC generation                         |
+| Network Migration Agent (NMA)                           | _(sub-agent, invoked by orchestrator)_     | Network mapping, optimization, and IaC generation                                                    |
+| Containerization sub-agent                              | _(sub-agent, invoked by orchestrator)_     | Source code analysis, Docker artifact generation, image building, IaC generation                     |
+| AWS Application Migration Service (MGN)                 | External                                   | Actual server replication, testing, and cutover execution                                            |
+| AWS Migration Hub                                       | External                                   | Migration tracking and orchestration                                                                 |
+
+**Discover agents dynamically:**
+
+```python
+list_resources(resource="agents")
+# Or ask the chat agent
+send_message(workspaceId="...", text="What agents are available for VMware migration?")
+# Then create job with discovered orchestratorAgent
+create_job(workspaceId="...", jobName="VMware Migration",
+  objective="Migrate VMware workloads to EC2", orchestratorAgent="vmware-migration-agent-v2")
+```
+
+---
+
+## Decision Points
+
+| Decision                  | Options                                                                  | When to Ask                                                             |
+| ------------------------- | ------------------------------------------------------------------------ | ----------------------------------------------------------------------- |
+| Job type                  | End-to-end / Discovery and planning / Network only / Landing zone / etc. | Before starting — based on what the user already has                    |
+| Discovery method          | ADS collectors / Export for vCenter / Independent import                 | Step 1 — before discovery                                               |
+| Migration mode            | Single-account / Multi-account                                           | Step 3 — connecting target accounts                                     |
+| Network topology          | Hub and Spoke / Isolated VPCs                                            | Step 5 — network migration                                              |
+| Security group strategy   | MAP / MAP_DHCP / SKIP                                                    | Step 5 — network migration. Determines IP assignment options in Step 6. |
+| IP assignment strategy    | Static IP / Dynamic IP (DHCP)                                            | Step 6 — wave setup. Constrained by SG strategy.                        |
+| Agent installation method | Organization tools / MGN connector / Manual                              | Step 6 — before replication agent deployment                            |
+| Testing scope             | Full wave / Selective                                                    | Step 6 — before launching test instances                                |
+| Cutover scope             | Full wave / Selective                                                    | Step 6 — before launching cutover instances                             |
+| Source code method        | Git repository (CodeConnections) / Zip upload                            | Step 7 — containerization                                               |
+| Deployment target         | Amazon EKS (Helm charts) / Amazon ECS (Terraform modules)                | Step 7 — before IaC generation. MUST ask explicitly, never infer.       |
+
+---
+
+## Example Requirements
+
+```
+## Requirement 1: VM Discovery and Migration Planning
+
+**User Story:** As an infrastructure engineer, I want all VMware VMs assessed and grouped into waves
+so that I have a clear, prioritized migration plan with right-sized EC2 targets.
+**Acceptance Criteria:**
+
+1. WHEN discovery completes, EACH VM SHALL have a recommended EC2 instance type
+2. WHEN discovery completes, network dependencies between VMs SHALL be documented
+3. WHEN migration plan is built, VMs SHALL be grouped into migration waves with dependency ordering
+   **Handled by:** AWS Transform VMware Migration Agent v2
+
+## Requirement 2: Network Migration
+
+**User Story:** As a network engineer, I want VMware network configuration translated to AWS VPC
+so that VM communication patterns are preserved after migration.
+**Acceptance Criteria:**
+
+1. WHEN network mapping completes, EACH source network segment SHALL map to a distinct AWS VPC
+2. WHEN network mapping completes, source firewall rules SHALL be translated to AWS Security Groups
+3. WHEN deployment completes, ALL VPCs, subnets, and security groups SHALL exist in the target account
+   **Handled by:** AWS Transform VMware Migration Agent v2 (NMA sub-agent)
+
+## Requirement 3: Server Migration
+
+**User Story:** As an operations engineer, I want VMware servers rehosted to EC2
+so that production workloads run natively on AWS with verified functionality.
+**Acceptance Criteria:**
+
+1. WHEN replication agents are deployed, ALL servers SHALL show replication state INITIATING or INITIAL_SYNC
+2. WHEN test instances are launched (after approval), instance IDs SHALL be provided for each server
+3. WHEN cutover is finalized (after approval), source machine replication SHALL stop and lifecycle state SHALL be locked
+   **Handled by:** AWS Transform Server Migration Agent
+
+## Requirement 4: Landing Zone
+
+**User Story:** As a cloud platform engineer, I want the core landing zone foundation deployed
+so that governance controls, centralized logging, and account isolation are in place before workloads arrive.
+**Acceptance Criteria:**
+
+1. WHEN foundation setup completes, Control Tower SHALL be initialized with Security OU, Log Archive account, and Audit account
+2. WHEN workload structure is proposed, ALL servers in a migration wave SHALL map to the same target account
+3. WHEN SCPs are applied, member accounts SHALL be unable to exceed the boundaries defined by the SCPs
+   **Handled by:** AWS Transform Landing Zone Agent
+
+## Requirement 5: Containerization
+
+**User Story:** As a platform engineer, I want selected applications containerized
+so that they can run on Amazon EKS or Amazon ECS instead of bare EC2 instances.
+**Acceptance Criteria:**
+
+1. WHEN containerization completes, a Dockerfile SHALL be generated for each application component
+2. WHEN images are published, vulnerability scanning SHALL report no critical findings
+3. WHEN IaC generation completes, deployment templates SHALL be available in the selected format (Helm charts or Terraform)
+   **Handled by:** AWS Transform VMware Migration Agent (Containerization sub-agent)
+```
+
+---
+
+## Example Tasks
+
+```
+- [ ] 1. Job setup
+  - [ ] 1.1 Confirm job type (end-to-end or subset of steps)
+  - [ ] 1.2 Confirm single-account or multi-account migration
+  - [ ] 1.3 Create and start VMware migration job
+- [ ] 2. Discovery (Step 1)
+  - [ ] 2.1 Choose discovery method (ADS / Export for vCenter / independent import)
+  - [ ] 2.2 Run discovery and collect VM inventory
+  - [ ] 2.3 Review discovery results
+- [ ] 3. Migration planning (Step 2)
+  - [ ] 3.1 Review AI-generated application groupings
+  - [ ] 3.2 Review and adjust wave assignments
+  - [ ] 3.3 Review right-sizing recommendations
+  - [ ] 3.4 Approve migration plan
+- [ ] 4. Connect target accounts (Step 3)
+  - [ ] 4.1 Provide target AWS account IDs
+  - [ ] 4.2 Verify MGN initialized in each target account
+  - [ ] 4.3 Verify cross-account IAM roles
+- [ ] 5. Build landing zone (Step 4)
+  - [ ] 5.1 Configure landing zone settings
+  - [ ] 5.2 Deploy landing zone (approval required)
+  - [ ] 5.3 Verify baseline infrastructure in target accounts
+- [ ] 6. Network migration (Step 5) — see workload-vmware-network.md
+  - [ ] 6.1 Upload source network file
+  - [ ] 6.2 Select topology and security group strategy
+  - [ ] 6.3 Review and optimize network design
+  - [ ] 6.4 Deploy network (approval required)
+- [ ] 7. Server migration (Step 6) — see workload-vmware-server.md
+  - [ ] 7.1 Set up migration wave per wave
+  - [ ] 7.2 Validate and confirm inventory
+  - [ ] 7.3 Deploy replication agents
+  - [ ] 7.4 Monitor data replication
+  - [ ] 7.5 Launch test instances (approval required)
+  - [ ] 7.6 Mark applications ready for cutover
+  - [ ] 7.7 Launch cutover instances (approval required)
+  - [ ] 7.8 Finalize cutover and archive source servers
+- [ ] 8. Containerization (Step 7, if applicable) — see workload-vmware-containerization.md
+  - [ ] 8.1 Provide source code (Git or zip)
+  - [ ] 8.2 Review AI-generated Docker artifacts
+  - [ ] 8.3 Publish images to ECR (web UI approval)
+  - [ ] 8.4 Select deployment target (EKS or ECS) and generate IaC
+  - [ ] 8.5 Deploy test infrastructure (web UI approval)
+  - [ ] 8.6 Deploy cutover infrastructure (web UI approval)
+```
+
+---
+
+## Troubleshooting
+
+| Symptom                                                | Likely Cause                                                | Resolution                                                                                                                                                                                                                |
+| ------------------------------------------------------ | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Job cannot be resumed after stop                       | VMWARE_V2 jobs are non-restartable                          | Stopping is irreversible — create a new job to start over. Artifacts from the stopped job are preserved.                                                                                                                  |
+| NSX import fails                                       | NSX imports only supported for end-to-end migration jobs    | Switch to end-to-end job type, or use a different source format (RVTools, ACI, etc.)                                                                                                                                      |
+| Cannot create job in desired Region                    | Jobs execute in the workspace Region                        | The job always runs in the workspace Region. To target a different Region for migration, configure the target Region in the job settings. To run the job itself in a different Region, create a workspace in that Region. |
+| Discovery data not recognized                          | Unsupported format or missing required fields               | Verify format matches one of the three supported discovery options; check required columns                                                                                                                                |
+| Network deployment fails with Organization ID mismatch | LZA deployment account not in same AWS Organization         | Verify Organization membership or choose a different IaC format                                                                                                                                                           |
+| Server replication issues                              | See `workload-vmware-server.md` Troubleshooting             | Covers agent install failures, stuck replication, MGN initialization, inventory import issues                                                                                                                             |
+| Network mapping issues                                 | See `workload-vmware-network.md` Troubleshooting            | Covers connector KMS issues, file upload, topology and SG strategy problems                                                                                                                                               |
+| Containerization issues                                | See `workload-vmware-containerization.md` Known Limitations | Covers TOOL_APPROVAL web UI requirement, connector targetRegion, source code size limits                                                                                                                                  |
+
+---
+
+## Known Limitations
+
+- One target AWS Region per VMware migration job — create multiple jobs to migrate to different Regions
+- Stopping a running migration job is irreversible — VMWARE_V2 jobs cannot be restarted once stopped. A new job must be created to start over. Artifacts from the stopped job are preserved but job progress is lost.
+- NSX imports are only supported for end-to-end migration jobs
+- Physical servers (non-virtualized) are not in scope
+- VMware-specific features (vMotion, DRS, HA) have no direct AWS equivalents — require architectural redesign
+- License mapping (Windows Server, SQL Server on VMs) requires manual review
+- AWS Transform generates network configurations and migration strategies based on environment assessment — review with stakeholders before proceeding to ensure security and compliance requirements are met


### PR DESCRIPTION
## Summary

This release expands the `aws-transform` power beyond the custom-transformation workflow to cover the full AWS Transform product surface: .NET Framework → .NET 8/10, mainframe COBOL → Java, VMware → EC2, SQL Server/Oracle/MySQL → Aurora, and Java/Python/Node.js language and AWS SDK upgrades — assessment, planning, and execution for each.

- **POWER.md**: rewritten around a mandatory 9-step workflow (Resume → Intent → Discovery → Scope → Assessment → Requirements → Approval → Tasks → Execute) with explicit NEVER-DO rules and just-in-time authentication. Frontmatter `description` / `keywords` updated to reflect the broader workload scope.
- **mcp.json**: added (did not exist upstream); declares the AWS Transform MCP server the power relies on.
- **steering/**: reorganized from a flat 7-file layout into workload-scoped guidance:
  - Shared: `auth.md`, `tools.md`, `workflow.md`
  - Custom transformations: `workload-custom.md` + `workload-custom-{cli-reference,multi-transformation,remote-execution,repo-analysis,results-synthesis,single-transformation,td-creation,troubleshooting}.md`
  - New workloads: `workload-dotnet.md`, `workload-mainframe.md`, `workload-sql.md`, `workload-vmware.md`, `workload-vmware-network.md`