### PR TITLE
fix(aws-healthomics): reconcile WDL migration Phase 1 with the ECR pull-through cache SOP

### DIFF
--- a/aws-healthomics/steering/migration-guide-for-wdl.md
+++ b/aws-healthomics/steering/migration-guide-for-wdl.md
@@ -24,31 +24,44 @@ AWS HealthOmics requires:
 
 ### Phase 1: Container Inventory and Migration
 
-**Objective**: Identify all containers and create ECR migration plan.
+**Objective**: Identify all containers and make them available to HealthOmics from private ECR.
 
 **Steps**:
 1. Extract all unique container URIs from runtime sections:
    - Scan all WDL files for `docker:` and `container:` runtime attributes.
    - Check imported WDL files and sub-workflows.
    - Identify containers in struct/object definitions.
-2. Generate `container_inventory.csv` with columns: Task name, Original container URI, Container registry, Tool name and version, Target ECR URI.
-3. Create `scripts/migrate_containers_to_ecr.sh` to:
-   - Find or create ECR repositories for each tool with access policies allowing the omics principal to read.
-   - Pull each container from source registry ensuring x86 containers are pulled.
-   - Tag for ECR: `<account>.dkr.ecr.<region>.amazonaws.com/<workflow-name>/<tool>:<version>`
-   - Push to ECR repositories.
-4. Create `scripts/update_container_refs.sh` to:
-   - Replace all container URIs in WDL task runtime sections.
-   - Update to use ECR registry.
-   - Parameterize container references.
-5. Create `healthomics.inputs.json` with ECR registry base path parameter.
+2. Generate `container_inventory.csv` with columns: Task name, Original container URI, Container registry, Tool names and versions, Target ECR URI, Approach (`registry-map` or `uri-replacement`).
+3. For each container, CHOOSE one approach — see **Registry Map or URI Replacement** under Technical Patterns:
+   - **Registry map (PREFERRED)**: the WDL keeps its original public URIs and HealthOmics redirects them to your pull-through caches. Use this WHERE the image itself is unchanged — same repository, same tag, served from your private ECR instead of the public registry.
+   - **URI replacement**: edit the WDL. Use this WHERE the migration changes which repository a task pulls from, because the command block's correctness then depends on which image is used.
+4. Stage the containers using the MCP tools — PREFER these over hand-written `docker pull`/`docker push` scripts. Follow the [ECR Pull Through Cache SOP](./ecr-pull-through-cache.md):
+   - Call `ListPullThroughCacheRules` first. IF a valid cache already exists for an upstream registry, reuse it — DO NOT create another.
+   - Call `CreatePullThroughCacheForHealthOmics` for each remaining upstream registry (`docker-hub`, `quay`, `ecr-public`). This also sets the registry permissions policy and repository creation template that HealthOmics needs.
+   - Call `CheckContainerAvailability` with `initiate_pull_through: true` to populate and confirm each image.
+   - Call `CloneContainerToECR` for registries NOT supported by pull-through cache.
+   - IF using a registry map: call `CreateContainerRegistryMap`, then pass it to `CreateAHOWorkflow` via `container_registry_map` (or `container_registry_map_uri`).
+   - IF replacing URIs: update the `docker`/`container` values in the WDL task runtime sections, and PREFER parameterizing the registry base path.
+
+   > **The registry map is a workflow attribute, not a run parameter.** It is supplied at workflow creation, and registration does not appear to validate the definition against it: a workflow whose tasks name public registries registers as `ACTIVE` and is unrunnable. The run then fails partway through with `has an invalid structure. Provide a valid ECR image URI`, naming the task it reached rather than the missing attribute, after earlier tasks have already consumed billed compute. ENSURE the map is attached at creation — a successful `CreateAHOWorkflow` does NOT confirm it.
+5. Verify container CONTENTS, not just availability. For each task:
+   - List the binaries its `command` block invokes. Take the first bare word of each pipeline stage and of each line, including inside `if`/`for` bodies, and discard shell builtins (`set`, `cd`, `echo`, `if`, `then`, `fi`, `for`, `do`, `done`, `mkdir`, `mv`, `cp`) and `~{}` interpolations.
+   - Confirm each one is present in that task's image:
+     ```bash
+     docker run --rm <image> sh -lc 'command -v bwa samtools bcftools'
+     ```
+   - IF any binary is absent, the task WILL fail at run time — resolve it via step 6 before proceeding.
+
+   > No static check substitutes for this. `CheckContainerAvailability`, `aws ecr describe-images`, `miniwdl check`, and `CreateWorkflow` all pass for an image that exists but lacks a tool the command block pipes to; the task then dies with `command not found`. Single-tool biocontainer images are a frequent source: an image named for one tool often does NOT carry the others in the same pipeline.
+6. IF a task needs several tools in one command, use a multi-tool image (for example a `mulled-v2-*` biocontainer). This changes the repository, so treat it as URI replacement per step 3, and record every tool's version in `container_inventory.csv` — they MAY differ from the single-tool images they replace.
+7. Create `healthomics.inputs.json` with an ECR registry base path parameter IF container references are parameterized.
 
 **Done WHEN**:
