### PR TITLE
fix: sync aws-transform steering from internal mainline; bump to 2.1.2

### DIFF
--- a/aws-transform/POWER.md
+++ b/aws-transform/POWER.md
@@ -4,7 +4,7 @@ displayName: "AWS Transform"
 description: "Migrate, modernize, and upgrade codebases: .NET Framework to .NET 8/10, mainframe COBOL to Java, VMware VMs to EC2, SQL Server/Oracle/MySQL to Aurora, and Java/Python/Node.js version upgrades or AWS SDK migrations. Assess, plan, and execute code transformations from your IDE."
 keywords: ["migrate", "modernize", "mainframe", "cobol", "vmware", "dotnet", ".net framework", "windows", "sql server", "oracle", "mysql", "aurora", "ec2 migration", "rehost", "lift-and-shift", "replatform", "legacy", "code upgrade", "sdk migration", "boto3", "java upgrade", "atx", "continuous modernization", "AWS Transform - continuous modernization"]
 author: "AWS"
-version: "2.1.1"
+version: "2.1.2"
 ---
 
 # AWS Transform Power

--- a/aws-transform/steering/workload-continuous-modernization-analysis.md
+++ b/aws-transform/steering/workload-continuous-modernization-analysis.md
@@ -67,43 +67,6 @@ atx ct analysis cancel --id <id>
 atx ct analysis delete --id <id> [--cascade-findings]
 ```
 
-## Security analysis prerequisite
-
-If the analysis type is `security`, `agentic-readiness`, or `modernization-readiness` (these all use the security-agent under the hood), the agent space resource must be provisioned in the customer's account before the analysis can run. The first run in any new account triggers `securityagent:CreateAgentSpace`, which requires admin credentials. After that one-time bootstrap, every subsequent run finds the existing agent space via `list-agent-spaces` and never needs `CreateAgentSpace` again.
-
-**The agent MUST run this check before submitting a security/agentic-readiness/modernization-readiness analysis:**
-
-```bash
-AGENT_SPACE_ID=$(atx ct setup security-agent --status 2>/dev/null | jq -r '.agentSpaceId // ""')
-
-if [ -z "$AGENT_SPACE_ID" ]; then
-  # First-time bootstrap required: agent space not yet provisioned in this account.
-  echo "agent space not yet provisioned"
-fi
-```
-
-**If `agentSpaceId` is empty**, the agent MUST stop and emit an admin handoff. The customer needs to run the analysis once with admin credentials (creates the agent space, populates `agentSpaceId` in the local config), then re-run with whatever credentials they normally use.
-
-**Profile-name guidance for the agent.** When emitting the bootstrap handoff command, the agent MUST use the placeholder `<your-admin-profile>` rather than guessing a profile name from the customer's local AWS config, environment variables, or shell history. Substituting a wrong name leads to confusing AccessDenied errors.
-
-Suggested phrasing:
-
-> "Before I can run a `<analysis-type>` analysis, the agent space resource needs to be provisioned in your account. This is a one-time bootstrap that requires admin credentials -- only the first security/agentic-readiness/modernization-readiness analysis ever in this account needs this. Run this with your admin profile:
->
-> ```bash
-> AWS_PROFILE=<your-admin-profile> atx ct analysis run \
->   --type <analysis-type> \
->   --source <source-name> \
->   --repo "<source-name>::<one-repo>" \
->   --telemetry "agent=<AGENT>,executionMode=local"
-> ```
->
-> Pick any one repo from your source -- the bootstrap doesn't depend on which one. After it completes, your local `~/.atxct/shared/security_agent_config.json` will have `agentSpaceId` populated. Re-run your original request and the analysis will proceed without admin creds."
-
-The agent then STOPS this turn. On the next user turn, re-check `--status`; if `agentSpaceId` is now populated, proceed with the original analysis request.
-
-**If `agentSpaceId` is populated** (already bootstrapped), proceed with the analysis normally using whatever credentials the customer's local profile has.
-
 ## Custom Analysis
 
 The `custom` type runs any transformation definition (TD) against a repository. Unlike other analysis types, custom analysis does not generate findings -- it executes the TD directly.

--- a/aws-transform/steering/workload-continuous-modernization-batch-execution.md
+++ b/aws-transform/steering/workload-continuous-modernization-batch-execution.md
@@ -139,15 +139,27 @@ will fail rather than auto-provision.
   guide the user toward any VPC (including the default VPC). Present all VPCs
   neutrally without commentary on which is "simplest", "easiest", or "looks
   pre-configured". The user must make their own informed choice.
-- After the user picks a VPC, show its subnets and security groups:
+- After the user picks a VPC, show its **private** subnets and security groups:
 
   ```bash
