### PR TITLE
docs(aws-healthomics): parameter types, run failure patterns, and the ECR Public fallback

### DIFF
--- a/aws-healthomics/steering/ecr-pull-through-cache.md
+++ b/aws-healthomics/steering/ecr-pull-through-cache.md
@@ -17,7 +17,7 @@ This SOP defines how you, the agent, configure ECR Pull-Through Caches and Conta
 ## Prerequisites
 
 - AWS credentials configured with appropriate IAM permissions for ECR and HealthOmics.
-- For Docker Hub: a Docker Hub access token (obtain from https://docs.docker.com/security/access-tokens/).
+- For Docker Hub: a Docker Hub access token (obtain from https://docs.docker.com/security/access-tokens/). This is required, not optional — WHERE it is unavailable, see [Using ECR Public Instead of Docker Hub](#using-ecr-public-instead-of-docker-hub).
 
 ## MCP Tools Reference
 
@@ -65,6 +65,46 @@ aws secretsmanager create-secret \
     --region us-east-1
 ```
 
+The Docker Hub credential is not optional. `CreatePullThroughCacheForHealthOmics` with `upstream_registry: docker-hub` and no `credential_arn` is rejected before anything is created:
+
+```
+Credential ARN is required for Docker Hub pull-through cache.
+Please provide a Secrets Manager ARN containing Docker Hub credentials.
+```
+
+IF the user cannot supply Docker Hub credentials, DO NOT stop — check ECR Public first, per [Using ECR Public Instead of Docker Hub](#using-ecr-public-instead-of-docker-hub).
+
+### Using ECR Public Instead of Docker Hub
+
+ECR Public needs no credentials, and many images that a legacy workflow names on Docker Hub are also published there. WHERE an equivalent exists, an `ecr-public` cache reaches it without a Docker Hub secret.
+
+The repository path differs between the two registries, so the Docker Hub name cannot be reused as-is. Resolve the ECR Public path first:
+
+```bash
+aws ecr-public describe-registries --region us-east-1 >/dev/null   # confirms access
+# Search the gallery for the image, then read the pull URI it lists:
+#   https://gallery.ecr.aws/?searchTerm=<image name>
+```
+
+Then confirm it through the cache before editing the workflow:
+
+```
+CheckContainerAvailability(
+    repository_name="ecr-public/ubuntu/ubuntu",   # note: not "library/ubuntu"
+    image_tag="20.04",
+    initiate_pull_through=true,
+)
+```
+
+A successful response reports `healthomics_accessible: "accessible"` and populates the cache, so the first run does not pay the pull.
+
+Two cautions:
+
+- **Treat this as a change of image identity, not of transport.** The repository is different, so it is URI replacement rather than a registry map entry — see the decision table in Phase 1 of the [WDL migration SOP](./migration-guide-for-wdl.md). Redirecting a Docker Hub URI to an ECR Public repository through a registry map would hide the substitution from anyone reading the workflow.
+- **Verify the tag and the contents.** ECR Public tags do not always match Docker Hub's, and an image published under the same name is not guaranteed to carry the same tools. Confirm the binaries the task's command block invokes are present.
+
+IF no ECR Public equivalent exists, the options are a Docker Hub secret (Step 2) or `CloneContainerToECR` from a registry you can already reach (Step 6).
+
 ### Step 3: Create Pull-Through Cache Rules
 
 1. Call `ListPullThroughCacheRules` to check for existing rules. IF a valid cache already exists for the upstream registry, reuse it — DO NOT create another.
@@ -80,7 +120,7 @@ This tool automatically:
 
 | Registry | upstream_registry | credential_arn | Notes |
 |----------|------------------|----------------|-------|
-| Docker Hub | `docker-hub` | Required | Use secret ARN from Step 2 |
+| Docker Hub | `docker-hub` | Required | Use secret ARN from Step 2. Omitting it fails the call — see [Using ECR Public Instead of Docker Hub](#using-ecr-public-instead-of-docker-hub) when credentials are unavailable |
 | Quay.io | `quay` | Optional | Only needed for private repos |
 | ECR Public | `ecr-public` | Not needed | Public access |
 

--- a/aws-healthomics/steering/running-a-workflow.md
+++ b/aws-healthomics/steering/running-a-workflow.md
@@ -28,12 +28,72 @@ Follow this SOP WHEN:
    - Permissions to read inputs and write to the output location.
    - Permissions to write HealthOmics logs to CloudWatch.
    - Access to ECR containers used in the run.
+8. PREFER `ValidateAHORunReadiness` over checking these pre-conditions individually. It reports the workflow status, the role's trust policy, whether the output bucket exists in the run's region, whether the role can write there, and whether the input objects exist — in one call, and before any compute is billed. See [Pre-Run Validation](#pre-run-validation).
+
+### Parameter Types
+
+Parameter values passed to `StartAHORun` MUST match the types declared in the workflow definition:
+
+| WDL type | JSON form | Example |
+| --- | --- | --- |
+| `String` | string | `"NA12878"` |
+| `Int`, `Float` | number | `42`, `3.14` |
+| `Boolean` | boolean | `true` |
+| `File`, `Directory` | string holding an S3 URI | `"s3://bucket/sample.bam"` |
+| `Array[T]` | array | `["s3://bucket/a.fq", "s3://bucket/b.fq"]` |
+| `Map[K, V]` | object | `{"chr1": "s3://bucket/chr1.bed"}` |
+| `Pair[L, R]` | object with `left` and `right` | `{"left": "a", "right": 1}` |
+| struct | object | `{"owner": "user", "id": 123}` |
+
+A struct MUST be passed as a JSON object. Passing it as a JSON-encoded string is rejected at run time:
+
+```
+# Wrong — the value is a string that happens to contain JSON
+{"sample_meta": "{\"owner\": \"user\"}"}
+
+# Right
+{"sample_meta": {"owner": "user"}}
+```
+
+The resulting failure names the struct rather than the mistake: `InputError: check JSON input; couldn't construct SampleMeta from "{\"owner\": \"user\"}" (in sample_meta)`. It arrives minutes into the run, after PENDING, because inputs are validated by the engine rather than by `StartRun`.
+
+`parameterTemplate` from `GetAHOWorkflow` will NOT tell you which parameters are structs — it carries only `description` and `optional`. To determine types, read the `input {}` block of the main workflow definition.
 
 ### Execution
 
 1. Call `StartAHORun` to start the run.
-2. Call `GetAHORun` to check status.
+2. Call `WaitForAHORun` to wait for the run to finish. It polls until the run reaches a terminal status (`COMPLETED`, `FAILED` or `CANCELLED`) and returns the full run details.
+   - DO NOT poll by calling `GetAHORun` in a loop.
+   - Reaching the wait timeout does NOT cancel the run. The result carries `timedOut` with the last observed status; call `WaitForAHORun` again to keep waiting.
+   - A `FAILED` status is a successful wait, not a tool error. Branch on `status`.
+   - `GetAHORun` remains the right call for a one-off status check.
 3. WHEN the workflow completes, outputs will be at the specified output location.
+
+### Pre-Run Validation
+
+`ValidateAHORunReadiness` checks a run's prerequisites without starting it. Every check is attempted regardless of earlier results, so one call reports every problem rather than surfacing them one failed run at a time.
+
+Call it before `StartAHORun` whenever the role, output location, or inputs have not already been proven by a successful run — a first run, a new output bucket, a new region, or a role you have not used before.
+
+```
+ValidateAHORunReadiness(
+    workflow_id="1234567",
+    role_arn="<from .healthomics/config.toml>",
+    output_uri="<from .healthomics/config.toml>",
+    parameters={...},                  # S3 URIs in the values are checked for existence
+    container_images=["<ecr uri>"],    # optional; see below
+)
+```
+
+Reading the result:
+
+- `ready` is true only when nothing failed.
+- A `fail` means the run will not succeed as configured. Fix it before starting the run.
+- A `warn` means the check could not be completed, not that something is wrong. `role_s3_write` warns when the caller lacks `iam:SimulatePrincipalPolicy`; an input object warns when the caller cannot read it but the run role may still be able to. Warnings do NOT affect `ready`.
+
+`container_images` is not populated automatically. Supply the image URIs from the `runtime`/`container` directives of the workflow definition when you want them verified. IF `validate_containers = true` is set in `.healthomics/config.toml`, you MUST collect those URIs and pass them.
+
+Passing checks do not guarantee a successful run. Parameter types, workflow logic and container contents are outside its scope — see [Parameter Types](#parameter-types) and Phase 1 of the [WDL migration SOP](./migration-guide-for-wdl.md) for verifying container contents.
 
 ### Engine Settings
 
@@ -59,8 +119,8 @@ Behavior to know (Nextflow profiles):
 
 IF the workflow run fails:
 1. Call `DiagnoseAHORunFailure` to get failure details.
-2. Fix the workflow definition based on the diagnosis.
-3. Create a new version via `CreateAHOWorkflowVersion` — see the [Workflow Versioning SOP](./workflow-versioning.md).
+2. Fix the cause. Not every failure is a workflow defect — a run also fails on an unusable role, an output bucket in the wrong region, a missing input, or a mistyped parameter. See [Common Run Failure Patterns](./troubleshooting.md#common-run-failure-patterns) for what to check first for a given error message.
+3. IF you modified the workflow definition, create a new version via `CreateAHOWorkflowVersion` — see the [Workflow Versioning SOP](./workflow-versioning.md). IF you only changed inputs, the role, or the output location, the existing workflow is reusable and a new version is NOT needed.
 4. Retry the run.
 
 IF the run fails with a service error (5xx), a transient error occurred — re-start the run without changes. See the [Troubleshooting SOP](./troubleshooting.md) for more detail.

--- a/aws-healthomics/steering/troubleshooting.md
+++ b/aws-healthomics/steering/troubleshooting.md
@@ -30,6 +30,28 @@ IF a workflow fails to reach `ACTIVE` status, check these causes in order:
     4. IF the previous run used a Run Cache you MUST reference that when starting the new run. Otherwise, you MAY create a Run Cache for this run.
     5. Start a new run of the workflow/ workflow version using identical or modified inputs and Run Cache as appropriate.
 
+## Common Run Failure Patterns
+
+The table below maps error messages observed against the service to the causes worth investigating first. Treat a row as a starting point, not a diagnosis: the same message can arise from more than one cause, and the ordering reflects which is most common rather than which is certain. IF the first action does not resolve it, call `DiagnoseAHORunFailure` and work from the engine and task logs.
+
+| Error message pattern | Investigate in this order | First action |
+| --- | --- | --- |
+| `couldn't construct <Type> from "..."` | 1. Struct passed as a JSON-encoded string rather than an object 2. Field name does not match the struct definition 3. Required field absent | Pass the value as a JSON object. See [Parameter Types](./running-a-workflow.md#parameter-types). |
+| `IAM role is invalid or inaccessible` | 1. Role ARN wrong or role deleted 2. Trust policy does not allow `omics.amazonaws.com` 3. Role belongs to another account | `aws iam get-role --role-name <name>`, then read `AssumeRolePolicyDocument`. |
+| `S3 bucket not located in <region>` | 1. Output bucket is in a different region than the run | `aws s3api get-bucket-location --bucket <name>`. A `null` LocationConstraint means `us-east-1`. Use a bucket in the run's region. |
+| `S3 access denied for s3://...` | 1. Role lacks `s3:PutObject` on the output prefix 2. Bucket policy denies the role 3. Object is SSE-KMS encrypted and the role lacks key access | Check the role's policies for S3 write on that prefix, then the bucket policy, then the KMS key policy. |
+| `has an invalid structure. Provide a valid ECR image URI` | 1. Task names a public registry and no container registry map was attached at workflow creation 2. Map attached but missing an entry for that registry | Re-create the workflow with `container_registry_map`, or replace the URI in the definition with a private ECR URI. The map is set at creation and cannot be added to an existing workflow. |
+| `Container image ... not found` | 1. Tag does not exist in ECR 2. Pull-through cache not yet populated 3. Repository policy does not grant HealthOmics pull access | `CheckContainerAvailability` with `initiate_pull_through: true`, then `ListECRRepositories` to confirm accessibility. |
+| `command not found` in a task log | 1. Image lacks a tool the command block invokes | The image exists but does not carry the tool. Use a multi-tool image — see Phase 1 of the [WDL migration SOP](./migration-guide-for-wdl.md). |
+| `Invalid zip file` on the workflow, not the run | 1. Definition source was a bare `.wdl`/`.nf`/`.cwl` file rather than a ZIP 2. Archive is corrupt | Package with `PackageAHOWorkflow`. See [Deploying a Workflow](./workflow-development.md#step-1-packaging). |
+
+Several of these are knowable before a run starts. `ValidateAHORunReadiness` checks the role, output location, input objects and container accessibility in one call — see [Pre-Run Validation](./running-a-workflow.md#pre-run-validation). PREFER it over discovering these one failed run at a time.
+
+Two properties of run failures shape how to read them:
+
+- **The message names where execution stopped, not what is misconfigured.** A missing container registry map surfaces as a task-level image URI error partway through the run, after earlier tasks have already consumed billed compute.
+- **Input errors arrive after PENDING.** Parameters are validated by the engine, not by `StartRun`, so a mistyped parameter costs the same minutes as a real workflow defect before it reports.
+
 ## VPC Connected Workflow Run Failures
 
 IF a workflow run using VPC networking fails with connectivity-related errors:

--- a/aws-healthomics/steering/workflow-development.md
+++ b/aws-healthomics/steering/workflow-development.md
@@ -98,6 +98,9 @@ This SOP defines how you, the agent, create and deploy genomics workflows for AW
 - You MUST use the `PackageAHOWorkflow` tool to create a zip package of the workflow.
 - You MUST use file paths or S3 paths to reference input files to the package AND the output path.
 - For large workflows with more than ~15 files output to S3 is recommended.
+- HealthOmics requires the definition to be a ZIP archive. A bare `.wdl`/`.nf`/`.cwl` file is packaged automatically WHERE `definition_source` is a file path or S3 URI, so a single-file workflow can be passed directly. This does NOT extend to a workflow with imports: only the named file is packaged, and the missing dependencies surface as import resolution errors at creation. Package anything with imports.
+- The automatic packaging keeps the original filename and produces a single top-level entry, so `path_to_main` is not required — the file does not have to be named `main.wdl`.
+- Inline definition content is left as-is, since that input is expected to be a ZIP already. A file with a `.zip` extension is also left as-is, so a corrupt archive reports as one rather than being wrapped again.
 
 ### Step 2. Deploy to HealthOmics
 - Call `CreateAHOWorkflow` to create the new workflow.


### PR DESCRIPTION
> **Sequencing**: two sections reference MCP server tools that are not released yet — `ValidateAHORunReadiness` ([awslabs/mcp#4486](https://github.com/awslabs/mcp/pull/4486)) and `WaitForAHORun` ([awslabs/mcp#4493](https://github.com/awslabs/mcp/pull/4493)). Everything else stands on its own. Happy to split those two out if you would rather land this first.

## Context

Four gaps found while taking a workflow through migration and running it end to end. Each one cost a failed run to discover, and none of them were workflow defects.

## Parameter types

`running-a-workflow.md` had no guidance on how parameter values map to WDL types. Passing a struct as a JSON-encoded string produces:

```
InputError: check JSON input; couldn't construct SampleMeta from "{\"owner\": \"user\"}" (in sample_meta)
```

Two things make this expensive. Inputs are validated by the engine rather than by `StartRun`, so it arrives minutes in, after `PENDING` — the same cost as a real defect. And the message names the struct, not the mistake, so the natural next move is to go looking at the struct definition.

`parameterTemplate` from `GetAHOWorkflow` does not resolve it either: it carries only `description` and `optional`, with no type information. The type has to be read from the workflow's `input {}` block, which is now stated.

Adds a type table and the failing and working forms side by side.

## Run failure patterns

`troubleshooting.md` covered creation failures and VPC connectivity, and routed everything else to `DiagnoseAHORunFailure`. Adds a table mapping observed messages to what to check first.

Deliberately framed as starting points rather than diagnoses — `S3 access denied` alone can be role policy, bucket policy or KMS, and presenting one as the answer would send an agent down a single track. Each row is ordered by likelihood and the section says to fall back to the logs.

Also records two properties that shape how to read any run failure:

- The message names where execution stopped, not what is misconfigured. A missing container registry map surfaces as a task-level image URI error partway through the run, after earlier tasks have already burned billed compute.
- Input errors arrive after `PENDING`.

## ECR Public fallback

`ecr-pull-through-cache.md` already documents creating the Docker Hub secret, but not what happens without one:

```
Credential ARN is required for Docker Hub pull-through cache.
```

Where credentials are unavailable, many images a legacy workflow names on Docker Hub are also published on ECR Public, which needs none. I hit this with `ubuntu:20.04` and reached it as `ecr-public/ubuntu/ubuntu:20.04`.

Two things the new section is careful about:

- **The repository path differs between the registries**, so the Docker Hub name cannot be reused. It points at the gallery to resolve the real path rather than listing mappings I have not verified.
- **This is URI replacement, not a registry map entry.** It substitutes one image for another, so routing a Docker Hub URI to an ECR Public repository through a map would hide the substitution from the next reader. That matches the decision table already in the WDL migration SOP.

It also notes that tags and contents are not guaranteed to match across registries.

## Packaging

Records that a bare `.wdl`/`.nf`/`.cwl` file behind a path or S3 URI is packaged automatically ([awslabs/mcp#4485](https://github.com/awslabs/mcp/pull/4485)), and the limit of that: only the named file goes in, so a workflow with imports still has to be packaged. Also notes `path_to_main` is unnecessary for the single-entry archive, and that inline content and `.zip` files are left untouched.

## Correction to the failure procedure

The existing steps assumed every run failure is a workflow defect:

```
2. Fix the workflow definition based on the diagnosis.
3. Create a new version via CreateAHOWorkflowVersion
```

Three of the four failures in my session were configuration, not definition — role, bucket region, bucket permissions. A new workflow version is the wrong move for those, and an agent following this literally would create versions that change nothing. Now conditional on having actually modified the definition.

## Verification

All seven cross-document anchors checked against the heading set. Section spacing matches the surrounding files. Content limited to behaviour observed against the service in `ap-northeast-2` and `us-east-1`.

## Related

Follows #179. Companion to the three MCP server PRs: [#4485](https://github.com/awslabs/mcp/pull/4485), [#4486](https://github.com/awslabs/mcp/pull/4486), [#4493](https://github.com/awslabs/mcp/pull/4493).