### PR TITLE
Postman: use the local MCP server so runCollection is available

### DIFF
--- a/postman/POWER.md
+++ b/postman/POWER.md
@@ -12,6 +12,18 @@ Before proceeding, validate that the user has completed the following steps befo
 
 ## Step 1
 
+Confirm the user has a Postman API key available to the MCP server as `POSTMAN_API_KEY`.
+
+This power runs the Postman MCP server **locally over stdio**, which authenticates with a Postman API key (the local server does not support OAuth). Ask the user in chat to confirm they have set it — do not probe the value from the terminal.
+
+- Generate a key at https://postman.postman.co/settings/me/api-keys
+- Export it in the environment Kiro launches from, e.g. `export POSTMAN_API_KEY=...`. `mcp.json` forwards it to the server via `"POSTMAN_API_KEY": "${POSTMAN_API_KEY}"`.
+- Node.js 20 or later must be installed, since the server is started with `npx`.
+
+To verify the connection, call the `getAuthenticatedUser` MCP tool. A successful response is the auth check — if it fails, the key is missing, expired, or invalid.
+
+## Step 2
+
 Create a hook that runs anytime the source code or configuration file has been changed. Save the hook in .kiro/hooks/hookname.kiro.hook. Example hook format. Please update the patterns to match the project's file structure.
 
 ```json
@@ -64,20 +76,23 @@ Create a hook that runs anytime the source code or configuration file has been c
 
 Automate API testing and collection management with Postman. Create workspaces, collections, environments, and run tests programmatically.
 
-**Authentication**: OAuth — Kiro will open a browser sign-in on first use. No API key required.
+**Authentication**: Postman API key, supplied to the local server as `POSTMAN_API_KEY`.
 
 ## Available MCP Servers
 
 ### postman
 **Package:** `@postman/postman-mcp-server`
-**Connection:** Streamable HTTP MCP server
-**Authentication:** OAuth (handled automatically by Kiro)
-**Mode:** Minimal (40 essential tools) - Default configuration
-**Endpoint:** https://mcp.postman.com/minimal
+**Connection:** Local server over stdio, started with `npx`
+**Authentication:** Postman API key via the `POSTMAN_API_KEY` environment variable
+**Mode:** Minimal (42 essential tools) - Default configuration
 
-**Note:** This power connects to Postman's hosted MCP server via streamable HTTP using OAuth. To enable Full mode (100+ tools) for advanced collaboration and enterprise features, change the URL to `https://mcp.postman.com/mcp`.
+**Why the local server:** `runCollection` — the tool that actually executes a collection and returns test results — is only exposed by the local server. Postman's hosted remote endpoints (`https://mcp.postman.com/minimal` and `/mcp`) do not include it. Because collection runs are the core of this power (the hook in Step 2 asks the agent to run the collection and propose fixes), the local server is required.
 
-**Available Tools (40 in Minimal Mode):**
+The local server also executes requests from the developer's own machine, so collections that target `http://localhost:3000` and other private hosts are reachable. The remote server has no network access to the user's workstation.
+
+To enable Full mode (125 tools) for advanced collaboration and enterprise features, add `--full` to `args`.
+
+**Available Tools (42 in Minimal Mode):**
 
 **Workspace Management:**
 - `createWorkspace` - Create a new workspace
@@ -92,6 +107,7 @@ Automate API testing and collection management with Postman. Create workspaces, 
 - `putCollection` - Replace/update entire collection
 - `duplicateCollection` - Create a copy of a collection
 - `createCollectionRequest` - Add a request to a collection
+- `updateCollectionRequest` - Update an existing request in a collection
 - `createCollectionResponse` - Add a response example to a request
 
 **Environment Management:**
@@ -127,12 +143,15 @@ Automate API testing and collection management with Postman. Create workspaces, 
 - `syncSpecWithCollection` - Sync spec with its collection
 
 **Testing & Execution:**
-- `runCollection` - Execute a collection with automated tests
+- `runCollection` - Execute a collection with automated tests (**local server only**)
+
+**Search & Discovery:**
+- `searchPostmanElements` - Search Postman elements across networks
 
 **User & Metadata:**
 - `getAuthenticatedUser` - Get current user information
 - `getTaggedEntities` - Get entities by tag
-- `getStatusOfAnAsyncApiTask` - Check async task status
+- `getDuplicateCollectionTaskStatus` - Check the status of a collection duplication task
 - `getEnabledTools` - List available tools by mode
 
 ## Tool Usage Examples