-  aws ec2 describe-subnets --filters "Name=vpc-id,Values=<vpcId>" \
-    --query 'Subnets[*].[SubnetId,AvailabilityZone,MapPublicIpOnLaunch,Tags[?Key==`Name`].Value|[0]]' --output table
+  aws ec2 describe-subnets --filters "Name=vpc-id,Values=<vpcId>" "Name=map-public-ip-on-launch,Values=false" \
+    --query 'Subnets[*].[SubnetId,AvailabilityZone,Tags[?Key==`Name`].Value|[0]]' --output table
   aws ec2 describe-security-groups --filters "Name=vpc-id,Values=<vpcId>" \
     --query 'SecurityGroups[*].[GroupId,GroupName,Description]' --output table
   ```
 
+- You MUST only present **private subnets** (`MapPublicIpOnLaunch=false`) to the user.
+  The query above filters them via `map-public-ip-on-launch=false`. This is a hard
+  requirement: the CDK stack sets `assignPublicIp: DISABLED` on Fargate tasks, so tasks
+  in public subnets get a private IP that cannot route through an internet gateway.
+  If the result set is empty (all subnets in the VPC are public), tell the user:
+  "No private subnets found in this VPC. This stack does not support public subnets —
+  Fargate tasks require private subnets with NAT gateway for outbound connectivity."
+  Then direct them to `create-vpc.sh`.
+  If the VPC contained public subnets that were filtered out, include this note when
+  presenting results: "Some subnets in this VPC were not shown because they are public
+  (auto-assign public IP enabled). This stack does not support public subnets — Fargate
+  tasks require private subnets with NAT gateway for outbound connectivity."
 - Then ask the user to select:
   1. `existing_subnet_ids`: which subnets (MANDATORY).
   2. `existing_security_group_id`: which security group (MANDATORY).
@@ -167,6 +179,28 @@ will fail rather than auto-provision.
 
 - You MUST verify, and report results to the user, the following BEFORE rewriting
   config, because each is a silent deploy-time or runtime failure if wrong:
+  - The selected subnets do NOT route to an internet gateway. Run:
+
+    ```bash
+    aws ec2 describe-route-tables \
+      --filters "Name=association.subnet-id,Values=<subnet-id-1>,<subnet-id-2>" \
+      --query 'RouteTables[*].Routes[?DestinationCidrBlock==`0.0.0.0/0`].[GatewayId]' --output text
+    ```
+
+    If no explicit association exists for a subnet, also check the VPC's main route
+    table:
+
+    ```bash
+    aws ec2 describe-route-tables \
+      --filters "Name=vpc-id,Values=<vpcId>" "Name=association.main,Values=true" \
+      --query 'RouteTables[*].Routes[?DestinationCidrBlock==`0.0.0.0/0`].[GatewayId]' --output text
+    ```
+
+    If any result starts with `igw-`, REJECT and tell the user: "Subnet <id> has a
+    default route to an internet gateway (igw-...). This stack does not support public
+    subnets — Fargate tasks deployed here would have no outbound network path. Please
+    select subnets that route through a NAT gateway or VPC endpoints."
+    You MUST NOT proceed to cdk.json rewrite if any selected subnet has an IGW route.
   - The supplied subnets are in availability zones `${REGION}a` and `${REGION}b`,
     because the stack hardcodes those AZs (`lib/infrastructure-stack.ts`).
   - The subnets have egress (NAT gateway or VPC endpoints), because the stack does

--- a/aws-transform/steering/workload-continuous-modernization-ec2-execution.md
+++ b/aws-transform/steering/workload-continuous-modernization-ec2-execution.md
@@ -1241,7 +1241,7 @@ The agent MUST print the following to the customer:
 - ❌ `AWS_PROFILE=admin aws cloudformation create-stack ...` (the agent assumed a name)
 - ✅ `AWS_PROFILE=<your-admin-profile> aws cloudformation create-stack ...` (placeholder for the customer to fill in)
 
-This rule applies to **every admin handoff in this skill**: create-stack, delete-stack, security-agent bootstrap, instance-tag handoff, instance-role-policy handoff, anywhere else admin is invoked.
+This rule applies to **every admin handoff in this skill**: create-stack, delete-stack, instance-tag handoff, instance-role-policy handoff, anywhere else admin is invoked.
 
 The full handoff command set (admin runs in their shell, in `${REGION}`):
 >
@@ -1385,37 +1385,7 @@ If `ANALYSIS_TYPE=security` (or `agentic-readiness` / `modernization-readiness` 
 
 The S3 + `iam:PassRole` grants the instance role needs for security analysis are **always-on** in the CFN template (the `securityagent:*` actions, `s3:*` on `kct-security-agent-*`, and `iam:PassRole` on `security-agent-*` are part of the base role policy). No stack redeploy is required if the customer decides to run security analysis after the stack is up -- the role already has what's needed.
 
-**One-time agent-space bootstrap.** The first time anyone in this account runs a security analysis, the runtime calls `securityagent:CreateAgentSpace` to provision the agent-space resource. That permission is intentionally NOT granted to the EC2 instance role (the role only has the operate-mode `securityagent:*` actions). So the first security analysis MUST run locally with admin credentials, which create the agent space and populate `agentSpaceId` in `~/.atxct/shared/security_agent_config.json`. Every subsequent run -- on EC2 or local, by any caller -- finds the existing agent space via `list-agent-spaces` and never needs `CreateAgentSpace` again.
-
-**The agent MUST run this check before submitting a security/agentic-readiness/modernization-readiness analysis on EC2:**
-
-```bash
-atx ct setup security-agent --status 2>/dev/null > /tmp/sa-status.json
-AGENT_SPACE_ID=$(jq -r '.agentSpaceId // ""' /tmp/sa-status.json)
-
-if [ -z "$AGENT_SPACE_ID" ]; then
-  # First-time bootstrap required.
-  echo "agent space not yet provisioned"
-fi
-```
-
-**If `agentSpaceId` is empty**, the agent MUST stop the EC2 flow and emit an admin handoff. Phrasing:
-
-> "Before I can run security analysis on EC2, the agent space resource needs to be provisioned in your account. This is a one-time bootstrap that requires admin credentials (only the first security analysis ever in this account needs this). Run this on your laptop with your admin profile:
->
-> ```bash
-> AWS_PROFILE=<your-admin-profile> AWS_REGION=$REGION atx ct analysis run \
->   --type security \
->   --source $LOGICAL_SOURCE_NAME \
->   --repo "$LOGICAL_SOURCE_NAME::<one-repo>" \
->   --telemetry "agent=$AGENT,executionMode=local"
-> ```
->
-> Pick any single repo from your source -- the bootstrap doesn't depend on which one. After this completes, your local `~/.atxct/shared/security_agent_config.json` will have `agentSpaceId` populated. Come back to this conversation and I'll sync it to the EC2 container and run the actual analysis there."
-
-The agent then STOPS this turn. On the next user turn, re-check `--status`; if `agentSpaceId` is now populated, proceed to the config-sync step below.
-
-**If `agentSpaceId` is populated** (either from a prior bootstrap, or because the customer just ran the one-time admin-creds analysis), sync the config file into the EC2 container so the runtime can find the existing agent space:
+The agent space is provisioned during `atx ct setup security-agent`, which writes the populated `agentSpaceId` into `~/.atxct/shared/security_agent_config.json`. The EC2 runtime is read-only -- it finds the existing agent space via `list-agent-spaces` and never creates one. Sync the local config file into the EC2 container so the runtime can find the existing agent space:
 
 ```bash
 # Sync security agent config from laptop into all atx-ct containers.

