### PR TITLE
fix(aws-transform-agent-toolkit): correct a2aSupported example and UpdateAgent claim

### DIFF
--- a/aws-transform-agent-toolkit/steering/agent-registration.md
+++ b/aws-transform-agent-toolkit/steering/agent-registration.md
@@ -212,7 +212,7 @@ These MUST be kept in sync with the `discover_subagents()` tool in `tools/orches
 | `chatAgentIdentifier` | string | Yes | Unique identifier for chat routing (use agent name) |
 | `a2aSupported` | boolean | Yes | Whether agent supports Agent-to-Agent protocol |
 
-> **Note:** If the agent is already registered (`ConflictException`), use `UpdateAgent` to modify `jobOrchestratorMetadata` (including `chatUILabel`) — it is fully updatable post-registration.
+> **Warning:** `jobOrchestratorMetadata` (`chatUILabel`, `chatAgentIdentifier`, `a2aSupported`) is set at `RegisterAgent` time and **cannot be updated** afterward — `UpdateAgent` only accepts `customerConfiguredAgentDependencies`, `marketplaceMetadata`, and `deprecated`. To fix a wrong value (e.g. `a2aSupported: false`), you must re-register under a different agent name. Choose carefully.
 
 ### Complete Examples
 
@@ -552,7 +552,7 @@ The minimum structure that passes boto3 and server-side validation (works for bo
     "tags": ["analysis", "assessment"],
     "capabilities": {
       "restartable": true,
-      "a2aSupported": false,
+      "a2aSupported": true,
       "legacyDashboard": false,
       "legacyTaskLink": false,
       "webAppV2": true,


### PR DESCRIPTION
## Summary
Two issues in `aws-transform-agent-toolkit/steering/agent-registration.md` caused users to register orchestrators that the AWS Transform webapp couldn't chat with:

1. The "Complete agentCard Example" set `a2aSupported: false`. Users (and LLMs) following this as a template registered chat-broken agents — the webapp lists them but won't route messages to them. Flipped to `true` to match every other example in the file (Minimal, Orchestrator, Python, etc.).
2. A note above claimed `jobOrchestratorMetadata` is "fully updatable post-registration" via `UpdateAgent`. The registry's `UpdateAgent` API actually only accepts `customerConfiguredAgentDependencies`, `marketplaceMetadata`, and `deprecated` — there is no path to update `jobOrchestratorMetadata` once registered. Replaced with an accurate warning that matches `troubleshooting.md`.

## Why this matters
The combination is a trap: users start by copying the "Complete" example (with `false`), assume they can fix it later, and end up unable to recover without re-registering under a new agent name.

## Test plan
- [x] Diff is 2 lines + 1 warning rewrite — no other changes
- [x] All other `a2aSupported` examples in the file remain `true` (verified via grep)
- [x] Updated note matches the existing accurate guidance in `troubleshooting.md` line 93