### PR TITLE
Update aws-lambda-managed-instances power for region expansion and scheduled scaling

### DIFF
--- a/aws-lambda-managed-instances/POWER.md
+++ b/aws-lambda-managed-instances/POWER.md
@@ -2,7 +2,7 @@
 name: "aws-lambda-managed-instances"
 displayName: "AWS Lambda Managed Instances"
 description: "Evaluate, configure, and migrate workloads to AWS Lambda Managed Instances (LMI). Run Lambda functions on EC2 instances in your account while AWS manages provisioning, patching, scaling, routing, and load balancing."
-keywords: ["lambda", "lmi", "managed-instances", "ec2", "capacity-provider", "multi-concurrency", "cold-start", "graviton", "cost-optimization", "serverless", "lambda-pricing", "reserved-instances", "savings-plans"]
+keywords: ["lambda", "lmi", "managed-instances", "ec2", "capacity-provider", "multi-concurrency", "cold-start", "graviton", "cost-optimization", "serverless", "lambda-pricing", "reserved-instances", "savings-plans", "scheduled-scaling"]
 author: "AWS"
 ---
 
@@ -24,17 +24,17 @@ If this fails, configure credentials via `aws configure` or set `AWS_PROFILE`.
 
 ### Step 2: Check regional availability
 