--- a/aws-transform/steering/workload-continuous-modernization-schedule.md
+++ b/aws-transform/steering/workload-continuous-modernization-schedule.md
@@ -369,7 +369,7 @@ This step provisions the `AtxSchedulerInvocationRole` (the role EventBridge Sche
 
 **The agent does NOT run these commands itself**, even if an admin profile is reachable locally. It prepares the inputs, prints the bundle as a single admin handoff, and waits for the user to come back. This is the same pattern Step 5d uses in `continuous-modernization-ec2-execution.md`.
 
-**Profile-name guidance for the agent.** When emitting this admin handoff (or any admin handoff in this skill -- including the security-agent bootstrap below in Mode 1), the agent MUST use the placeholder `<your-admin-profile>` rather than guessing a profile name from the customer's local AWS config, environment variables, or shell history. Customers commonly have multiple AWS profiles configured locally and the agent has no reliable way to identify which one carries admin permissions. Substituting a wrong name leads to confusing AccessDenied errors during execution.
+**Profile-name guidance for the agent.** When emitting this admin handoff (or any admin handoff in this skill), the agent MUST use the placeholder `<your-admin-profile>` rather than guessing a profile name from the customer's local AWS config, environment variables, or shell history. Customers commonly have multiple AWS profiles configured locally and the agent has no reliable way to identify which one carries admin permissions. Substituting a wrong name leads to confusing AccessDenied errors during execution.
 
 This step is also idempotent -- re-running it on an already-set-up account is safe (`grep -v EntityAlreadyExists` and `grep -v ConflictException` swallow the no-op cases). So the admin runs it once per account; subsequent schedules reuse the same role and group.
 
@@ -557,37 +557,6 @@ if [ "$JOB_TYPE" = "analysis" ]; then
   fi
 fi
 ```
-
-**Security analysis bootstrap pre-check.** If `ANALYSIS_TYPE` is `security`, `agentic-readiness`, or `modernization-readiness`, the agent MUST verify the agent space has been bootstrapped before creating the schedule. Otherwise the schedule fires and the analysis fails almost immediately (the runtime tries `securityagent:CreateAgentSpace`, which the executor role doesn't grant).
-
-```bash
-if [ "$JOB_TYPE" = "analysis" ] && [[ "$ANALYSIS_TYPE" =~ ^(security|agentic-readiness|modernization-readiness)$ ]]; then
-  AGENT_SPACE_ID=$(atx ct setup security-agent --status 2>/dev/null | jq -r '.agentSpaceId // ""')
-
-  if [ -z "$AGENT_SPACE_ID" ]; then
-    cat <<'EOF'
-ERROR: Security agent space not bootstrapped.
-
-Before scheduling a security/agentic-readiness/modernization-readiness analysis,
-run ONE security analysis locally with admin credentials. This populates the
-agent-space ID in your config so subsequent runs (including this schedule)
-can use it without admin permissions.
-
-  AWS_PROFILE=<your-admin-profile> AWS_REGION=$REGION atx ct analysis run \
-    --type security \
-    --source $LOGICAL_SOURCE_NAME \
-    --repo "$LOGICAL_SOURCE_NAME::<one-repo>" \
-    --telemetry "agent=$AGENT,executionMode=local"
-
-After it completes, re-run the schedule setup. The check will see agentSpaceId
-populated and proceed.
-EOF
-    return 1
-  fi
-fi
-```
-
-The agent MUST stop and emit the bootstrap admin handoff to the customer if `agentSpaceId` is empty. **Do NOT create the schedule until bootstrap is done** -- creating it anyway just produces a schedule that fails on every fire.
 
 #### Mode 2: Remediation (`JOB_TYPE=remediation`)
 

--- a/aws-transform/steering/workload-continuous-modernization-security-agent.md
+++ b/aws-transform/steering/workload-continuous-modernization-security-agent.md
@@ -180,12 +180,14 @@ S3_BUCKET=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --regi
   --query "Stacks[0].Parameters[?ParameterKey=='S3Resource'].ParameterValue" --output text --no-cli-pager)
 ROLE_ARN=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region us-east-1 \
   --query "Stacks[0].Outputs[?OutputKey=='RoleArn'].OutputValue" --output text --no-cli-pager)
+AGENT_SPACE_ID=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region us-east-1 \
+  --query "Stacks[0].Outputs[?OutputKey=='AgentSpaceId'].OutputValue" --output text --no-cli-pager)
 
 # Write the config file
 mkdir -p ~/.atxct/shared
 cat > ~/.atxct/shared/security_agent_config.json << EOF
 {
-  "agentSpaceId": "",
+  "agentSpaceId": "${AGENT_SPACE_ID}",
   "agentSpaceName": "${AGENT_SPACE_NAME}",
   "s3Bucket": "${S3_BUCKET}",
   "roleArn": "${ROLE_ARN}",

--- a/aws-transform/steering/workload-custom-remote-execution.md
+++ b/aws-transform/steering/workload-custom-remote-execution.md
@@ -93,7 +93,13 @@ Ensure `prebuiltImageUri` is set in `cdk.json` (it should be set to "public.ecr.
 **Network configuration (MANDATORY):** Before deploying, you MUST collect VPC, subnet,
 and security group IDs from the user and write them into `cdk.json` context. AWS
 Transform does NOT create VPCs, subnets, or NAT gateways — the user provides those.
-If no suitable VPC exists, direct the user to:
+When querying subnets, filter to private subnets only (add filter
+`map-public-ip-on-launch=false`). After selection, verify the subnets' route tables
+do not have a default route to an internet gateway (`0.0.0.0/0 → igw-*`). The CDK
+stack sets `assignPublicIp: DISABLED` on Fargate tasks, so public subnets cannot
+provide outbound connectivity. If public subnets were excluded, inform the user. If
+no private subnets exist, or if an IGW route is detected post-selection, reject and
+direct the user to:
 
 ```
 cd "$ATX_INFRA_DIR" && ./create-vpc.sh


### PR DESCRIPTION
## Summary

Updates the `aws-transform` power's continuous-modernization steering docs and bumps the power version from `2.1.1` to `2.1.2` in `POWER.md`.

## Steering doc changes

- **Enforce private-subnet selection for EC2/Fargate execution** (`workload-continuous-modernization-ec2-execution.md`, `workload-continuous-modernization-batch-execution.md`, `workload-custom-remote-execution.md`): filter out public subnets (`MapPublicIpOnLaunch=true`) and reject subnets with a default route to an internet gateway. The CDK stack sets `assignPublicIp: DISABLED` on Fargate tasks, so tasks in public subnets have no outbound network path.
- **Security-agent EC2 runtime** (`workload-continuous-modernization-security-agent.md`): add agent-space provisioning/sync guidance — the runtime looks up the existing agent space read-only and syncs local config into the container.
- **Admin handoffs**: require the `<your-admin-profile>` placeholder rather than guessing a profile name from local AWS config.
- Minor cleanups in `workload-continuous-modernization-analysis.md` and `workload-continuous-modernization-schedule.md`.

## Version bump

- `aws-transform/POWER.md` frontmatter: `2.1.1` → `2.1.2`