-- `container_inventory.csv` documents all containers.
-- Migration script pushes all containers to ECR.
-- All WDL task runtime sections use ECR URIs.
-- Zero references to external registries remain.
-- At least 5 key containers verified accessible from ECR.
+- `container_inventory.csv` documents all containers and records the approach chosen for each.
+- All containers are pullable by HealthOmics from private ECR.
+- IF using URI replacement: all WDL task runtime sections use ECR URIs, and zero references to external registries remain.
+- IF using a registry map: every external registry still referenced in the WDL has a mapping entry, and the map is passed to `CreateAHOWorkflow`.
+- For every task, each command invoked in its `command` block is confirmed present in that task's image using the check in step 5.
 
 ### Phase 2: Runtime Attribute Audit
 
@@ -193,14 +206,39 @@ AWS HealthOmics requires:
 
 ## Technical Patterns
 
+### Registry Map or URI Replacement
+
+Decide per container by asking whether the migration changes the image's TRANSPORT or its IDENTITY.
+
+| The change is | Same repository and tag, served from private ECR | A different repository (different tool set or versions) |
+|---|---|---|
+| Approach | Registry map | Edit the WDL |
+| WDL | Unmodified — keeps the public URI | `docker`/`container` value replaced |
+| Why | The image is identical, so the redirect hides nothing | The command block's correctness now depends on which image is used |
+
+DO NOT hide an identity change inside a registry map. A task whose runtime says `bwa` while the map redirects it to a different repository executes something other than what the WDL says, and the next reader has no way to see it from the workflow definition.
+
+PREFER pinning by digest (`repository@sha256:...`) over a mutable tag on either path. A tag can be reassigned upstream, in which case the same WDL resolves to a different image on a later run.
+
 ### Container Runtime (Before/After)
+
+Both paths add the required `cpu` and `memory` attributes. They differ only in whether the image reference changes.
+
 ```wdl
 # Before
 runtime {
     docker: "quay.io/biocontainers/bwa:0.7.17--h5bf99c6_8"
 }
 
-# After
+# After — registry map path: the image reference is UNCHANGED.
+# The map is passed to CreateAHOWorkflow, which redirects quay.io to your pull-through cache.
+runtime {
+    docker: "quay.io/biocontainers/bwa:0.7.17--h5bf99c6_8"
+    cpu: 4
+    memory: "8 GB"
+}
+
+# After — URI replacement path, for when the repository itself changes.
 runtime {
     docker: "<account-id>.dkr.ecr.<region>.amazonaws.com/workflow-name/bwa:0.7.17--h5bf99c6_8"
     cpu: 4
@@ -252,7 +290,7 @@ workflow MyWorkflow {
 - S3 bucket(s) created with appropriate permissions
 - HealthOmics service access
 - HealthOmics MCP server
-- Docker/Finch/Podman installed for container operations
+- Docker/Finch/Podman installed for container operations, including verifying image contents (Phase 1)
 
 ## References
 


### PR DESCRIPTION
## What

Reconciles the WDL migration guide's Phase 1 with the ECR Pull Through Cache SOP in the same Power. Today the two files prescribe opposite outcomes, and Phase 1 does not reference the other SOP or any of the eight container MCP tools it documents.

Also strengthens the container verification criterion from *accessible* to *contains the tools the task invokes*, because accessibility is not the property that makes a task run.

Only `migration-guide-for-wdl.md` is touched. The ECR SOP is unchanged — it is the file I believe is correct.

## 1. The two files require opposite end states

`ecr-pull-through-cache.md:15`:

> **Migrating existing workflows**: Use container registry maps to avoid changing container URIs in workflow definitions.

`ecr-pull-through-cache.md:135`:

> IF migrating existing workflows that reference public container URIs you MUST create a container registry map (preferred) ALTERNATIVELY you MAY replace the existing container URIs with the new ECR Private URIs

But `migration-guide-for-wdl.md:50` makes this a completion criterion for migration:

> - Zero references to external registries remain.

Using a registry map means `quay.io/...` **stays** in the WDL — that is the entire point of the map. The migration SOP's Done WHEN therefore defines the preferred approach's end state as failure. An agent that satisfies Phase 1 as written cannot have used a registry map, and an agent that follows the ECR SOP cannot satisfy Phase 1.

Phase 1 also instructs the agent to author `scripts/migrate_containers_to_ecr.sh` doing manual `docker pull` / tag / `docker push` (`:35-39`), while the same Power documents `CreatePullThroughCacheForHealthOmics`, `CloneContainerToECR`, `CreateContainerRegistryMap`, `CheckContainerAvailability`, and four more (`ecr-pull-through-cache.md:24-33`). Phase 1 mentions none of them and does not link to that SOP.

**Change** — Phase 1 step 3 makes the approach an explicit per-container choice, step 4 routes staging through the MCP tools and links the ECR SOP, and the Done WHEN bullets are split so each approach has its own criterion. `Zero references to external registries remain` is preserved, scoped to the URI-replacement case.

The `Container Runtime (Before/After)` pattern showed only the URI-replacement outcome, which would have contradicted the new preference, so it now shows both — the registry-map "After" leaves `docker:` unchanged and adds only `cpu`/`memory`.

## 2. Which approach applies when

Rather than declaring one approach correct, I added a decision rule to `## Technical Patterns` — transport vs. identity. It is what makes both files right about different cases:

