### PR TITLE
feat(aws-transform): document AWS_PUBLIC visibility level

### DIFF
--- a/aws-transform-agent-toolkit/POWER.md
+++ b/aws-transform-agent-toolkit/POWER.md
@@ -248,8 +248,8 @@ This power includes an MCP server with search and registration tools:
 - **publish_agent_version** - Publish a new version of an existing agent
   - Copies config from the current (or specified) version, applies optional overrides (runtimeArn, atxAccessRoleArn), and publishes the new version
   - Use after initial registration to iterate on agent versions
-- **list_agent_access_control** - List access control settings for an agent
-- **update_publisher_access_control** - Grant or revoke account access to an agent
+- **list_agent_access_control** - List access control settings for a RESTRICTED or AWS_PUBLIC agent
+- **update_publisher_access_control** - Grant or revoke account access to a RESTRICTED or AWS_PUBLIC agent
 
 ### Debugging Tools
 - **fetch_logs** - Fetch CloudWatch logs for an agent runtime

--- a/aws-transform-agent-toolkit/steering/agent-registration.md
+++ b/aws-transform-agent-toolkit/steering/agent-registration.md
@@ -777,9 +777,44 @@ client.publish_agent_version(
 )
 ```
 
+## Agent Visibility Levels
+
+Agents have three visibility levels that control who can access them:
+
+| Visibility | Access Model | Transition |
+|-----------|-------------|-----------|
+| `RESTRICTED` (default) | Only explicitly allowlisted accounts | Starting state for all agents |
+| `AWS_PUBLIC` | All internal AWS accounts get automatic access; external accounts must be allowlisted | `RESTRICTED → AWS_PUBLIC` (self-service, one-way) |
+| `PUBLIC` | All accounts have access (requires Marketplace productId) | `AWS_PUBLIC → PUBLIC` or `RESTRICTED → PUBLIC` (one-way) |
+
+Transitions are **one-way toward broader access** — you cannot narrow visibility once promoted.
+
+### Promoting to AWS_PUBLIC
+
+Only agents with `ownerType: INTERNAL_AGENT` can be promoted to `AWS_PUBLIC`. Use the `update_agent` MCP tool:
+
+```python
+update_agent(name="my-agent", visibility="AWS_PUBLIC")
+```
+
+Or via CLI:
+
+```bash
+aws atxagentregistryexternal update-agent \
+  --name my-agent \
+  --visibility AWS_PUBLIC \
+  --endpoint-url https://iad.prod.agent-registry-external.elastic-gumby.ai.aws.dev \
+  --region us-east-1
+```
+
+After promotion:
+- All internal AWS accounts automatically have access — no `update-publisher-access-control` needed for them
+- External (non-AWS) accounts can still be explicitly allowlisted via `update-publisher-access-control`
+- Attempting to allowlist an internal account on an AWS_PUBLIC agent is a no-op (returns success)
+
 ## UpdatePublisherAccessControl API
 
-Controls which AWS accounts can access your agent. **REQUIRED** to make agents visible, even in same-account scenarios.
+Controls which AWS accounts can access your agent. For `RESTRICTED` agents, this is **REQUIRED** to make agents visible, even in same-account scenarios. For `AWS_PUBLIC` agents, this is only needed to grant access to external (non-AWS) accounts.
 
 ### API Signature
 


### PR DESCRIPTION
## Summary

- Add **Agent Visibility Levels** section to `agent-registration.md` documenting the three-tier model (`RESTRICTED → AWS_PUBLIC → PUBLIC`)
- Document how to promote agents to `AWS_PUBLIC` via MCP tool and CLI
- Update `POWER.md` tool descriptions for `list_agent_access_control` and `update_publisher_access_control` to mention AWS_PUBLIC

### What is AWS_PUBLIC?

A middle-tier visibility where all internal AWS accounts get automatic access without individual allowlisting. External (non-AWS) accounts must still be explicitly allowlisted by the publisher. Only `INTERNAL_AGENT` owner types can promote to this visibility.

Companion PR: https://github.com/awslabs/agent-builder-toolkit-aws-transform/pull/76

## Test plan

- [x] Steering docs render correctly in markdown
- [x] CLI/Python examples are syntactically valid
- [x] No broken cross-references to other steering files