### PR TITLE
Add github reference link to new security agent policy json and existing EC2 policy json

### DIFF
--- a/aws-transform/POWER.md
+++ b/aws-transform/POWER.md
@@ -4,7 +4,7 @@ displayName: "AWS Transform"
 description: "Migrate, modernize, and upgrade codebases: .NET Framework to .NET 8/10, mainframe COBOL to Java, VMware VMs to EC2, SQL Server/Oracle/MySQL to Aurora, and Java/Python/Node.js version upgrades or AWS SDK migrations. Assess, plan, and execute code transformations from your IDE."
 keywords: ["migrate", "modernize", "mainframe", "cobol", "vmware", "dotnet", ".net framework", "windows", "sql server", "oracle", "mysql", "aurora", "ec2 migration", "rehost", "lift-and-shift", "replatform", "legacy", "code upgrade", "sdk migration", "boto3", "java upgrade", "atx", "continuous modernization", "AWS Transform - continuous modernization"]
 author: "AWS"
-version: "2.1.0"
+version: "2.1.1"
 ---
 
 # AWS Transform Power

--- a/aws-transform/steering/AWSTransformSecurityAgentExecutorAccess.json
+++ b/aws-transform/steering/AWSTransformSecurityAgentExecutorAccess.json
@@ -1,0 +1,70 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "STSIdentity",
+            "Effect": "Allow",
+            "Action": "sts:GetCallerIdentity",
+            "Resource": "*"
+        },
+        {
+            "Sid": "SecurityAgentApi",
+            "Effect": "Allow",
+            "Action": [
+                "securityagent:ListAgentSpaces",
+                "securityagent:CreateCodeReview",
+                "securityagent:StartCodeReviewJob",
+                "securityagent:ListCodeReviewJobsForCodeReview",
+                "securityagent:ListFindings",
+                "securityagent:BatchGetFindings",
+                "securityagent:StartCodeRemediation"
+            ],
+            "Resource": "arn:aws:securityagent:*:*:agent-space*",
+            "Condition": {
+                "StringEquals": {
+                    "aws:ResourceAccount": "${aws:PrincipalAccount}"
+                }
+            }
+        },
+        {
+            "Sid": "S3SecurityAgentBucketRead",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject",
+                "s3:ListBucket"
+            ],
+            "Resource": [
+                "arn:aws:s3:::kct-security-agent-*",
+                "arn:aws:s3:::kct-security-agent-*/*"
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "s3:ResourceAccount": "${aws:PrincipalAccount}"
+                }
+            }
+        },
+        {
+            "Sid": "S3SecurityAgentUpload",
+            "Effect": "Allow",
+            "Action": "s3:PutObject",
+            "Resource": "arn:aws:s3:::kct-security-agent-*/security-scans/*",
+            "Condition": {
+                "StringEquals": {
+                    "s3:ResourceAccount": "${aws:PrincipalAccount}"
+                }
+            }
+        },
+        {
+            "Sid": "IAMPassSecurityAgentRole",
+            "Effect": "Allow",
+            "Action": "iam:PassRole",
+            "Resource": "arn:aws:iam::*:role/security-agent-*",
+            "Condition": {
+                "StringEquals": {
+                    "iam:PassedToService": "securityagent.amazonaws.com",
+                    "aws:ResourceAccount": "${aws:PrincipalAccount}"
+                }
+            }
+        }
+    ]
+}

--- a/aws-transform/steering/workload-continuous-modernization-ec2-execution.md
+++ b/aws-transform/steering/workload-continuous-modernization-ec2-execution.md
@@ -1229,7 +1229,7 @@ The agent MUST print the following to the customer:
 >
 > The agent MUST include the following sentence verbatim in every Step 5d handoff, immediately after the admin-identity sentence above and before the command block. Do NOT abbreviate, drop, or paraphrase it -- customers onboarding a new executor identity rely on this pointer:
 >
-> For reference, the executor policy this skill expects is in `references/AWSTransformInfrastructureExecutorAccessEC2.json`.
+> For reference, the executor policy this skill expects is in https://github.com/kirodotdev/powers/blob/main/aws-transform/steering/AWSTransformInfrastructureExecutorAccessEC2.json
 >
 > Those permissions are admin-scope; the executor permissions I'm running under intentionally do not grant them, so day-to-day analysis runs cannot escalate privileges.
 >

--- a/aws-transform/steering/workload-continuous-modernization-security-agent.md
+++ b/aws-transform/steering/workload-continuous-modernization-security-agent.md
@@ -31,6 +31,8 @@ The admin provisions the security agent infrastructure: an IAM role, a managed p
 Tell the customer:
 
 > "This deploys the security agent infrastructure (IAM role, S3 bucket, CloudFormation stack). It requires admin/role-creation permissions. Run it with an admin identity. Read-only or runtime credentials are enough for everything afterward."
+>
+> For reference, the executor policy this skill expects is in https://github.com/kirodotdev/powers/blob/main/aws-transform/steering/AWSTransformSecurityAgentExecutorAccess.json
 
 ```bash
 # Ensure atx ct is installed and up to date


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Add github reference link to new security agent policy json and existing EC2 policy json since JSON files are not visible when downloading the kiro power.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