- Same repository and tag, fetched from closer by → **map**, WDL untouched. The image is byte-identical, so the redirect hides nothing.
- A **different repository** (so a different tool set or different versions) → **edit the WDL**. The command block's correctness now depends on which image is pulled. A task whose runtime says `bwa` while a map silently redirects it elsewhere runs something other than what the definition says, and that is invisible in the workflow definition.

This distinction is also measurable, and one run shows both halves at once. A workflow with mixed references was registered without `--container-registry-map`:

```
workflow 2238961   ACTIVE       registration accepted it
run      9421504   FAILED

  bwa_mem_align       COMPLETED   (carried a rewritten ECR URI — needed no map)
  sort_and_index      never ran   (carried quay.io/... — needed the map)

statusMessage:
  ECR image URI: quay.io/biocontainers/samtools:1.21--h50ea8bc_0 has an
  invalid structure. Provide a valid ECR image URI and retry.
```

Three things worth noting about that shape, all now stated in step 4:

- `CreateWorkflow` returned `ACTIVE`. The registry map is a workflow attribute supplied at creation, and registration did not validate the definition against it. A workflow that names public registries registers cleanly and is unrunnable. (I've worded this as "does not appear to validate" in the steering text, since this is one observation rather than documented behavior.)
- The failure is not fail-fast. Storage was provisioned, an image pulled, `bwa` ran to completion and wrote its BAM — then the run died on the *next* task's URI. Everything before it was billed.
- The message names `samtools`, and nothing is wrong with the samtools reference. It is a valid public quay.io URI. What is missing is a workflow-level attribute unrelated to samtools.

## 3. Accessible is not the same as contains

`workflow-development.md:60` states the actual requirement:

> Containers MUST contain all software used in the script/command.

No procedure in the Power checks it. `migration-guide-for-wdl.md:51` offers instead:

> - At least 5 key containers verified accessible from ECR.

Accessibility is a different property, and "at least 5" is an arbitrary sample of an inventory the same phase just enumerated in full.

Measured — `quay.io/biocontainers/bwa:0.7.18--he4a0461_0`:

```
/usr/local/bin/bwa
samtools: NOT PRESENT
```

The task using it pipes `bwa mem | samtools view -bS`, so it dies at the pipe with `samtools: command not found`. Everything upstream passed honestly: `aws ecr describe-images` OK, `miniwdl check` OK, `CreateWorkflow` `ACTIVE`. The image genuinely exists — that is why nothing objects. `CheckContainerAvailability` cannot see this either; it reports availability, as named.

The only check that answers the question is running the image:

```bash
docker run --rm <image> sh -lc 'command -v bwa samtools bcftools'
```

Swapping to a multi-tool `mulled-v2-*` image fixes it, and that is a **different repository** — so by the rule in §2 it belongs in the WDL, not in a map. (In our case that also shifted samtools 1.21 → 1.20, which is the kind of thing worth recording in the inventory.)

**Change** — the Done WHEN bullet becomes per-task command coverage rather than a count of accessible images. Step 5 gives the `docker run` check, a heuristic for deriving the binary list from the `command` block (so the criterion is executable rather than aspirational), what to do when a binary is absent, and why no static gate substitutes for it. Step 6 covers the multi-tool image case.

## Scope

`migration-guide-for-wdl.md` only. Not changed: `ecr-pull-through-cache.md`, the Nextflow migration guide (the same Phase 1 pattern likely applies there, but I have not measured it), and resource limit values.

No file overlap with #175. That PR covers a different axis — registries that pull-through cache does not support, staged via `Registry Staging Mapping` — whereas this one is about choosing between a registry map and URI replacement for PTC-supported registries. If #175 merges first I'm happy to add a pointer from Phase 1 step 4 to `image-staging.md` for the non-PTC case, or to rebase in whichever order suits you.

## Measurement conditions

2026-07, `ap-northeast-2`, two accounts (one with no pre-existing HealthOmics resources), miniwdl 1.15.0 / Python 3.12.13. AWS account IDs are masked as `123456789012` where they appeared in output; run and workflow IDs are left as-is since they are meaningless without the account.
