### PR TITLE
docs(healthomics): Add Nextflow profile support and v26.04
  guidance

### DIFF
--- a/aws-healthomics/steering/migration-guide-for-nextflow.md
+++ b/aws-healthomics/steering/migration-guide-for-nextflow.md
@@ -47,9 +47,7 @@ AWS HealthOmics requires:
 1. Scan all module files for resource declarations.
 2. Identify processes relying only on labels.
 3. Verify all processes in `conf/base.config` have explicit resources.
-4. Add HealthOmics-specific resource overrides to Nextflow files or the modules configuration file or the top level `nextflow.config`.
-
-DO NOT create a HealthOmics specific profile. HealthOmics DOES NOT current support profiles.
+4. Add HealthOmics-specific resource overrides to Nextflow files or the modules configuration file or the top level `nextflow.config`. Overrides MAY live at the top level or inside a profile — see Phase 5.
 
 **Done WHEN**:
 - All processes have resources via direct declaration or label.
@@ -118,10 +116,21 @@ You MUST complete the following steps
 
 ### Phase 5: Configuration and Testing
 
-**Objective**: Create HealthOmics-specific configuration and validate.
+**Objective**: Create HealthOmics-compatible configuration and validate.
+
+**Profile Support Notes**:
+- HealthOmics supports Nextflow profiles for ALL supported Nextflow versions. Profiles MUST be defined inside the workflow definition zip — HealthOmics does NOT fetch profile definitions from external sources.
+- Profiles are selected at runtime by passing `engineSettings.profile` on `StartRun`. HealthOmics injects `-profile` into the engine. Multiple profiles MAY be specified comma-separated (e.g. `"test,docker"`). See the [Running a Workflow SOP](./running-a-workflow.md) for the StartRun parameters.
+- For Nextflow v26.04+, profiles are applied in command-line order; for earlier versions, in definition order.
+- IF the user does not specify a profile and a `standard` profile is defined, HealthOmics applies `standard` automatically. Otherwise the top-level (default) configuration applies.
+- IF the workflow uses profiles, RECOMMEND pinning `manifest.nextflowVersion` so profile application stays consistent across runs.
+- A nonexistent profile name returns a validation error from HealthOmics.
+- Explicit run parameters override profile-defined parameter values.
 
 **Steps**:
-1. Create comprehensive `conf/healthomics.config`:
+1. Choose a configuration shape based on the workflow and user preference. Top-level `nextflow.config` settings, profile-scoped settings, and a hybrid are all supported. Examples:
+
+   **Option A — top-level config (no profile required at run time)**:
    ```groovy
    params {
        container_registry = '<account>.dkr.ecr.<region>.amazonaws.com/<workflow-name>'
@@ -141,25 +150,63 @@ You MUST complete the following steps
    }
    ```
 
-2. Create `conf/test/test_healthomics.config` with small test dataset.
-
-3. Update `nextflow.config` with profiles:
+   **Option B — profile-based**:
    ```groovy
    profiles {
        healthomics { includeConfig 'conf/healthomics.config' }
        test_healthomics { includeConfig 'conf/test/test_healthomics.config' }
    }
    ```
+   Then run with `engineSettings.profile = "healthomics"`.
 
-4. Execute test plan:
+2. IF using a test profile, create `conf/test/test_healthomics.config` (or equivalent) with a small test dataset.
+
+3. Execute test plan:
    - Stage 1: Validate configuration locally.
-   - Stage 2: Test on HealthOmics with minimal dataset.
-   - Stage 3: Test with full-size dataset.
+   - Stage 2: Test on HealthOmics with a minimal dataset.
+   - Stage 3: Test with a full-size dataset.
    - Stage 4: Resource optimization.
 
 **Done WHEN**:
