### PR TITLE
refactor(aws-devops-agent): remove references to aws___suggest_aws_commands

### DIFF
--- a/aws-devops-agent/POWER.md
+++ b/aws-devops-agent/POWER.md
@@ -54,7 +54,6 @@ You are enhanced with the **AWS DevOps Agent**, an AI-powered operational intell
 |------|---------|
 | `aws___call_aws` | Execute any AWS API — use with `devops-agent` service for standard (non-streaming) operations |
 | `aws___run_script` | Execute Python in a sandboxed environment with AWS API access — **required for streaming APIs** like `SendMessage` |
-| `aws___suggest_aws_commands` | Get syntax help for DevOps Agent APIs (use when unsure of parameters) |
 | `aws___search_documentation` | Search AWS docs, skills (formerly Agent SOPs), and best practices |
 | `aws___read_documentation` | Read full AWS documentation pages |
 | `aws___retrieve_skill` | Retrieve domain-specific expertise, workflows, and best practices (formerly `retrieve_agent_sop`) |
@@ -564,7 +563,6 @@ These tools are inherently safe regardless of arguments — they **cannot modify
       "autoApprove": [
         "aws___list_regions",
         "aws___get_regional_availability",
-        "aws___suggest_aws_commands",
         "aws___search_documentation",
         "aws___read_documentation",
         "aws___recommend",

--- a/aws-devops-agent/steering/steering.md
+++ b/aws-devops-agent/steering/steering.md
@@ -9,7 +9,6 @@ alwaysApply: true
 - **For standard operations**: Use `aws___call_aws` with `cli_command="aws devops-agent <operation> ..."` for all non-streaming DevOps Agent operations
 - **For streaming APIs (SendMessage)**: Use `aws___run_script` with the sandbox's `call_boto3` helper — `call_aws` cannot handle EventStream responses. Raw `import boto3` is blocked; use `await call_boto3(service_name='devops-agent', operation_name='SendMessage', params={...})`. See POWER.md for the full streaming code
 - **For knowledge discovery**: Use `aws___search_documentation` or `aws___retrieve_skill`
-- **For API help**: Use `aws___suggest_aws_commands` when unsure of parameters
 - **For long-running tasks**: Use `aws___get_tasks` to poll status of tasks started by `call_aws` or `run_script`
 
 ## Intent Routing (auto-detect, never ask)


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Remove references to `aws___suggest_aws_commands` as it is being retired.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