-Currently available: us-east-1, us-east-2, us-west-2, ap-northeast-1, eu-west-1. Expanding to all commercial regions soon. Verify the latest availability:
+Available in all commercial AWS Regions except Israel (Tel Aviv), Middle East (Bahrain), Middle East (UAE), and Asia Pacific (Auckland). Verify the latest availability:
 
 - [Lambda Managed Instances documentation](https://docs.aws.amazon.com/lambda/latest/dg/lambda-managed-instances.html)
 
 ## When to Load Steering Files
 
 - **Cost comparison**, **pricing analysis**, **Lambda vs LMI cost**, **Savings Plans**, or **Reserved Instances** → `cost-comparison.md`
-- **Instance types**, **memory sizing**, **vCPU ratios**, **scaling tuning**, or **capacity provider config** → `configuration-guide.md`
+- **Instance types**, **memory sizing**, **vCPU ratios**, **scaling tuning**, **scheduled scaling**, or **capacity provider config** → `configuration-guide.md`
 - **Thread safety**, **concurrency model**, **code review checklist**, **Powertools compatibility**, or **multi-concurrency readiness** → `thread-safety.md`
 - **Before/after code examples**, **runtime-specific migration** (Node.js, Python, Java, .NET), or **connection pooling** → `migration-patterns.md`
-- **IAM roles**, **VPC setup**, **CLI commands**, **SAM template**, or **CDK example** → `infrastructure-setup.md`
+- **IAM roles**, **VPC setup**, **CLI commands**, **SAM template**, **CDK example**, or **scheduled scaling setup (EventBridge Scheduler)** → `infrastructure-setup.md`
 - **Errors**, **throttling**, **debugging**, or **stuck deployments** → `troubleshooting.md`
 
 ## Quick Decision: Is LMI Right for This Workload?
@@ -82,6 +82,7 @@ Use the [LMI Pricing Calculator](https://aws-samples.github.io/sample-aws-lambda
 - **Memory-to-vCPU ratios**: 2:1 (compute), 4:1 (general, default), 8:1 (memory). Min 2 GB, max 32 GB.
 - **Multi-concurrency defaults/vCPU**: Node.js 64, Java 32, .NET 32, Python 16.
 - **Scaling**: MinExecutionEnvironments (default 3), MaxVCpuCount (default 400), TargetResourceUtilization.
+- **Scheduled scaling**: For predictable traffic (business hours, marketing events), use EventBridge Scheduler to adjust Min/Max execution environments on a one-time or recurring schedule — scale up before peak, scale down or to zero when idle.
 
 See `configuration-guide.md` for decision trees and detailed tuning.
 
@@ -135,8 +136,10 @@ See `infrastructure-setup.md` for CLI commands and SAM templates.
 ### Operations
 
 - Set CloudWatch alarms on throttle rate > 1% and CPU > 80%
+- Use scheduled scaling (EventBridge Scheduler) for predictable traffic — raise Min/Max before peak periods and lower them (or scale to zero) when idle
 - Never manually terminate LMI EC2 instances (delete the capacity provider instead)
 - Always publish a version — unpublished functions cannot run on LMI
+- Never rely on a deactivated (Min=Max=0) function to self-recover — schedule an explicit scale-up to reactivate it
 
 ## Limits Quick Reference
 
@@ -153,6 +156,7 @@ See `infrastructure-setup.md` for CLI commands and SAM templates.
 ## Resources
 
 - [Lambda Managed Instances Docs](https://docs.aws.amazon.com/lambda/latest/dg/lambda-managed-instances.html)
+- [Scaling LMI & Scheduled Scaling Docs](https://docs.aws.amazon.com/lambda/latest/dg/lambda-managed-instances-scaling.html)
 - [Introducing LMI (AWS Blog)](https://aws.amazon.com/blogs/aws/introducing-aws-lambda-managed-instances-serverless-simplicity-with-ec2-flexibility/)
 - [Build High-Performance Apps with LMI](https://aws.amazon.com/blogs/compute/build-high-performance-apps-with-aws-lambda-managed-instances/)
 - [Migrating Functions to LMI](https://aws.amazon.com/blogs/compute/migrating-your-functions-to-aws-lambda-managed-instances/)

--- a/aws-lambda-managed-instances/steering/configuration-guide.md
+++ b/aws-lambda-managed-instances/steering/configuration-guide.md
@@ -51,6 +51,26 @@ Total capacity = MinExecutionEnvironments × PerExecutionEnvironmentMaxConcurren
 | AllowedInstanceTypes | All | Restrict only for specific hardware needs |
 | ExcludedInstanceTypes | None | Exclude expensive types in dev/test |
 
+## Scheduled Scaling (Predictable Traffic)
+
+For workloads with known traffic patterns (business hours, marketing events, batch windows), use [Amazon EventBridge Scheduler](https://docs.aws.amazon.com/scheduler/latest/UserGuide/managing-targets-universal.html) to adjust a function's `MinExecutionEnvironments` and `MaxExecutionEnvironments` on a one-time or recurring schedule. A schedule (cron or rate expression) targets the Lambda `PutFunctionScalingConfig` API as an EventBridge Scheduler universal target, passing new Min/Max values in the input payload.
+
+**Behavior:**
+
+- Scheduled scaling sets the provisioned floor and ceiling. Actual scaling between Min and Max still responds to CPU utilization and concurrency saturation.
+- If traffic more than doubles within 5 minutes of a scheduled scale-up, you may still see throttles while capacity provisions.
+- Setting both `MinExecutionEnvironments` and `MaxExecutionEnvironments` to 0 deactivates the function version (instances terminate). A deactivated function does NOT auto-recover — schedule a separate action with non-zero values to reactivate it.
+
+**Common patterns:**
+
+| Pattern | Scale-up schedule | Scale-down schedule |
+|---------|-------------------|---------------------|
+| Business hours | Raise Min/Max before work starts | Lower Min/Max after hours |
+| Marketing/launch event | Raise Min ahead of the campaign | Restore baseline after the event |
+| Idle scale-to-zero | Reactivate (non-zero) before demand | Set Min=Max=0 when idle |
+
+See `infrastructure-setup.md` for the EventBridge Scheduler IAM role and `create-schedule` CLI examples.
+
 ## Monitoring Thresholds
 
 - **CPU > 80%**: reduce concurrency or add vCPUs

--- a/aws-lambda-managed-instances/steering/infrastructure-setup.md
+++ b/aws-lambda-managed-instances/steering/infrastructure-setup.md
@@ -216,6 +216,83 @@ Resources:
           CapacityProviderArn: !GetAtt MyCP.Arn
 ```
 
+## Scheduled Scaling (EventBridge Scheduler)
+
+For predictable traffic, adjust `MinExecutionEnvironments`/`MaxExecutionEnvironments` on a schedule using [Amazon EventBridge Scheduler](https://docs.aws.amazon.com/scheduler/latest/UserGuide/managing-targets-universal.html). The schedule calls the Lambda `PutFunctionScalingConfig` API directly as a universal target — no Lambda code or extra glue required.
+
+### 1. Scheduler execution role
+
+Trust policy (allow EventBridge Scheduler to assume the role):
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {"Service": "scheduler.amazonaws.com"},
+    "Action": "sts:AssumeRole"
+  }]
+}
+```
+
+Permissions (call `PutFunctionScalingConfig` on the target function):
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": "lambda:PutFunctionScalingConfig",
+    "Resource": "arn:aws:lambda:*:*:function:my-lmi-function"
+  }]
+}
+```
+
+### 2. Create schedules
+
+Scale up before peak (08:00 UTC daily):
+
+```bash
+aws scheduler create-schedule \
+  --name ScaleUpLmi \
+  --schedule-expression "cron(0 8 * * ? *)" \
+  --flexible-time-window '{"Mode": "OFF"}' \
+  --target '{
+    "Arn": "arn:aws:scheduler:::aws-sdk:lambda:PutFunctionScalingConfig",
+    "RoleArn": "arn:aws:iam::<account-id>:role/eventbridge-scheduler-role",
+    "Input": "{\"FunctionName\": \"my-lmi-function\", \"Qualifier\": \"$LATEST.PUBLISHED\", \"FunctionScalingConfig\": {\"MinExecutionEnvironments\": 100, \"MaxExecutionEnvironments\": 1000}}"
+  }'
+```
+
+Scale down after peak (18:00 UTC daily):
+
+```bash
+aws scheduler create-schedule \
+  --name ScaleDownLmi \
+  --schedule-expression "cron(0 18 * * ? *)" \
+  --flexible-time-window '{"Mode": "OFF"}' \
+  --target '{
+    "Arn": "arn:aws:scheduler:::aws-sdk:lambda:PutFunctionScalingConfig",
+    "RoleArn": "arn:aws:iam::<account-id>:role/eventbridge-scheduler-role",
+    "Input": "{\"FunctionName\": \"my-lmi-function\", \"Qualifier\": \"$LATEST.PUBLISHED\", \"FunctionScalingConfig\": {\"MinExecutionEnvironments\": 5, \"MaxExecutionEnvironments\": 20}}"
+  }'
+```
+
+Set both values to `0` to deactivate during idle periods; schedule a separate non-zero action to reactivate (a deactivated function does not auto-recover).
+
+### Manual override
+
+Update scaling limits directly at any time:
+
+```bash
+aws lambda put-function-scaling-config \
+  --function-name my-lmi-function \
+  --qualifier '$LATEST.PUBLISHED' \
+  --function-scaling-config MinExecutionEnvironments=5,MaxExecutionEnvironments=20
+```
+
+`MinExecutionEnvironments` and `MaxExecutionEnvironments` accept values from 0 to 15000 and must be set together. Setting them on `$LATEST.PUBLISHED` propagates to future published versions.
+
 ## Cleanup
 
 ```bash


### PR DESCRIPTION
## Summary

Updates the `aws-lambda-managed-instances` power for two recent Lambda Managed Instances launches:

1. **Region expansion** ([announcement](https://aws.amazon.com/about-aws/whats-new/2026/06/aws-lambda-managed-instances-region-expansion/)) — LMI is now available in all commercial AWS Regions **except** Israel (Tel Aviv), Middle East (Bahrain), Middle East (UAE), and Asia Pacific (Auckland). Replaces the previous fixed five-region list in the Onboarding section.
2. **Scheduled scaling** ([announcement](https://aws.amazon.com/about-aws/whats-new/2026/05/aws-lambda-managed-instances/)) — documents using Amazon EventBridge Scheduler to adjust `MinExecutionEnvironments`/`MaxExecutionEnvironments` on a one-time or recurring schedule for predictable traffic (scale up before peak, scale down or to zero when idle).

## Files changed

- **`POWER.md`**: regional availability; `scheduled-scaling` keyword; scheduled-scaling note in Workflow Step 3; two Operations best practices; updated steering pointers; Scaling docs link in Resources.
- **`steering/configuration-guide.md`**: new "Scheduled Scaling (Predictable Traffic)" section — behavior notes (still scales on CPU/concurrency between bounds; `Min=Max=0` deactivates and needs explicit reactivation) and a common-patterns table.
- **`steering/infrastructure-setup.md`**: new "Scheduled Scaling (EventBridge Scheduler)" section — scheduler IAM trust/permissions policies, `create-schedule` examples targeting the `PutFunctionScalingConfig` universal target, and a manual `put-function-scaling-config` override.

## Notes

Documentation-only change; content verified against the [LMI scaling documentation](https://docs.aws.amazon.com/lambda/latest/dg/lambda-managed-instances-scaling.html). Uses placeholder identifiers (`<account-id>`) only.
