### PR TITLE
docs(aws-transform-agent-toolkit): pass required owner_contact_info to deploy pipeline

### DIFF
--- a/aws-transform-agent-toolkit/steering/deploy-agent-workflow.md
+++ b/aws-transform-agent-toolkit/steering/deploy-agent-workflow.md
@@ -79,7 +79,7 @@ Ask the user these questions in order:
 4. **Owner contact** (required): "What email or CTI should receive notifications about this agent?" (e.g., `team@example.com`)
    - Passed as `owner_contact_info`. The registry requires a contact on every published agent, so this is required unless you deploy with `skip_registry=True`.
 
-5. **IMPORTANT - Agent type**: "Will this agent be the main orchestrator that users interact with in the AWS Transform console?"
+5. **IMPORTANT - Agent type**: "Will this agent be the main orchestrator that users interact with in the AWS Transform WebApp?"
    - If user says **YES** → This is a job orchestrator (set `job_orchestrator=True`)
    - If user says **NO** → This is a subagent (set `job_orchestrator=False`)
 

--- a/aws-transform-agent-toolkit/steering/deploy-agent-workflow.md
+++ b/aws-transform-agent-toolkit/steering/deploy-agent-workflow.md
@@ -76,13 +76,16 @@ Ask the user these questions in order:
 
 3. **Agent version**: "What version?" (default: `1.0.0`)
 
-4. **IMPORTANT - Agent type**: "Will this agent be the main orchestrator that users interact with in the AWS Transform console?"
+4. **Owner contact** (required): "What email or CTI should receive notifications about this agent?" (e.g., `team@example.com`)
+   - Passed as `owner_contact_info`. The registry requires a contact on every published agent, so this is required unless you deploy with `skip_registry=True`.
+
+5. **IMPORTANT - Agent type**: "Will this agent be the main orchestrator that users interact with in the AWS Transform console?"
    - If user says **YES** → This is a job orchestrator (set `job_orchestrator=True`)
    - If user says **NO** → This is a subagent (set `job_orchestrator=False`)
 
-5. **If YES to question 4**, also ask: "What should the display name be in the chat UI?" (e.g., "Eswar Test Orchestrator")
+6. **If YES to question 5**, also ask: "What should the display name be in the chat UI?" (e.g., "Eswar Test Orchestrator")
 
-6. **Build method**: "Use CodeBuild?" (recommend yes for Windows, auto-detect otherwise)
+7. **Build method**: "Use CodeBuild?" (recommend yes for Windows, auto-detect otherwise)
 
 ### Step 2: Use deploy_agent_full_pipeline Tool
 
@@ -92,6 +95,7 @@ Call `deploy_agent_full_pipeline` with the gathered information:
 deploy_agent_full_pipeline(
     agent_path="<path from Step 1>",
     agent_name="<name from Step 1>",
+    owner_contact_info="<owner email or CTI from Step 1>",  # Required
     agent_version="<version from Step 1>",
     job_orchestrator=<True if user answered YES to orchestrator question, False otherwise>,
     chat_ui_label="<display name if job_orchestrator=True>",  # Optional
@@ -100,6 +104,7 @@ deploy_agent_full_pipeline(
 ```
 
 **Key parameters:**
+- `owner_contact_info` → Required. Email or CTI for the agent's owner contact and notifications (required unless `skip_registry=True`)
 - `job_orchestrator=True` → Agent can be bound to workspaces (for orchestrators)
 - `job_orchestrator=False` → Agent called by other agents only (for subagents)
 - `chat_ui_label` → Only needed if job_orchestrator=True
@@ -176,6 +181,7 @@ If you want to deploy to Bedrock AgentCore but skip registry registration:
 deploy_agent_full_pipeline(
     agent_path="./agents/modernization",
     agent_name="modernization-orchestrator",
+    owner_contact_info="",  # not required when skip_registry=True
     skip_registry=True
 )
 ```
@@ -188,6 +194,7 @@ For Windows users or CI/CD pipelines without local Docker:
 deploy_agent_full_pipeline(
     agent_path="./agents/modernization",
     agent_name="modernization-orchestrator",
+    owner_contact_info="team@example.com",
     use_codebuild=True
 )
 ```
@@ -200,6 +207,7 @@ If your IAM roles have different names:
 deploy_agent_full_pipeline(
     agent_path="./agents/modernization",
     agent_name="modernization-orchestrator",
+    owner_contact_info="team@example.com",
     execution_role_arn="arn:aws:iam::123456:role/CustomExecutionRole",
     access_role_arn="arn:aws:iam::123456:role/CustomAccessRole"
 )

--- a/aws-transform-agent-toolkit/steering/deployment-pipeline-guide.md
+++ b/aws-transform-agent-toolkit/steering/deployment-pipeline-guide.md
@@ -993,6 +993,7 @@ Instead of manual shell scripts, you can deploy agents directly from Kiro using 
 deploy_agent_full_pipeline(
     agent_path="./agents/modernization",
     agent_name="modernization-orchestrator",
+    owner_contact_info="team@example.com",
     agent_version="1.0.0"
 )
 ```


### PR DESCRIPTION
## What

Companion to awslabs/agent-builder-toolkit-aws-transform#67, which makes
`owner_contact_info` a required argument of `deploy_agent_full_pipeline`.

That argument populates the agent's `ownerContactInfo` and the Agent Provider
extension `contactInfo`, which the AWS Transform registry's agent-card
validation rejects when empty. With the tool arg now required, the steering must
collect and pass it, otherwise the guided deploy flow calls the tool without the
required argument.

## Change

- `deploy-agent-workflow.md`:
  - Add an "Owner contact" question to the Step 1 information gathering and
    renumber the subsequent questions.
  - Add `owner_contact_info` to the Step 2 call example and the key-parameters
    list.
  - Update the Force CodeBuild and Custom IAM Roles examples to pass it.
  - Note in the skip_registry example that a contact is not required in that mode.
- `deployment-pipeline-guide.md`:
  - Add `owner_contact_info` to the MCP deployment-tools example.

Docs only.
