### PR TITLE
fix: walkthrough frontmatter + clarify identity requirements for chat

### DIFF
--- a/aws-devops-agent/POWER.md
+++ b/aws-devops-agent/POWER.md
@@ -119,7 +119,7 @@ Call these via `aws___call_aws` with service `devops-agent` (except `SendMessage
 |-----------|-----------|---------|
 | `CreateChat` | `agentSpaceId, userId, userType` (`IAM`\|`IDC`\|`IDP`) | Create a new chat session → returns `executionId`. **userId and userType are required** |
 | `ListChats` | `agentSpaceId, userId?, maxResults?` | List recent chat sessions |
-| `SendMessage` | `agentSpaceId, executionId, content, userId, context?` | Send a message and stream the response. **Requires `aws___run_script`** — returns EventStream. userId is required for chat sessions (may be optional for investigation executionIds). **Note**: use `call_boto3` only with chat executionIds (pure UUID from `create-chat`); investigation executionIds (`exe-ops1-*`) require the CLI path |
+| `SendMessage` | `agentSpaceId, executionId, content, userId, context?` | Send a message and stream the response. **Requires `aws___run_script`** — returns EventStream. **userId is always required.** Use `call_boto3` only with chat executionIds (pure UUID from `create-chat`); investigation executionIds (`exe-ops1-*`) require the CLI path (`list-journal-records`) |
 
 ### Account & Resource Management
 | Operation | Parameters | Purpose |
@@ -418,7 +418,7 @@ You:
 - **Track investigation IDs**: Keep the `taskId` and `executionId` from each investigation to poll progress and retrieve results
 - **Resume analysis**: Use `ListBacklogTasks` to find previous investigations. Check their status and recommendations
 - **One investigation per incident**: Don't create duplicate investigations. Use `ListBacklogTasks` with status filter to check for existing ones
-- **Send follow-up on investigation**: You can use `SendMessage` with an investigation's `executionId` to ask follow-up questions about its findings
+- **Send follow-up on investigation**: Use `list-journal-records` to read investigation findings. Do NOT use `SendMessage` with investigation executionIds — chat and investigation are separate workflows
 
 ---
 
@@ -451,7 +451,7 @@ aws configure sso  # SSO users
 aws configure      # IAM access keys (chat may require SSO identity)
 ```
 
-> **Note**: `CreateChat` requires user identity resolution through the Operator App (IDC or IAM auth). If using plain IAM credentials and `CreateChat` fails with "User identity could not be resolved", you can still use `SendMessage` on investigation executionIds from `CreateBacklogTask`.
+> **Note**: All chat operations (`CreateChat` and `SendMessage`) require user identity resolution. If `CreateChat` fails with "User identity could not be resolved", `SendMessage` will fail the same way — use the investigation workflow (`create-backlog-task` + `list-journal-records`) instead.
 
 ### 1b. Required IAM Permissions
 
@@ -507,7 +507,7 @@ Restart Kiro → `/mcp` to check connection → `/tools` to see `aws___call_aws`
 
 1. **SSO (recommended)**: Run `aws sso login`, then use `--user-type IDC` on `create-chat`
 2. **IAM with explicit userId**: Pass `--user-id YOUR_USERNAME --user-type IAM` on `create-chat` and `userId=YOUR_USERNAME` on `SendMessage`. The `--user-id` value must match `^[a-zA-Z0-9_.-]+$` (any string, e.g. your Unix username)
-3. **Investigation fallback**: Use `SendMessage` on investigation executionIds (from `CreateBacklogTask`) which may work without explicit userId
+3. **Investigation fallback**: If chat identity resolution fails entirely, use the investigation workflow (`create-backlog-task` + `list-journal-records`) which does not require user identity
 
 **"AccessDeniedException"**
 → Missing IAM permissions. Attach these to your IAM user/role:

--- a/aws-devops-agent/steering/ecs-incident-walkthrough.md
+++ b/aws-devops-agent/steering/ecs-incident-walkthrough.md
@@ -1,5 +1,7 @@
 ---
 inclusion: auto
+name: ecs-incident-walkthrough
+description: Worked example of the full ECS incident workflow — chat triage, deep investigation with streamed progress, mitigation plan generation, and local IaC fix. Use when investigating ECS 503 errors, service outages, or deployment failures.
 ---
 # Walkthrough: ECS 503 incident — chat triage → investigation → mitigation
 

--- a/aws-devops-agent/steering/steering.md
+++ b/aws-devops-agent/steering/steering.md
@@ -65,7 +65,7 @@ Best for: cost optimization, architecture review, topology mapping, knowledge di
 
 ## Error Recovery
 - **ExpiredTokenException** → Tell user: "Run `aws sso login` to refresh AWS credentials"
-- **User identity could not be resolved** → Pass `--user-id YOUR_USERNAME --user-type IAM` on `create-chat` and `userId=YOUR_USERNAME` on `SendMessage`. Use `--user-type IDC` for SSO. Fallback: `SendMessage` on investigation executionIds may work without userId
+- **User identity could not be resolved** → Pass `--user-id YOUR_USERNAME --user-type IAM` on `create-chat` and `userId=YOUR_USERNAME` on `SendMessage`. Use `--user-type IDC` for SSO. If identity resolution still fails, chat is unavailable — use the investigation workflow instead
 - **ResourceNotFoundException** → AgentSpace may be deleted, re-run `list-agent-spaces`
 - **ThrottlingException** → Wait 5 seconds and retry once
 - **ValidationException** on userId → alphanumeric, `.`, `-`, `_` only — no ARNs


### PR DESCRIPTION
## Changes

1. **Walkthrough frontmatter** — adds `name` + `description` to `ecs-incident-walkthrough.md` so Kiro can keyword-match and auto-load it (per [steering docs](https://kiro.dev/docs/steering/#auto-inclusion)).

2. **Identity resolution clarity** — removes misleading suggestions that `SendMessage` works on investigation executionIds or without identity resolution:
   - SendMessage API reference: "may be optional" → "**userId is always required**"
   - Setup note: "you can still use SendMessage on investigation executionIds" → "use the investigation workflow instead"
   - Follow-up section: removed suggestion to SendMessage with investigation executionIds
   - Troubleshooting: "may work without userId" → "use investigation workflow which does not require user identity"
   - Steering: removed "Fallback: SendMessage on investigation executionIds may work without userId"

## Why

The walkthrough needs `name`/`description` for Kiro's auto-inclusion to keyword-match it (follow-up from PR #127 review).

The identity docs sent users down a rabbit hole — both `CreateChat` and `SendMessage` require identity resolution. If one fails, the other will too. Investigations (`create-backlog-task` + `list-journal-records`) are the correct fallback since they don't require user identity.