@@ -215,20 +234,33 @@ for (const collection of collections) {
 
 **Test failures**: Verify API server running, check environment variables (base_url), review test scripts
 
-**Authentication issues**: If the OAuth flow did not complete, remove the power and re-add it to trigger a fresh sign-in
+**Authentication issues**: Confirm `POSTMAN_API_KEY` is exported in the environment Kiro was launched from, then restart the MCP server so it picks up the value. Call `getAuthenticatedUser` to verify. Keys can be regenerated at https://postman.postman.co/settings/me/api-keys
+
+**Server fails to start**: Ensure Node.js 20 or later is installed and `npx` is on `PATH`. The first run downloads the package, which may take a moment.
+
+**`runCollection` not available**: The tool is only exposed by the local server. Confirm `mcp.json` uses `command`/`args` rather than a `url` pointing at `https://mcp.postman.com/...`.
 
 ## Configuration
 
-**MCP Configuration (Minimal mode - 40 tools):**
+**MCP Configuration (Minimal mode - 42 tools):**
 ```json
 {
   "mcpServers": {
     "postman": {
-      "url": "https://mcp.postman.com/minimal",
+      "command": "npx",
+      "args": ["-y", "@postman/postman-mcp-server@latest"],
+      "env": {
+        "POSTMAN_API_KEY": "${POSTMAN_API_KEY}"
+      },
       "disabled": false
     }
   }
 }
 ```
 
-**Full mode (100+ tools):** Change URL to `https://mcp.postman.com/mcp`
+**Full mode (125 tools):** Add `--full` to `args`:
+```json
+"args": ["-y", "@postman/postman-mcp-server@latest", "--full"]
+```
+
+**EU region:** Add `--region eu` to `args`.

--- a/postman/mcp.json
+++ b/postman/mcp.json
@@ -1,7 +1,11 @@
 {
   "mcpServers": {
     "postman": {
-      "url": "https://mcp.postman.com/minimal",
+      "command": "npx",
+      "args": ["-y", "@postman/postman-mcp-server@latest"],
+      "env": {
+        "POSTMAN_API_KEY": "${POSTMAN_API_KEY}"
+      },
       "disabled": false
     }
   }

--- a/postman/steering/steering.md
+++ b/postman/steering/steering.md
@@ -605,6 +605,7 @@ Include test scripts in all requests to validate:
 **STEP 2: Verify API availability**
    - If the target API is a local server, ensure it is running before executing the collection
    - For remote APIs (e.g. staging, production, cloud endpoints), skip this check
+   - `runCollection` executes on this machine via the local Postman MCP server, so `localhost` and other private hosts referenced by your environment variables are reachable
 
 **STEP 3: Run collection**
    ```


### PR DESCRIPTION
## Summary

The Postman power's core workflow is running a collection and reporting test results. The onboarding hook says so explicitly:

> "…get the collection ID and **run the collection**, showing me the results and propose fixes for any errors found."

That isn't possible with the current configuration. **`runCollection` is only exposed by the local (stdio) Postman MCP server** — Postman's hosted remote endpoints don't include it, and the power currently points at `https://mcp.postman.com/minimal`. So the tool the hook depends on isn't there.

This PR switches the power to the local server.

## Verification

Live `tools/list` against each server (protocol `2025-06-18`, authenticated):

| Server | Tools | `runCollection` |
|---|---|---|
| Remote `https://mcp.postman.com/minimal` | 41 | ❌ |
| Remote `https://mcp.postman.com/mcp` (full) | 124 | ❌ |
| Local `npx @postman/postman-mcp-server@latest` (minimal, default) | 42 | ✅ |
| Local `npx … --full` | 125 | ✅ |

The local minimal toolset is **exactly** the remote minimal toolset plus `runCollection` — a set difference of one tool, in our favour. Nothing is lost by switching.

I also launched the server using the exact `command`/`args` from the new `mcp.json` and confirmed it completes the MCP handshake and advertises all 42 tools.

## Why local, beyond tool availability

`runCollection` runs Newman in-process, so requests originate from wherever the MCP server runs. On the local server that's the developer's machine, which means collections targeting `http://localhost:3000` — the exact case in this power's own `createEnvironment` example — actually work. The remote server has no network route to a user's workstation. This matches the guidance in the [server README](https://github.com/postmanlabs/postman-mcp-server#readme):

> Use the local server to test local APIs, as the remote server won't have network access to your workstation.

## Changes

**`postman/mcp.json`** — local stdio server, API key forwarded with Kiro's `${VAR}` substitution (same idiom as the `localstack` power):

```json
{
  "mcpServers": {
    "postman": {
      "command": "npx",
      "args": ["-y", "@postman/postman-mcp-server@latest"],
      "env": { "POSTMAN_API_KEY": "${POSTMAN_API_KEY}" },
      "disabled": false
    }
  }
}
```

**`postman/POWER.md`**
- Auth is now a Postman API key. The local server doesn't support OAuth, so the previous "OAuth — no API key required" text no longer applies.
- New onboarding Step 1 for obtaining and exporting the key (existing hook step becomes Step 2). Following the `localstack` power's convention, it tells the agent to confirm with the user in chat rather than probing the secret from the shell, and to use a `getAuthenticatedUser` call as the real connectivity check.
- Added a "Why the local server" note so this doesn't get reverted to the remote URL later.
- Updated Configuration and Troubleshooting; documented `--full` and `--region eu`.
- **Corrected the tool list to match the server.** It was inaccurate independently of this change: it listed `getStatusOfAnAsyncApiTask`, which the server doesn't expose, and omitted `updateCollectionRequest` and `searchPostmanElements`. Now 42/42, cross-checked programmatically against `tools/list`.

**`postman/steering/steering.md`** — one line under "Verify API availability" noting runs execute locally, so private hosts are reachable.

## Trade-off worth flagging

This does trade browser-based OAuth for a manually exported API key, which is a small step backwards on first-run friction. It's unavoidable if the power is to run collections at all: the local server only supports API key auth. Happy to adjust the onboarding wording if you'd prefer it framed differently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)