-- `conf/healthomics.config` complete with correct syntax.
-- Test profile completes successfully on HealthOmics.
+- Configuration shape (top-level, profile, or hybrid) is documented.
+- IF profiles are used, profile definitions are inside the workflow zip and the run uses `engineSettings.profile`.
+- Test run completes successfully on HealthOmics.
+
+### Phase 6: Nextflow Version Compatibility
+
+**Objective**: Reconcile workflow with the Nextflow engine version selected for the run (`manifest.nextflowVersion`).
+
+**Plugin pre-install matrix** — HealthOmics ignores any other plugin versions specified in `nextflow.config` and CANNOT fetch plugins at run time:
+
+| Engine version | Pre-installed plugins |
+| --- | --- |
+| v22.04 | none |
+| v23.10 | `nf-validation@1.1.1`, `nf-schema@2.3.0` |
+| v24.10 | `nf-schema@2.3.0` |
+| v25.10 | `nf-schema@2.6.1`, `nf-core-utils@0.4.0`, `nf-prov@1.7.0`, `nf-fgbio@1.0.1` |
+| v26.04 | `nf-schema@2.7.2`, `nf-core-utils@0.4.0`, `nf-prov@1.7.0`, `nf-fgbio@1.0.1` |
+
+For Nextflow v24+, `nf-schema` replaces the deprecated `nf-validation`.
+
+**Steps**:
+1. Determine the target engine version. Read `manifest.nextflowVersion` if pinned; otherwise ASK the user.
+2. Verify every plugin the workflow uses appears in the matrix above for the chosen version. Remove or replace plugin references that aren't pre-installed.
+3. IF the target version is v26.04, audit the workflow for v26 breaking changes and deprecations:
+   - **Strict (v2) syntax is the default.** v1-only syntax will fail to parse. The user has two options — present BOTH and let them choose:
+     - Migrate the workflow to v2 syntax (see the [Strict syntax reference](https://docs.seqera.io/nextflow/strict-syntax)).
+     - Keep v1 syntax and pass `engineSettings.syntaxVersion = "v1"` on `StartRun`.
+   - Replace `listFiles()` with `listDirectory()` (deprecation warning otherwise).
+   - Remove `nextflow.enable.strict` from config (no longer needed; strict is the default).
+   - Remove `manifest.defaultBranch` from config (not used; HealthOmics has never supported Git-based pipeline checkout).
+4. IF the target version is v25.10 or v26.04, the workflow MAY use the top-level `output { }` block and write workflow-level content (provenance reports, DAGs) to `/mnt/workflow/output/` — see Phase 4.
+5. The following Nextflow v26.04 features are NOT supported on HealthOmics. Remove or avoid them:
+   - **Nextflow Registry module fetching** — HealthOmics workflows run in an isolated network; include modules directly in the workflow zip.
+   - **Static typing (preview)**.
+   - **Auto-load collection params from files** — depends on static typing.
+
+**Done WHEN**:
+- All plugins referenced by the workflow are in the pre-install matrix for the selected engine version.
+- For v26.04 targets: deprecated symbols/configs removed, syntax decision documented, unsupported features absent.
 
 ## Technical Patterns
 

--- a/aws-healthomics/steering/running-a-workflow.md
+++ b/aws-healthomics/steering/running-a-workflow.md
@@ -35,6 +35,26 @@ Follow this SOP WHEN:
 2. Call `GetAHORun` to check status.
 3. WHEN the workflow completes, outputs will be at the specified output location.
 
+### Engine Settings
+
+`StartRun` accepts an `engineSettings` map that customizes how HealthOmics invokes the workflow engine. The map is engine-agnostic in concept; today only Nextflow keys are implemented, so pass it only for Nextflow workflows. Pass it only when the user requests the corresponding behavior.
+
+> **Tooling support**: `engineSettings` is part of the HealthOmics REST API, but it is NOT yet exposed by every released AWS CLI/SDK version — older clients reject it with `Unknown parameter: "engineSettings"`. Prefer the HealthOmics MCP server (which sends the field directly) to start runs that use `engineSettings`. If you must use the AWS CLI, first confirm the installed version accepts it (`aws omics start-run help` lists `--engine-settings`); if it does not, upgrade the CLI/SDK. Do not assume the `--engine-settings` flag exists on the user's installed CLI.
+
+Currently supported keys (Nextflow):
+
+| Key | Purpose | Notes |
+| --- | --- | --- |
+| `profile` | Selects one or more profiles defined in the workflow's `nextflow.config`. | Comma-separated for multiple (e.g. `"test,docker"`). Order matters: v26.04+ applies in command-line order; earlier versions apply in definition order. A nonexistent profile = validation error. Profiles MUST be inside the workflow zip. |
+| `syntaxVersion` | Selects the Nextflow parser syntax. | v26.04 defaults to strict (v2) syntax. Set to `"v1"` to run a workflow authored against the legacy parser. Not supported on v25.10 and earlier. |
+| `outputFormat` | Format for the workflow output summary printed on completion. | v26.04+ only. |
+| `agentMode` | Enables Nextflow agent logging mode. | v26.04+ only. |
+
+Behavior to know (Nextflow profiles):
+- IF the workflow defines a `standard` profile and the user does not specify one, HealthOmics applies `standard` automatically.
+- Explicit run parameters (in `parameters.json`) override profile-defined parameter values.
+- Recommend pinning `manifest.nextflowVersion` in the workflow when profiles are in use, so profile application is consistent across runs.
+
 ### Handling Failures
 
 IF the workflow run fails:

--- a/aws-healthomics/steering/workflow-development.md
+++ b/aws-healthomics/steering/workflow-development.md
@@ -47,6 +47,15 @@ This SOP defines how you, the agent, create and deploy genomics workflows for AW
 - WHEN using Nextflow 25.10+ `output { }` block, you MUST use ONLY relative paths in the `path` directive (HealthOmics manages the output directory).
 - Workflow-level content (provenance reports, DAGs) MUST be written to `/mnt/workflow/output/`.
 
+### Nextflow Engine Version
+- Pin the engine version with `manifest.nextflowVersion` in `nextflow.config` when the workflow depends on version-specific behavior or plugins.
+- HealthOmics workflows run in an isolated network and CANNOT fetch plugins or modules at run time. The workflow MUST only depend on plugins pre-installed by HealthOmics for the target engine version. For the per-version plugin matrix and feature support, see [Phase 6: Nextflow Version Compatibility](./migration-guide-for-nextflow.md#phase-6-nextflow-version-compatibility) in the Nextflow migration guide.
+- Nextflow v26.04 defaults to the strict (v2) syntax parser. Workflows authored against the legacy (v1) parser must opt in via `engineSettings.syntaxVersion = "v1"` at run time — see [Engine Settings](./running-a-workflow.md#engine-settings) in the Running a Workflow SOP.
+
+### Nextflow Profiles
+- HealthOmics supports profiles defined in the workflow's `nextflow.config` `profiles { }` block. Profiles MUST be defined inside the workflow zip — HealthOmics does NOT fetch profile definitions from external sources.
+- Profiles are selected at run time via `engineSettings.profile` — see [Engine Settings](./running-a-workflow.md#engine-settings).
+
 ### Containers
 - All workflow tasks run in containers. Containers MUST contain all software used in the script/command.
 - If the container is in a public registry (e.g. docker, ecr-public, quay.io) you MUST use ECR Pull Through caches. Consult the [ECR Pull Through Cache SOP](./ecr-pull-through-cache.md).


### PR DESCRIPTION
Updates the aws-healthomics steering docs for Nextflow profile
  support across all engine versions and Nextflow v26.04 (strict v2 syntax, new
  pre-installed plugins, agent mode, output summaries).

  - **migration-guide-for-nextflow.md**: removes the contradictory "no profiles
  support" line in Phase 2; reworks Phase 5 to present top-level,
  profile-based, and hybrid configs as equally valid; adds Phase 6 (version
  compatibility) with the per-version plugin pre-install matrix, v26
  strict-syntax migration options, deprecations, and unsupported v26 features.
  - **running-a-workflow.md**: adds an Engine Settings section documenting the
  Nextflow `engineSettings` keys (`profile`, `syntaxVersion`,
  `outputFormat`, `agentMode`) and profile application behavior.
  - **workflow-development.md**: adds short Engine Version and Profiles
  subsections linking to the matrix and Engine Settings reference.