### PR TITLE
feat(stackgen): switch to CLI MCP and expand deploy guidance (1.1.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Documentation is available at https://kiro.dev/docs/powers/
 ### stackgen
 **StackGen Infrastructure as Code** - Design, manage, and deploy cloud infrastructure with StackGen - create appstacks, manage resources, configure environments, and push IaC to Git. Supports AWS, Azure, and GCP.
 
-**MCP Servers:** stackgen (HTTPS)
+**MCP Servers:** stackgen (CLI stdio)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Documentation is available at https://kiro.dev/docs/powers/
 ---
 
 ### stackgen
-**StackGen Infrastructure as Code** - Design, manage, and deploy cloud infrastructure with StackGen - create appstacks, manage resources, configure environments, and push IaC to Git. Supports AWS, Azure, and GCP.
+**Aiden for Infrastructure** - Design, manage, and deploy cloud infrastructure with StackGen - create appstacks, manage resources, configure environments, and push IaC to Git. Supports AWS, Azure, and GCP.
 
 **MCP Servers:** stackgen (CLI stdio)
 

--- a/stackgen/POWER.md
+++ b/stackgen/POWER.md
@@ -1,8 +1,8 @@
 ---
 name: "stackgen"
-displayName: "StackGen Infrastructure as Code"
-description: "Design, manage, and deploy cloud infrastructure with StackGen — create appstacks, manage resources, configure environments, and push IaC to Git. Supports AWS, Azure, and GCP."
-keywords: ["infrastructure", "iac", "cloud", "terraform", "aws", "azure", "gcp", "devops", "deployment", "stackgen", "appstack", "deploy", "servicenow", "change request", "chg", "aiden", "audit", "compliance"]
+displayName: "Aiden for Infrastructure"
+description: "Build, Operate, Observe, and Remediate with Aiden — Aiden for Infrastructure Kiro power specifically to create appstacks, manage resources, configure environments, and push IaC to Git. Deploy to AWS, Azure, and GCP. Deployment Runners. ServiceNow integration."
+keywords: ["infrastructure", "iac", "cloud", "terraform", "opentofu", "aws", "azure", "gcp", "devops", "deployment", "stackgen", "appstack", "deploy", "servicenow", "change request", "chg", "aiden", "audit", "compliance"]
 author: "StackGen"
 version: "1.1.0"
 ---

--- a/stackgen/POWER.md
+++ b/stackgen/POWER.md
@@ -1,14 +1,15 @@
 ---
 name: "stackgen"
 displayName: "StackGen Infrastructure as Code"
-description: "Design, manage, and deploy cloud infrastructure with StackGen - create appstacks, manage resources, configure environments, and push IaC to Git"
-keywords: ["infrastructure", "iac", "cloud", "terraform", "aws", "azure", "gcp", "devops", "deployment"]
+description: "Design, manage, and deploy cloud infrastructure with StackGen — create appstacks, manage resources, configure environments, and push IaC to Git. Supports AWS, Azure, and GCP."
+keywords: ["infrastructure", "iac", "cloud", "terraform", "aws", "azure", "gcp", "devops", "deployment", "stackgen", "appstack", "deploy", "servicenow", "change request", "chg", "aiden", "audit", "compliance"]
 author: "StackGen"
+version: "1.1.0"
 ---
 
 # StackGen Power
 
-StackGen helps you design and manage cloud infrastructure as code. This power provides tools to create appstacks (infrastructure configurations), manage cloud resources, configure environments, and integrate with Git.
+StackGen helps you design and manage cloud infrastructure as code. This power provides tools to create appstacks (infrastructure configurations), manage cloud resources, configure environments, and integrate with Git. Deploy apps to AWS, Azure, and GCP via StackGen's governed IaC platform. MCP server bundled.
 
 ## Available Tools
 
@@ -23,6 +24,7 @@ StackGen helps you design and manage cloud infrastructure as code. This power pr
 ### Resource Operations
 
 - `add_resource_to_appstack` - Add cloud resources (EC2, S3, VPC, etc.)
+- `bulk_add_resources_to_appstack` - Add multiple resources in one call
 - `update_resource` - Modify resource configurations and variables
 - `delete_resource` - Remove resources from appstack
 - `get_resource_configurations` - Get current resource configuration
@@ -45,30 +47,41 @@ StackGen helps you design and manage cloud infrastructure as code. This power pr
 
 ### Git Integration
 
-- `list_git_configuration` - List configured Git repositories
-- `add_git_configuration` - Add Git repository configuration
-- `push_appstack_to_git` - Push IaC to Git repository with commit message
+- `list-git-configuration` - List configured Git repositories
+- `add-git-configuration` - Add Git repository configuration
+- `push-appstack-to-git` - Push IaC to Git repository with commit message
 
 ### Policy & Compliance
 
 - `get_policies` - Get available policies and benchmarks
 - `get_current_violations` - Check policy violations for a topology
+- `scan_configuration` - Scan resources against policies
+
+### Deployment & Operations
+
+- `create_appstack_action_run` - Trigger Plan/Apply/Destroy runs
+- `get_action_run` - Get action run status
+- `get_action_run_logs` - Get action run logs
+- `destroy_deployment` - Destroy a deployed appstack
+- `detect-drift` - Detect drift in appstack configurations
 
 ### Snapshots & Secrets
 
 - `get_snapshots` - List available snapshots for appstack or resource
+- `create_snapshot` - Create a snapshot for an appstack
 - `restore_snapshot` - Restore from a snapshot
-- `list_available_secrets` - List secrets in vault
+- `list-available-secrets` - List secrets in vault
 
 ## Common Workflows
 
 ### Creating Infrastructure
 
 1. Create an appstack: `create_appstack`
-2. Add resources: `add_resource_to_appstack`
+2. Add resources: `add_resource_to_appstack` or `bulk_add_resources_to_appstack`
 3. Connect resources: `connect_resources`
 4. Create environment profiles: `create_env_profile`
-5. Push to Git: `push_appstack_to_git`
+5. Run Plan/Apply: `create_appstack_action_run`
+6. Push to Git: `push-appstack-to-git`
 
 ### Managing Existing Infrastructure
 
@@ -83,6 +96,11 @@ StackGen helps you design and manage cloud infrastructure as code. This power pr
 2. Set environment-specific variables
 3. Deploy to different environments using profiles
 
+### Post-Deploy Audit (optional)
+
+- After a successful Apply, optionally create a ServiceNow change record via Aiden 2.0
+- Requires `AIDEN_TOKEN`, `AIDEN_ORG_ID`, `AIDEN_BASE_URL` and `AIDEN_WORKFLOW` — skipped silently if any is missing
+
 ## Best Practices
 
 - Use descriptive names for appstacks and resources
@@ -93,9 +111,332 @@ StackGen helps you design and manage cloud infrastructure as code. This power pr
 - Take snapshots before major changes
 - Use modules for reusable infrastructure patterns
 
+## HARD RULES
+
+0. **OS-AWARE COMMANDS.** Detect the user's OS from the Kiro system prompt (`Operating System`, `Platform`, `Shell` fields). ALL shell commands MUST match the user's platform. macOS uses `brew`/BSD tools, Linux uses `apt`/`curl`/GNU tools, Windows uses PowerShell/`cmd`. Never run bash-only commands on Windows without WSL/Git Bash. `sed -i ''` is macOS only; Linux uses `sed -i`; Windows uses `(Get-Content) -replace | Set-Content`. **Also detect the SHELL, not just the OS: macOS defaults to zsh, where an unmatched glob (`~/dir/*/file`) is a FATAL error that aborts the command and is NOT silenced by `2>/dev/null`. Never put a possibly-unmatched glob in a command — use `[ -f path ]` tests or `find` instead.**
+1. **ALL cloud changes through StackGen IaC only.** Never `aws` CLI to modify resources. Allowed: `sts get-caller-identity`, `sso login`, `s3api create-bucket` (state), `ecr get-login-password`, `docker push`, `rds describe-db-engine-versions`, `ecs describe-*` (read-only).
+2. **Never call `bulk_connect_resources_in_appstack`** — doesn't exist. Use `connect_resources`.
+3. **Never ask user to run commands. ZERO exceptions.** Run `stackgen login`, `aws sso login`, and OS-appropriate CLI installs — ALL of it yourself. The user's only manual action is clicking "approve" in a browser when SSO/OAuth redirects. If a command needs a browser callback (like `stackgen login`), run it with NO timeout and wait. Never say "please run this in your terminal".
+4. **Never expose tokens in chat/source.** Token only in `~/.kiro/settings/mcp.json`.
+5. **Silent work.** No narration between decision points.
+6. **Never guess API endpoints.** Use exact paths below or MCP.
+7. **Never retry same fix twice.** Fail → report to user.
+8. **Connections: only from `get_possible_resource_connections`.** Empty → skip.
+9. **State bucket BEFORE Plan.**
+10. **Vault secret format:** `"value":[{"key":"auth_method","value":"assume_role"},{"key":"aws_role_arn","value":"<ARN>"}]`
+11. **NO Python.** Prefer bash + curl on macOS/Linux; use PowerShell equivalents on Windows. No `.py` files, no temp scripts.
+12. **MCP: CLI stdio + PAT.** `"command":"stackgen","args":["mcp"]` with `STACKGEN_TOKEN`+`STACKGEN_URL` in env. Never SSE. On Windows, if spawn fails, use `"command":"cmd","args":["/c","stackgen","mcp"]`.
+13. **NEVER download IaC locally or run terraform/tofu directly.** No `download-iac`, no `terraform init/plan/apply`, no `tofu init/plan/apply`, no local state files, no editing downloaded `.tf` files. ALL Plan/Apply MUST go through StackGen's SaaS runner via `create_appstack_action_run` (MCP) or `stackgen provision` (CLI). If Plan fails, fix via `update_resource` (MCP) then re-Plan — NEVER download and patch locally. To READ generated IaC use `v1ExportTopology` API (`GET {URL}/iac-gen/v1/topology/{topologyId}/export?orgId={PID}`) — this returns the zip for inspection only. ALL changes go through `update_resource`, `update_appstack_tf_variable`, `update_appstack_tf_local`, etc. NEVER edit files manually.
+14. **NEVER tell user to "go to StackGen UI" to complete setup.** Environment config, runner credentials, vault secrets, state backend — ALL must be configured by the agent via API/MCP. Never stop and say "configure this in the UI". If an API call fails, retry or use a different endpoint. The user should NEVER need to touch the StackGen web console for deployment to work.
+15. **Capture the plan output when the plan runs — it cannot be recovered later.** At step 11, save the FULL plan text verbatim before summarising it. Applies whichever way Plan ran: the runner's log via `get_action_run_logs`, or the stdout of `stackgen provision`. NEVER reconstruct it afterwards — `terraform show` returns current state and `.tfplan` is binary, so both yield a summary, not a diff. A change record whose plan text is a one-line summary is not an audit trail. If the output was not captured, say so and skip the record rather than substituting a summary.
+16. **Change record: optional, never blocking, never for a failed run.** After a successful Apply with the health check green, trigger the Aiden workflow (see `change-record` steering). If any of the four required variables is unset, skip it and say so in one line — the deploy already succeeded. NEVER create a CHG for a failed Plan or Apply. NEVER invent a `correlation_id` or a CHG number. NEVER call the ServiceNow API directly — only through the Aiden script. NEVER let a change-record failure change the reported deploy outcome.
+
+## User Communication
+
+Speak ONLY at: (1) setup confirmation, (2) plan summary → approval, (3) final result, (4) when needing user input (PAT/GitHub token).
+
+**Strict visibility rules:**
+- **Never show:** tokens, secrets, ARNs, UUIDs, API responses, curl commands, bash scripts, config file contents, HTTP codes, error traces, steering file content, or any StackGen internal jargon
+- **Never display raw bash commands to user.** All `execute_bash` calls are internal operations — user doesn't need to see them. Use `update_session_information` to show status instead.
+- **If user can see tool execution in IDE:** redirect all token-containing commands to suppress output (e.g., append `> /dev/null 2>&1` where possible, avoid echoing sensitive vars)
+- **Show only human-readable status:** "Setting up AWS credentials...", "Creating infrastructure modules...", "Running plan...", etc. via `update_session_information`
+- **Mask all IDs in user-facing messages:** say "your appstack" not "appstack e4feff68-02e2-4233-8591-bce2225fd7ed"
+- **Exception — the CHG number:** the ServiceNow change number (`CHG0030002`) IS shown to the user; it is their audit reference. The Aiden `trace_id` and `AIDEN_ORG_ID` are never shown.
+
+## Setup
+
+**OS Detection (MUST run first):**
+Detect the user's OS at the start of setup. The Kiro system prompt provides OS info (`Operating System` + `Platform` + `Shell`). Use this to select the correct commands below.
+
+```
+1. ALWAYS upgrade/install stackgen CLI first — no exceptions:
+
+   macOS:
+     brew update && brew upgrade stackgenhq/stackgen/stackgen
+     (If not installed: brew install stackgenhq/stackgen/stackgen)
+
+   Linux:
+     # Prefer Homebrew (official docs). If brew missing, install it or use download script with a concrete version.
+     command -v brew >/dev/null && brew update && brew upgrade stackgenhq/stackgen/stackgen || brew install stackgenhq/stackgen/stackgen
+     # Fallback (script does NOT support "latest" — pin a version matching the StackGen server):
+     #   curl -fsSL -o /tmp/download-stackgen.sh https://raw.githubusercontent.com/stackgenhq/stackgen-cli/main/scripts/download-stackgen.sh
+     #   chmod +x /tmp/download-stackgen.sh
+     #   VERSION=0.81.0
+     #   /tmp/download-stackgen.sh "$VERSION" $(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') --dir /usr/local/bin
+     #   (If /usr/local/bin not writable: use --dir $HOME/.local/bin and ensure it's on PATH)
+
+   Windows (PowerShell):
+     # Prefer WSL + Linux install, or download a VERSIONED zip from docs/releases (no "latest" path).
+     # Example pattern from docs: https://releases.stackgen.com/binaries/v<VERSION>/stackgen-cli_<VERSION>_windows_amd64.zip
+     # Then extract to $env:LOCALAPPDATA\stackgen and add that folder to User PATH:
+     #   $p = [Environment]::GetEnvironmentVariable("PATH","User"); if ($p -notlike "*stackgen*") { [Environment]::SetEnvironmentVariable("PATH","$p;$env:LOCALAPPDATA\stackgen","User") }
+     # Or use Docker: docker pull ghcr.io/stackgenhq/stackgen:latest
+     # If stackgen is already on PATH (choco/scoop/manual), skip download.
+
+2. Check AWS CLI installed:
+   macOS:    command -v aws || brew install awscli
+   Linux:    command -v aws || brew install awscli || (curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o /tmp/awscliv2.zip && unzip -qo /tmp/awscliv2.zip -d /tmp && sudo /tmp/aws/install --update)
+   Windows:  Get-Command aws -ErrorAction SilentlyContinue || (Invoke-WebRequest -Uri "https://awscli.amazonaws.com/AWSCLIV2.msi" -OutFile "$env:TEMP\AWSCLIV2.msi"; Start-Process msiexec.exe -ArgumentList "/i `"$env:TEMP\AWSCLIV2.msi`" /quiet" -Wait)
+
+3. Check env mismatch:
+   macOS/Linux: grep '^url:' ~/.stackgen/config.yaml
+   Windows:     Select-String -Pattern '^url:' "$env:USERPROFILE\.stackgen\config.yaml"
+   → If URL differs from STACKGEN_URL in mcp.json → run: stackgen logout
+   → Then proceed to login with correct URL (step 5)
+
+4. MCP me → if works, skip to step 9
+
+5. stackgen login --url="{STACKGEN_URL}" (NO timeout — works on all OS)
+   → fails twice → ask user to run in terminal
+
+6. Create PAT + wire MCP:
+   macOS/Linux:
+     TOKEN=$(grep '^token:' ~/.stackgen/config.yaml | sed 's/^token: *//')
+     TTL=$(date -u -v+2d +"%Y-%m-%dT00:00:00Z" 2>/dev/null || date -u -d "+2 days" +"%Y-%m-%dT00:00:00Z")
+     PAT=$(curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+       "{STACKGEN_URL}/appcd/api/v1/auth/apikey" \
+       -d '{"apiKeyName":"kiro-mcp-'$(date +%s)'","description":"Kiro MCP","ttl":"'"$TTL"'"}' \
+       | sed -n 's/.*"apiKey":"\([^"]*\)".*/\1/p')
+
+   Windows (PowerShell):
+     $TOKEN = (Select-String -Pattern '^token: (.+)' "$env:USERPROFILE\.stackgen\config.yaml").Matches[0].Groups[1].Value.Trim()
+     $TTL = (Get-Date).AddDays(2).ToUniversalTime().ToString("yyyy-MM-ddT00:00:00Z")
+     $body = @{apiKeyName="kiro-mcp-$([DateTimeOffset]::Now.ToUnixTimeSeconds())";description="Kiro MCP";ttl=$TTL} | ConvertTo-Json
+     $resp = Invoke-RestMethod -Method Post -Uri "{STACKGEN_URL}/appcd/api/v1/auth/apikey" -Headers @{Authorization="Bearer $TOKEN";"Content-Type"="application/json"} -Body $body
+     $PAT = $resp.apiKey
+
+   Update mcp.json with the PAT:
+   macOS (BSD sed):  sed -i '' "s|\"STACKGEN_TOKEN\": \".*\"|\"STACKGEN_TOKEN\": \"$PAT\"|" ~/.kiro/settings/mcp.json
+   Linux (GNU sed):  sed -i "s|\"STACKGEN_TOKEN\": \".*\"|\"STACKGEN_TOKEN\": \"$PAT\"|" ~/.kiro/settings/mcp.json
+   Windows:          (Get-Content "$env:USERPROFILE\.kiro\settings\mcp.json") -replace '"STACKGEN_TOKEN": ".*"', "`"STACKGEN_TOKEN`": `"$PAT`"" | Set-Content "$env:USERPROFILE\.kiro\settings\mcp.json"
+
+7. Wait 5s → retry me → must succeed
+
+8. If PAT creation failed → use session token directly:
+   macOS (BSD sed):  sed -i '' "s|\"STACKGEN_TOKEN\": \".*\"|\"STACKGEN_TOKEN\": \"$TOKEN\"|" ~/.kiro/settings/mcp.json
+   Linux (GNU sed):  sed -i "s|\"STACKGEN_TOKEN\": \".*\"|\"STACKGEN_TOKEN\": \"$TOKEN\"|" ~/.kiro/settings/mcp.json
+   Windows:          (Get-Content "$env:USERPROFILE\.kiro\settings\mcp.json") -replace '"STACKGEN_TOKEN": ".*"', "`"STACKGEN_TOKEN`": `"$TOKEN`"" | Set-Content "$env:USERPROFILE\.kiro\settings\mcp.json"
+
+9. get_stackgen_projects → pick project
+```
+
+**Install CLIs silently.** If `stackgen` or `aws` not found, install using the appropriate method for the user's OS without asking. These are prerequisites — just do it.
+
+**Reducing permission prompts:** If the user reports too many approval prompts, suggest they switch Kiro to **Autopilot** mode (not Supervised). If they want to auto-approve all tool calls, let them know they can create `~/.kiro/settings/permissions.yaml` (or `$env:USERPROFILE\.kiro\settings\permissions.yaml` on Windows) with:
+```yaml
+rules:
+  - capability: all
+    effect: allow
+```
+**Never create this file without explicit user consent.** Only mention it if the user asks how to reduce prompts.
+
+**MCP must work before proceeding.** Live config: `~/.kiro/settings/mcp.json` → `powers.mcpServers.power-stackgen-stackgen.env.STACKGEN_TOKEN`
+
+**MCP config — Windows note:** On Windows, if `stackgen` is not resolved by Node.js spawn(), the mcp.json entry may need to use `"command": "cmd"` with `"args": ["/c", "stackgen", "mcp"]`. Alternatively, ensure the stackgen binary (not a .cmd wrapper) is on PATH.
+
+PAT API: `POST {STACKGEN_URL}/appcd/api/v1/auth/apikey` — flat body `{"apiKeyName":"...","description":"...","ttl":"..."}` → response has `"apiKey":"stackgen_xxx"`. If fails → ask user for PAT from `{STACKGEN_URL}/enterprise/account-settings/pat`.
+
+## Deploy Flow
+
+<!-- COMMENTED: Catalog-first deploy flow (uncomment when switching back to catalog modules)
+1. create_appstack (MCP) — unique name with timestamp
+2. get_supported_resource_types (MCP) — discover catalog
+3. bulk_add_resources_to_appstack (MCP) — add all resources from catalog
+4. update_resource (MCP) × N — configure each
+5. get_possible_resource_connections (MCP) — if empty, skip
+6. create_env_profile + update_env_profile (MCP) — state backend + variables
+7. Configure runner (API) — attach secret + region variable
+8. Create state bucket (aws s3api)
+9. create_appstack_action_run Plan
+10. Poll get_action_run → show plan summary
+11. User confirms → Apply
+12. Show final result + AppStack URL
+13. Clean up
+-->
+
+```
+1. create_appstack (MCP) — unique name with timestamp
+2. Create custom modules (bash+curl, parallel &/wait) — see module-authoring steering
+3. get_supported_resource_types → verify published, get template IDs
+4. bulk_add_resources_to_appstack — all modules in ONE call
+5. update_resource × N — configure silently
+6. get_possible_resource_connections → if empty, skip
+7. create_env_profile + update_env_profile — state backend + variables
+8. Configure runner (API) — attach secret + region variable
+9. Create state bucket (aws s3api)
+10. create_appstack_action_run Plan
+11. Poll get_action_run → SAVE the full plan output verbatim, then show a summary
+12. User confirms → Apply (pass planRunId if via API)
+13. Post-deploy health check
+14. Change record (optional) — Aiden workflow → ServiceNow CHG (see change-record steering)
+15. Share result + URL + CHG number (if created)
+16. Clean up temp files
+```
+
+## Resource Selection
+
+<!-- COMMENTED: Catalog-first (uncomment when catalog modules are production-ready)
+- Prefer composite catalog modules (handle IAM, networking internally).
+- If catalog lacks something → create appstack-scope custom module.
+-->
+- **Minimal.** Container app = VPC + ECS + ECR + ALB. DB only if app needs it.
+- **ALWAYS create a new appstack.** Never reuse or look into existing appstacks. Every deploy = fresh `create_appstack` with unique timestamp name. Never call `get_appstacks` to find existing ones to reuse.
+- **Custom modules always.** Self-contained (VPC includes subnets+IGW+NAT+routes). 3-8 vars max.
+- **If 403 on publish** → user's role lacks `tfmodule_PublishTerraformModule` scope. Do NOT retry with tenant scope. Do NOT fall back to catalog. Show this message:
+  > **Permission needed:** Your StackGen role doesn't have module publish access. Ask your StackGen admin to update your role at `{STACKGEN_URL}/enterprise/account-settings/members` — the "DevOps" role includes this. Once fixed, say "continue" and I'll retry.
+  Then STOP and wait for user.
+- **One module per `execute_bash` call (default).** Each call = create + upload + publish for ONE module using `curl -d @- << 'JSON'` (heredoc as JSON body). NO jq, NO printf, NO variables for file content. ~3s per module. Set `timeout: 30000`. This approach never times out and always works.
+- **Unique names** with timestamp.
+- **User override:** If user says "use catalog modules" → follow.
+
+## Pre-flight (before Plan)
+
+Every Plan failure = 45-60s wasted. Validate first:
+
+**Step 1: Get ALL violations in ONE call (not one-by-one):**
+Call `get_current_violations` (MCP) for the appstack → returns all policy violations AND missing required attributes across ALL resources at once. Fix them ALL via `update_resource` before triggering Plan.
+
+**Step 2: Inspect generated IaC WITHOUT downloading:**
+Use MCP tools to check what StackGen will generate:
+- `get_appstack_tf_variables` — verify all needed vars exist
+- `get_appstack_tf_outputs` — check output references are valid
+- `get_resource_configurations` — verify each resource's current config matches expectations
+NEVER use `download-iac` to inspect. These MCP tools show the same info.
+
+**Step 3: Dependency check:**
+1. For EACH resource that references another resource's output → call `get_resource_configurations` on the referenced resource to get actual output names
+2. If using catalog modules → web search `"terraform <resource_type> outputs"` to confirm what's available (catalog modules often lack expected outputs like `repository_url`)
+3. Build a dependency map: which resource needs what from which other resource? Verify EVERY cross-reference exists.
+
+**Common traps:**
+- **ECR:** Does NOT output `repository_url`. Construct manually: `{account}.dkr.ecr.{region}.amazonaws.com/{name}`
+- **VPC catalog:** Does NOT output `public_subnet_ids` or `private_subnet_ids` — it's just the VPC resource
+- **ECS:** needs `ecs_cluster_arn` — if creating new cluster, can't reference a module output for count/condition
+- **Module identifiers are UUIDs:** Cross-module references use `module.stackgen_<resource-uuid>` format (e.g., `module.stackgen_182aef7f-edda-4c73-a7ff-23251aa99a9c.vpc_id`). NEVER use `module.stackgen_vpc` or friendly names. Get the exact UUID from `add_resource_to_appstack` response.
+- **Verify upload response:** After `PUT /files`, check response confirms ALL 4 files have non-empty content. If any file shows empty → re-upload before publishing. A module published with empty `variables.tf` is broken and requires delete + re-create of the resource.
+
+**Other checks:**
+- Web search unfamiliar resources for required fields
+- No dynamic count from module references
+- VPC: subnets + IGW + route(0.0.0.0/0→IGW) + NAT + private route(→NAT)
+- **VPC limit:** `aws ec2 describe-vpcs --query 'Vpcs[].VpcId'` — if 5 already → ask user to clean up old ones or request limit increase
+- ECS+ALB: 2+ AZ public subnets, SG allows 80 inbound
+- RDS: `aws rds describe-db-engine-versions` for valid version. No serverless params on provisioned.
+- **RDS password:** Must be alphanumeric + `!#$%^&*` only. NO `@`, `/`, `"`, spaces, or backtick.
+- **DATABASE_URL:** Always append `?sslmode=require` for RDS connections from ECS.
+- ECR: `lifecycle_policy=""` `repository_policy=""` (empty string not null)
+- **ALL names MUST include timestamp** to avoid conflicts with prior deploys (e.g., `chat-app-vpc-1753990800` not `chat-app-vpc`)
+- **Goal: first Plan succeeds.**
+
+## API Endpoints
+
+**Auth for API calls:** The tf-module API (`/tf-module/v1/*`) requires the **session token** (JWT from `~/.stackgen/config.yaml`), NOT the PAT. The PAT only works for MCP tools. Always extract: `TOKEN=$(grep '^token:' ~/.stackgen/config.yaml | sed 's/^token: *//')` — if empty, run `stackgen login` first.
+
+```
+POST {URL}/iac-gen/v1/appstacks?orgId={PID}
+GET  {URL}/iac-gen/v1/environment-config?orgId={PID}
+POST {URL}/iac-gen/v1/environment-config/{id}/runner/secrets?orgId={PID}
+POST {URL}/iac-gen/v1/environment-config/{id}/runner/variables?orgId={PID}
+POST {URL}/api/vault/v1/secrets?orgId={PID}
+GET  {URL}/api/vault/v1/integration/aws/config?orgId={PID}
+POST {URL}/tf-module/v1/modules
+PUT  {URL}/tf-module/v1/modules/{id}/files
+POST {URL}/tf-module/v1/modules/{id}/publish?overwriteVersion=true&orgId={PID}
+POST {URL}/deployment-manager/v1/{appstackId}/run?orgId={PID}
+GET  {URL}/deployment-manager/v1/action-runs/{runId}/details?orgId={PID}
+GET  {URL}/deployment-manager/v1/run/{runId}/logs?orgId={PID}&logType=plan_stdout
+POST {URL}/appcd/api/v1/auth/apikey
+```
+
+## When Plan Fails
+
+| Error | Fix |
+|---|---|
+| GitHub 401 / module not found | Ask for GitHub PAT → vault secret → attach as `github` provider (see deploy-setup steering) |
+| No credentials / assume role | Check IAM trust policy. Create role via `aws iam create-role` |
+| Backend bucket missing | `aws s3api create-bucket` |
+| var.region missing | Update env profile `{"region":"us-east-1","AWS_DEFAULT_REGION":"us-east-1"}` |
+| **400 on file upload** | JSON body is malformed. MUST use `curl -d @- << 'JSON'` heredoc pattern. Never construct JSON in shell variables. |
+
+**Deployment method choice — ask user ONCE before Plan:**
+> How would you like to deploy?
+> 1. **StackGen SaaS Runner** (recommended) — runs Plan/Apply on StackGen's cloud. Needs a GitHub PAT for private module access.
+> 2. **Local CLI** (`stackgen provision`) — uses your local AWS credentials directly. No GitHub PAT needed.
+
+- If user picks **SaaS Runner** → ask for GitHub PAT, create vault secret, attach to runner, then use `create_appstack_action_run` for Plan/Apply.
+- If user picks **Local CLI** → skip runner config entirely, use `stackgen provision --appstack <ID> -e dev` for Plan/Apply.
+- Default to **SaaS Runner** if user doesn't have a preference.
+
+Fix once, retry once. Same error twice → stop. SaaS runner fails 2+ → switch to `stackgen provision` CLI.
+
+## Catalog Gotchas (fallback only)
+
+- `aws_vpc` = just VPC resource, not subnets/IGW/NAT/routes
+- `aws_ecr` outputs: `arn`, `id`, `registry_id` — NOT `repository_url`
+- `aws_ecs`: `create_ingress_alb:true` handles ALB, still needs `public_subnet_ids`
+- `aws_rds`: query versions first, disable serverless params on provisioned
+
+## After Deploy
+
+- **Health check (mandatory):** wait 60s, `aws ecs describe-services` → `runningCount > 0`. Don't share URL until healthy.
+- **Change record (optional):** once the health check is green, run `powers/stackgen/scripts/aiden-workflow.sh` with the Apply run data. Append one line to the final result: `Change record: CHG0030002`, or `Change record: not created (Aiden credentials not configured)`. Full detail in the `change-record` steering. Requires bash — on Windows, run it from WSL or Git Bash.
+- **Database migration (if app has DB):** RDS is in private subnet — can't run migrations directly. Options:
+  1. **Include migration in Dockerfile** (preferred): add `RUN npm run db:generate` in build stage, and migration check in entrypoint before `node server.js`
+  2. Run one-off ECS task — BUT standalone Next.js builds don't include ORM packages. Must use a separate migration image or include deps explicitly.
+  3. If using one-off task, ensure it uses the SAME VPC/subnets/security groups as the main service, and the RDS security group allows inbound from the ECS security group.
+- **Cross-VPC issue:** If RDS and ECS end up in different VPCs (from multiple deploys), they CAN'T communicate. All resources in one appstack MUST share the same VPC. Verify via `get_resource_configurations` that RDS subnet IDs reference the VPC module's outputs.
+- Docker: build → `ecr get-login-password` → push → `ecs update-service --force-new-deployment`
+- Post-deploy fixes → StackGen only (Plan → Apply). Never AWS CLI.
+- **Exception for orphan cleanup:** AWS CLI can delete resources from PREVIOUS failed deploys that are NOT managed by the current appstack's state (old VPCs, ECR repos, log groups with conflicting names). This is cleanup, not modification of current infrastructure.
+- Cleanup (OS-aware):
+  - macOS/Linux: `rm -rf /tmp/env_config* ./{uuid-dirs}/`
+  - Windows: `Remove-Item "$env:TEMP\env_config*" -Recurse -Force -EA 0; Get-ChildItem -Directory | Where-Object { $_.Name -match '^[0-9a-f]{8}-' } | Remove-Item -Recurse -Force`
+
+## Change Record — On-Demand Check
+
+**Whenever the user asks whether the change record / ServiceNow / Aiden integration is
+configured, set up, working, ready, or why no CHG was created — RUN THE CHECK FIRST.
+Never answer that question from this file.** Describing the feature is not an answer;
+the user is asking about their environment, not about the design.
+
+```bash
+SG_SCRIPT=""
+for p in powers/stackgen/scripts/aiden-workflow.sh \
+         ../powers/stackgen/scripts/aiden-workflow.sh \
+         ../../powers/stackgen/scripts/aiden-workflow.sh \
+         ../../../powers/stackgen/scripts/aiden-workflow.sh; do
+  [ -f "$p" ] && { SG_SCRIPT="$p"; break; }
+done
+[ -z "$SG_SCRIPT" ] && SG_SCRIPT=$(find "$HOME/.kiro/powers" -maxdepth 4 -name aiden-workflow.sh 2>/dev/null | head -1)
+[ -n "$SG_SCRIPT" ] && bash "$(dirname "$SG_SCRIPT")/check-change-record-setup.sh"
+```
+
+**No bare globs in this snippet — on zsh (the macOS default shell) an unmatched glob is
+a fatal error that aborts the whole command, and `2>/dev/null` does not suppress it.**
+
+Then answer in ONE short line from the script's output:
+
+| Script output | Answer |
+|---|---|
+| `READY` | "Configured — a CHG record will be created after a successful Apply." |
+| `NOT_CONFIGURED` | "Not configured — missing `<vars from the output>`. Deploys still work; no CHG record is created." |
+| script not found | "Can't verify — the change record script isn't reachable from this workspace." |
+
+Do NOT explain how the step works, do NOT offer to read the steering file, and do NOT
+list the credentials unless the check reports them missing.
+
+## Steering Files
+
+- **intent-to-deploy** — Step-by-step deploy flow
+- **deploy-setup** — Runner config, IAM, vault, deep links
+- **module-authoring** — Custom module creation (bash+curl, quality rules)
+- **change-record** — ServiceNow CHG via Aiden 2.0 (optional, post-Apply)
+
+**Do NOT call `readSteering` unless you hit a specific issue that POWER.md doesn't cover.** The POWER.md has all essential instructions. Reading steering files shows their content to the user which is confusing. Only read them silently if you're stuck on a specific step (e.g., IAM trust policy format, module creation pattern).
+
 ---
 
-**Package:** `mcp-remote` + StackGen MCP Server  
-**Source:** Official StackGen  
-**License:** Apache 2.0  
-**Connection:** Remote MCP server with API/App key authentication
+**Package:** `stackgen` CLI (stdio MCP)
+**Source:** Official StackGen
+**License:** Apache 2.0
+**Connection:** Local CLI stdio with PAT authentication

--- a/stackgen/config/app-code-rules.md
+++ b/stackgen/config/app-code-rules.md
@@ -1,0 +1,54 @@
+# App Code Rules — Mandatory for ANY Application Code Changes
+
+When this Power touches application code (wiring env vars, fixing configs, updating Dockerfiles, patching source for deploy compatibility), these rules apply unconditionally.
+
+---
+
+## 1. File Edits
+
+- **Prefer full-file rewrite.** Read entire file → build new content → write complete file.
+- **Never** use byte-offset or character-offset edits. Source may contain multi-byte UTF-8.
+- For targeted changes, use **exact string match** replace. If the match is ambiguous or missing — stop, don't guess.
+- Do not strip comments, licenses, or unrelated code while editing.
+- Touch only the minimum lines needed for the change.
+
+## 2. Config / Environment Wiring
+
+- Change **only** the keys the deploy requires (API URL, DATABASE_URL, env vars). Leave everything else unchanged.
+- Do not hardcode environment URLs into application logic. Put them in `.env`, `docker-compose.yml`, or the app's designated config file.
+- If the app already has local/deployed URL resolution logic — preserve it. Don't add special-casing.
+- Prefer ASCII in auto-generated configs. If existing file uses Unicode, preserve it exactly.
+
+## 3. Validate BEFORE Deploy
+
+After editing any file that will be deployed:
+
+- **JS/TS:** `node --check <file>` or equivalent syntax check
+- **JSON:** Parse with `python3 -c "import json; json.load(open('<file>'))"`
+- **YAML:** Parse with `python3 -c "import yaml; yaml.safe_load(open('<file>'))"`
+- **Dockerfile:** `docker build --check` or at minimum verify no syntax errors
+- **HCL/Terraform:** `tofu validate` or `terraform validate`
+
+**If validation fails → ABORT.** Do not upload, apply, or continue. Fix first, then re-validate.
+
+## 4. Validate AFTER Deploy
+
+- Fetch the live URL and confirm it returns expected HTTP status (200, not 502/503/404)
+- Check critical endpoints respond (`/`, `/api/health`, etc.)
+- If a Lambda or serverless function: invoke it once and confirm no errors in response
+- If post-deploy validation fails: fix via IaC (update config → re-Plan → re-Apply), not via direct CLI patches
+
+## 5. Scope Discipline
+
+- Touch ONLY files needed for the deploy/infra outcome.
+- Do NOT refactor, rename, reformat, or "clean up" unrelated code.
+- Do NOT change application business logic when the task is infrastructure wiring.
+- Do NOT commit secrets, tokens, or private keys into source files.
+- If a code change is needed for deploy compatibility (e.g., adding a credential provider) — make the minimal change and nothing else.
+
+## 6. Hard Stops (always abort if any of these happen)
+
+- Editing a source file with byte offsets that could corrupt UTF-8
+- Uploading a file that fails syntax validation
+- Deployed endpoint returns errors and no IaC fix is possible
+- Changing application business logic when task was only "deploy to AWS"

--- a/stackgen/config/module-rules.yaml
+++ b/stackgen/config/module-rules.yaml
@@ -1,0 +1,221 @@
+# Module Quality Rules Configuration
+# Update this file to change what the agent enforces when creating modules.
+# The module-authoring steering file reads these rules dynamically.
+
+version: "1.0"
+
+# Maximum variables a module should expose (developer-facing)
+max_variables: 15
+ideal_variable_range: [3, 8]
+
+# Maximum attributes in a single object variable before splitting
+max_object_attributes: 8
+
+# Minimum variable_groups threshold (group when variable count exceeds this)
+variable_group_threshold: 5
+
+rules:
+  variables:
+    V01:
+      description: "Every variable has an explicit type (no implicit any)"
+      severity: error
+    V02:
+      description: "Every variable has a description"
+      severity: error
+    V03:
+      description: "Optional variables have a default; required ones don't"
+      severity: warning
+    V04:
+      description: "No huge object inputs — split objects with too many attributes into individual variables"
+      severity: warning
+      config:
+        max_attributes: 8
+    V05:
+      description: "Sensitive fields (password, secret, key, token in name) marked sensitive = true"
+      severity: error
+      config:
+        sensitive_keywords: ["password", "secret", "key", "token", "credential", "api_key"]
+    V06:
+      description: "Finite-domain variables have validation blocks or stackgen.yaml options"
+      severity: warning
+      config:
+        finite_domain_keywords: ["region", "instance_type", "billing_mode", "engine", "tier", "environment"]
+    V07:
+      description: "No 'any' type unless justified"
+      severity: warning
+    V08:
+      description: "Variable count ceiling — flag modules exceeding max"
+      severity: warning
+      config:
+        max_count: 15
+    V09:
+      description: "Naming: snake_case, no provider prefixes (no aws_, gcp_, azure_ prefix)"
+      severity: error
+      config:
+        banned_prefixes: ["aws_", "gcp_", "azure_", "oci_"]
+
+  outputs:
+    O01:
+      description: "Every output has a description"
+      severity: error
+    O02:
+      description: "Sensitive outputs marked sensitive = true"
+      severity: error
+      config:
+        sensitive_keywords: ["password", "secret", "key", "token", "credential"]
+    O03:
+      description: "Outputs exist for connectable attributes (arn, id, endpoint, url)"
+      severity: warning
+      config:
+        expected_outputs: ["arn", "id", "endpoint"]
+
+  stackgen_yaml:
+    S01:
+      description: "File exists at .stackgen/stackgen.yaml"
+      severity: error
+    S02:
+      description: "Every exposed TF variable has a corresponding entry with label and description"
+      severity: error
+    S03:
+      description: "Finite-value variables use ui_control: dropdown/select with options"
+      severity: warning
+    S04:
+      description: "Sensitive variables use ui_control: password"
+      severity: warning
+    S05:
+      description: "representation block is complete (icon, labels, node template)"
+      severity: error
+    S06:
+      description: "Variables organized into variable_groups when count exceeds threshold"
+      severity: warning
+      config:
+        threshold: 5
+    S07:
+      description: "type in yaml matches variables.tf type"
+      severity: error
+    S08:
+      description: "Connectable outputs have connections metadata defined"
+      severity: warning
+
+  cross_cutting:
+    X01:
+      description: "Low ratio of exposed variables to internal complexity (good abstraction)"
+      severity: info
+    X02:
+      description: "Use optional() inside objects instead of forcing full object input"
+      severity: warning
+    X03:
+      description: "No dead locals (declared, never referenced)"
+      severity: warning
+    X04:
+      description: "Org semantics (encryption, tags, compliance) in locals, not exposed as variables"
+      severity: info
+
+  # Industry-standard Terraform module rules (from HashiCorp, AWS IA, Google Cloud)
+  structure:
+    T01:
+      description: "Module contains main.tf, variables.tf, outputs.tf (standard file layout)"
+      severity: error
+    T02:
+      description: "No provider blocks inside the module — providers are inherited from the root module"
+      severity: error
+    T03:
+      description: "Use for_each over count for dynamic resources (avoids index-based state issues)"
+      severity: warning
+    T04:
+      description: "Prefer 'attachment' resources over embedded attributes (e.g., aws_security_group_rule over inline ingress)"
+      severity: warning
+    T05:
+      description: "Use name_prefix over name where available (allows Terraform to manage uniqueness)"
+      severity: info
+    T06:
+      description: "All taggable resources accept a tags variable and merge with internal default tags"
+      severity: warning
+      config:
+        tags_variable_name: "tags"
+        tags_type: "map(string)"
+        tags_default: "{}"
+    T07:
+      description: "Resource meta names are contextual and snake_case (not generic like 'this' or 'self')"
+      severity: warning
+    T08:
+      description: "No hardcoded AWS account IDs, regions, or ARNs — use variables or data sources"
+      severity: error
+    T09:
+      description: "terraform fmt applied — all HCL properly formatted"
+      severity: error
+    T10:
+      description: "Disruptive optional attributes use default = null so Terraform omits them when unset"
+      severity: warning
+
+  security:
+    SEC01:
+      description: "Encryption enabled by default on all storage resources (S3, RDS, EBS, DynamoDB)"
+      severity: error
+      config:
+        resources: ["aws_s3_bucket", "aws_rds_cluster", "aws_rds_instance", "aws_ebs_volume", "aws_dynamodb_table"]
+    SEC02:
+      description: "Public access blocked by default (only enabled via explicit opt-in variable)"
+      severity: error
+    SEC03:
+      description: "IAM policies follow least privilege — no wildcard (*) actions or resources in defaults"
+      severity: error
+    SEC04:
+      description: "Security groups have no 0.0.0.0/0 ingress rules by default"
+      severity: error
+    SEC05:
+      description: "Logging/monitoring enabled by default (CloudWatch, access logs, flow logs)"
+      severity: warning
+    SEC06:
+      description: "Deletion protection enabled by default on stateful resources (RDS, DynamoDB, S3)"
+      severity: warning
+    SEC07:
+      description: "Backup/versioning enabled by default on data resources"
+      severity: warning
+
+# Terraform registry URLs for research when creating modules
+registries:
+  - name: "Terraform AWS Provider Docs"
+    url: "https://registry.terraform.io/providers/hashicorp/aws/latest/docs"
+    search_pattern: "site:registry.terraform.io/providers/hashicorp/aws"
+    use_for: "Resource arguments, attributes, usage examples"
+  - name: "Terraform AWS Modules (community)"
+    url: "https://registry.terraform.io/namespaces/terraform-aws-modules"
+    search_pattern: "site:registry.terraform.io/modules/terraform-aws-modules"
+    use_for: "Well-structured module patterns and composition"
+  - name: "AWS IA Modules (official)"
+    url: "https://registry.terraform.io/namespaces/aws-ia"
+    search_pattern: "site:registry.terraform.io/modules/aws-ia"
+    use_for: "AWS official reference architectures"
+  - name: "Terraform Azure Provider"
+    url: "https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs"
+    search_pattern: "site:registry.terraform.io/providers/hashicorp/azurerm"
+    use_for: "Azure resource definitions"
+  - name: "Terraform GCP Provider"
+    url: "https://registry.terraform.io/providers/hashicorp/google/latest/docs"
+    search_pattern: "site:registry.terraform.io/providers/hashicorp/google"
+    use_for: "GCP resource definitions"
+
+# Web search queries to use when building a module
+search_templates:
+  - "terraform {provider} {resource_type} module best practice"
+  - "terraform {resource_type} variables.tf example"
+  - "site:registry.terraform.io {resource_type}"
+
+# Default stackgen.yaml icon mappings (common AWS resources)
+icon_mapping:
+  s3: "aws-s3-bucket"
+  ec2: "aws-ec2-instance"
+  ecs: "aws-ecs"
+  rds: "aws-rds"
+  lambda: "aws-lambda-function"
+  dynamodb: "aws-dynamodb-table"
+  sqs: "aws-sqs-queue"
+  sns: "aws-sns-topic"
+  vpc: "aws-vpc"
+  alb: "aws-alb"
+  ecr: "aws-ecr"
+  cloudwatch: "aws-cloudwatch"
+  iam: "aws-iam"
+  elasticache: "aws-elasticache"
+  bedrock: "aws-bedrock"

--- a/stackgen/mcp.json
+++ b/stackgen/mcp.json
@@ -1,9 +1,51 @@
 {
   "mcpServers": {
     "stackgen": {
-      "url": "https://cloud.stackgen.com/api/mcp/sse",
-      "disabled": false,
-      "disabledTools": []
+      "command": "stackgen",
+      "args": [
+        "mcp"
+      ],
+      "env": {
+        "STACKGEN_URL": "https://cloud.stackgen.com",
+        "STACKGEN_TOKEN": ""
+      },
+      "autoApprove": [
+        "me",
+        "get_stackgen_projects",
+        "get_appstacks",
+        "create_appstack",
+        "get_supported_resource_types",
+        "get_resource_type_configurations",
+        "add_resource_to_appstack",
+        "bulk_add_resources_to_appstack",
+        "get_appstack_resources",
+        "get_resource_configurations",
+        "update_resource",
+        "delete_resource",
+        "get_possible_resource_connections",
+        "connect_resources",
+        "get_current_violations",
+        "scan_configuration",
+        "get_env_profiles",
+        "create_env_profile",
+        "update_env_profile",
+        "delete_env_profile",
+        "list-available-secrets",
+        "create_appstack_action_run",
+        "get_action_run",
+        "get_action_run_logs",
+        "destroy_deployment",
+        "detect-drift",
+        "create_snapshot",
+        "get_snapshots",
+        "restore_snapshot",
+        "list_template_appstacks",
+        "get_module_versions",
+        "create_appstack_tf_variables",
+        "get_appstack_tf_variables",
+        "list-git-configuration",
+        "push-appstack-to-git"
+      ]
     }
   }
 }

--- a/stackgen/scripts/aiden-workflow.sh
+++ b/stackgen/scripts/aiden-workflow.sh
@@ -1,0 +1,328 @@
+#!/usr/bin/env bash
+# =============================================================================
+# aiden-workflow.sh — Create a ServiceNow change_request via the Aiden 2.0
+#                     GUILD workflow (post-stackgen-servicenow-change-request).
+#
+# Called by the StackGen power AFTER a successful Apply. Never for a failed run.
+# All inputs are supplied as environment variables so that multi-line values
+# (plan_stdout, backout_plan, …) are passed without quoting/escaping problems.
+#
+# Required inputs (env vars):
+#   appStack        — appStack name           (e.g. chat-app-infra-1753990800)
+#   environment     — dev | staging | prod
+#   provider        — aws | azure | gcp
+#   region          — cloud region            (e.g. us-east-1)
+#   run_type        — Plan | Apply
+#   created changed replaced removed          — resource counts from the run
+#   plan_stdout     — full Terraform/OpenTofu plan or apply output
+#   cli_run_url     — URL to the StackGen action run
+#   correlation_id  — idempotency key = the StackGen action run ID
+#   justification   — reason for this change
+#
+# Optional inputs:
+#   executed_via    — saas-runner | local-cli  (how the Apply actually ran)
+#   backout_plan test_plan impact risk start_date end_date
+#
+# Required credentials (env vars):
+#   AIDEN_TOKEN     — StackGen PAT with GUILD access (stackgen_…)
+#   AIDEN_ORG_ID    — Aiden workspace/org UUID
+#   AIDEN_BASE_URL  — base URL of the Aiden API, e.g. https://ai.stackgen.com
+#   AIDEN_WORKFLOW  — GUILD workflow to invoke, e.g.
+#                     post-stackgen-servicenow-change-request
+#
+#                     Neither has a default. Together they name WHERE a
+#                     completed Apply gets reported, and a guess there fails
+#                     right after a successful Apply. Unset is reported as
+#                     NOT_CONFIGURED, which is a safe skip.
+#
+# Optional overrides:
+#   AIDEN_MAX_POLLS — default 30 (× 5 s = 150 s)
+#
+# Exit codes / stdout contract (single line, machine-readable):
+#   0   COMPLETED trace_id=<id> chg=<CHG…> correlation_id=<id>
+#   1   SN_ERROR <detail>            — network, auth, or Aiden failure
+#   2   NOT_CONFIGURED               — AIDEN_TOKEN / AIDEN_ORG_ID missing
+#   64  BAD_ARGS                     — a required input is missing
+#
+# No Python, no temp files, no jq — POSIX shell + curl + awk only.
+# =============================================================================
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Guard: credentials  (exit 2 is "not configured", NOT an error to retry)
+# ---------------------------------------------------------------------------
+AIDEN_TOKEN="${AIDEN_TOKEN:-}"
+AIDEN_ORG_ID="${AIDEN_ORG_ID:-}"
+AIDEN_BASE_URL="${AIDEN_BASE_URL:-}"
+AIDEN_WORKFLOW="${AIDEN_WORKFLOW:-}"
+
+if [[ -z "$AIDEN_TOKEN" || -z "$AIDEN_ORG_ID" || -z "$AIDEN_BASE_URL" || -z "$AIDEN_WORKFLOW" ]]; then
+  missing=""
+  [[ -z "$AIDEN_TOKEN"    ]] && missing="${missing}AIDEN_TOKEN "
+  [[ -z "$AIDEN_ORG_ID"   ]] && missing="${missing}AIDEN_ORG_ID "
+  [[ -z "$AIDEN_BASE_URL" ]] && missing="${missing}AIDEN_BASE_URL "
+  [[ -z "$AIDEN_WORKFLOW" ]] && missing="${missing}AIDEN_WORKFLOW"
+  cat >&2 <<EOF
+Missing: ${missing}
+Change records need Aiden 2.0 credentials, an explicit Aiden endpoint, and an
+explicit workflow name:
+
+  export AIDEN_TOKEN="stackgen_..."
+  export AIDEN_ORG_ID="<your-workspace-uuid>"
+  export AIDEN_BASE_URL="https://<your-aiden-host>"   # e.g. https://ai.stackgen.com
+  export AIDEN_WORKFLOW="post-stackgen-servicenow-change-request"
+
+Use the Aiden instance where AIDEN_WORKFLOW is published. Neither value has a
+default: both name where a completed Apply gets reported, and a guess there
+fails right after a successful Apply.
+EOF
+  echo "NOT_CONFIGURED"
+  exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# Required inputs
+# ---------------------------------------------------------------------------
+_missing=()
+for _var in appStack environment provider region run_type \
+            created changed replaced removed \
+            plan_stdout cli_run_url correlation_id justification; do
+  [[ -z "${!_var:-}" ]] && _missing+=("$_var")
+done
+
+if (( ${#_missing[@]} > 0 )); then
+  echo "Missing required inputs: ${_missing[*]}" >&2
+  echo "BAD_ARGS"
+  exit 64
+fi
+
+# ---------------------------------------------------------------------------
+# Optional inputs with defaults
+# ---------------------------------------------------------------------------
+executed_via="${executed_via:-}"
+backout_plan="${backout_plan:-Revert to the previous Terraform state and re-run Apply from the prior appStack version.}"
+test_plan="${test_plan:-Post-apply policy scan reviewed. Service health checks validated after deploy.}"
+impact="${impact:-3}"
+risk="${risk:-Low}"
+start_date="${start_date:-}"
+end_date="${end_date:-}"
+
+AIDEN_BASE_URL="${AIDEN_BASE_URL%/}"   # tolerate a trailing slash
+AIDEN_MAX_POLLS="${AIDEN_MAX_POLLS:-30}"
+
+# ---------------------------------------------------------------------------
+# Cross-check the declared counts against the plan text itself.
+#
+# The counts are supplied by the caller, and a caller that reconstructs them
+# after the fact gets them wrong — an observed failure was changed=1 replaced=1
+# removed=1 against a plan that plainly said "0 changed, 0 destroyed". A record
+# carrying invented numbers is worse than no record: it looks like verified
+# audit data.
+#
+# Only `changed` is enforced. Terraform folds a replacement into both the add
+# and the destroy totals, so `created` and `removed` can legitimately differ
+# from the summary line depending on how the caller counts replacements —
+# failing on those would reject correct input. "N to change" has no such
+# ambiguity.
+# ---------------------------------------------------------------------------
+PLAN_CHANGED=$(printf '%s' "$plan_stdout" \
+  | grep -oE '(Plan: [0-9]+ to add, [0-9]+ to change|Resources: [0-9]+ added, [0-9]+ changed)' \
+  | head -1 | grep -oE '[0-9]+ (to change|changed)' | grep -oE '^[0-9]+' || true)
+
+if [[ -n "$PLAN_CHANGED" && "$PLAN_CHANGED" != "$changed" ]]; then
+  cat >&2 <<EOF
+Counts do not match the plan text.
+  changed was given as : ${changed}
+  the plan text says   : ${PLAN_CHANGED}
+Take the counts from the captured run output instead of restating them.
+EOF
+  echo "BAD_ARGS"
+  exit 64
+fi
+
+# ---------------------------------------------------------------------------
+# Build the structured payload. One field per line so the workflow parser does
+# not depend on any particular JSON/YAML shape inside the LLM input.
+# ---------------------------------------------------------------------------
+EXECUTED_VIA_LINE=""
+[[ -n "$executed_via" ]] && EXECUTED_VIA_LINE="
+executed_via: ${executed_via}"
+
+OPTIONAL_DATES=""
+[[ -n "$start_date" ]] && OPTIONAL_DATES="${OPTIONAL_DATES}start_date: ${start_date}
+"
+[[ -n "$end_date"   ]] && OPTIONAL_DATES="${OPTIONAL_DATES}end_date: ${end_date}
+"
+
+PAYLOAD_TEXT="Create a ServiceNow change request for this StackGen infrastructure run.
+
+appStack: ${appStack}
+environment: ${environment}
+provider: ${provider}
+region: ${region}
+run_type: ${run_type}${EXECUTED_VIA_LINE}
+created: ${created}
+changed: ${changed}
+replaced: ${replaced}
+removed: ${removed}
+correlation_id: ${correlation_id}
+cli_run_url: ${cli_run_url}
+justification: ${justification}
+impact: ${impact}
+risk: ${risk}
+backout_plan: ${backout_plan}
+test_plan: ${test_plan}
+${OPTIONAL_DATES}
+plan_stdout:
+${plan_stdout}"
+
+# ---------------------------------------------------------------------------
+# JSON-encode the payload as a JSON string body (no surrounding quotes).
+# Pure awk: strips ANSI colour codes and any remaining control characters that
+# would make the JSON invalid, then escapes \, ", tab, CR and newline.
+# ---------------------------------------------------------------------------
+json_escape() {
+  awk '
+    BEGIN { ORS = ""; first = 1 }
+    {
+      line = $0
+      gsub(/\033\[[0-9;]*[A-Za-z]/, "", line)   # strip ANSI escape sequences
+      gsub(/\r/, "", line)                      # strip CR (CRLF input)
+      gsub(/\\/, "\\\\", line)                  # escape backslash first
+      gsub(/"/,  "\\\"", line)                  # escape double quote
+      gsub(/\t/, "\\t",  line)                  # escape tab
+      gsub(/[\001-\010\013\014\016-\037\177]/, "", line)  # drop other controls
+      if (first) { first = 0 } else { print "\\n" }
+      print line
+    }
+  '
+}
+
+JSON_INPUT=$(printf '%s' "$PAYLOAD_TEXT" | json_escape)
+
+# ---------------------------------------------------------------------------
+# Extract the change record number from an execution body.
+#
+# The body carries the whole agent trace, which can include EXAMPLE numbers from
+# the workflow's own prompt. Scanning it blindly and taking the first match can
+# return a placeholder, which is worse than returning nothing: a fake number
+# looks like a verifiable audit reference. So: prefer structured fields, and
+# fall back to a bare scan only when the body contains exactly one distinct
+# candidate. Prints nothing and returns 1 when there is no safe answer.
+# ---------------------------------------------------------------------------
+extract_chg() {
+  local body="$1" v cands n
+  # Ordered by how the real Aiden trace carries the number. Verified against
+  # live executions: the final answer appears as "answer":"CHG…", the agent
+  # part as "content":"CHG…", and the tool result as a sentence.
+  for pat in '"answer"[[:space:]]*:[[:space:]]*"CHG[0-9]+' \
+             '"output"[[:space:]]*:[[:space:]]*"CHG[0-9]+' \
+             '"content"[[:space:]]*:[[:space:]]*"CHG[0-9]+' \
+             'Created Change Request successfully: CHG[0-9]+' \
+             'number[\\"]*[[:space:]]*:[[:space:]]*[\\"]*CHG[0-9]+'; do
+    v=$(printf '%s' "$body" | grep -oE "$pat" | grep -oE 'CHG[0-9]+' | head -1 || true)
+    [[ -n "$v" ]] && { printf '%s' "$v"; return 0; }
+  done
+  # Fallback: every remaining candidate, minus the ones sitting inside a tool
+  # schema. The workflow's own JSON schema documents the field as
+  #   "change_number":{"description":"Change request number (e.g., \"CHG0012345\")"}
+  # so a naive scan can return that placeholder — a fake number that looks like
+  # a real audit reference. Drop anything whose context says description/e.g.
+  cands=$(printf '%s' "$body" | grep -oE '.{0,60}CHG[0-9]+' \
+          | grep -vi 'description' | grep -v 'e\.g\.' \
+          | grep -oE 'CHG[0-9]+' | sort -u || true)
+  n=$(printf '%s' "$cands" | grep -c 'CHG' || true)
+  if [[ "$n" == "1" ]]; then printf '%s' "$cands"; return 0; fi
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Step 1 — Invoke the workflow
+# ---------------------------------------------------------------------------
+INVOKE_URL="${AIDEN_BASE_URL}/guild/api/v1/workflows/${AIDEN_WORKFLOW}/run?orgId=${AIDEN_ORG_ID}"
+
+INVOKE_RESPONSE=$(curl -sS -w $'\n__HTTP_STATUS__%{http_code}' \
+  -X POST "${INVOKE_URL}" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer ${AIDEN_TOKEN}" \
+  --data-binary "{\"input\": \"${JSON_INPUT}\"}") || {
+    echo "SN_ERROR Aiden invoke request failed (network)"; exit 1; }
+
+HTTP_STATUS=$(printf '%s' "$INVOKE_RESPONSE" | sed -n 's/.*__HTTP_STATUS__\([0-9]*\).*/\1/p')
+INVOKE_BODY=$(printf  '%s' "$INVOKE_RESPONSE" | sed 's/__HTTP_STATUS__[0-9]*//')
+
+if [[ "$HTTP_STATUS" != "202" && "$HTTP_STATUS" != "200" ]]; then
+  echo "SN_ERROR Aiden invoke failed (HTTP ${HTTP_STATUS})" >&2
+  echo "SN_ERROR Aiden invoke failed (HTTP ${HTTP_STATUS})"
+  exit 1
+fi
+
+TRACE_ID=$(printf '%s' "$INVOKE_BODY" | grep -o '"trace_id":"[^"]*"' | head -1 | cut -d'"' -f4)
+
+if [[ -z "$TRACE_ID" ]]; then
+  echo "SN_ERROR no trace_id in Aiden response"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Step 2 — Poll until terminal (default max 150 s, every 5 s)
+# ---------------------------------------------------------------------------
+POLL_URL="${AIDEN_BASE_URL}/guild/api/v1/executions/${TRACE_ID}?orgId=${AIDEN_ORG_ID}"
+POLL_COUNT=0
+SETTLE_COUNT=0
+SETTLE_MAX="${AIDEN_SETTLE_POLLS:-12}"  # ~60s of grace after the turn completes
+STATUS=""
+
+while (( POLL_COUNT < AIDEN_MAX_POLLS )); do
+  sleep 5
+
+  POLL_RESPONSE=$(curl -sS -w $'\n__HTTP_STATUS__%{http_code}' \
+    "${POLL_URL}" -H "Authorization: Bearer ${AIDEN_TOKEN}") || {
+      echo "SN_ERROR poll request failed (network) trace_id=${TRACE_ID}"; exit 1; }
+
+  POLL_HTTP=$(printf '%s' "$POLL_RESPONSE" | sed -n 's/.*__HTTP_STATUS__\([0-9]*\).*/\1/p')
+  POLL_BODY=$(printf '%s' "$POLL_RESPONSE" | sed 's/__HTTP_STATUS__[0-9]*//')
+
+  if [[ "$POLL_HTTP" != "200" ]]; then
+    echo "SN_ERROR poll failed (HTTP ${POLL_HTTP}) trace_id=${TRACE_ID}"
+    exit 1
+  fi
+
+  # NOTE: do NOT trust `grep '"status"' | head -1` as the execution status. In a
+  # large trace the first match belongs to an early ACTIVITY, not to the run —
+  # so a still-running execution reads as "completed". That is why big payloads
+  # reported chg=unknown while small ones worked: more activities, more chance
+  # an early completed one appears first. Success is defined by having the
+  # number, not by a status string.
+
+  CHG_NUMBER=$(extract_chg "$POLL_BODY" || true)
+  if [[ -n "$CHG_NUMBER" ]]; then
+    echo "COMPLETED trace_id=${TRACE_ID} chg=${CHG_NUMBER} correlation_id=${correlation_id}"
+    exit 0
+  fi
+
+  # Only a terminal failure is read from status, and only when it is the sole
+  # value present — an activity that failed inside a run that recovers is not
+  # a workflow failure.
+  if printf '%s' "$POLL_BODY" | grep -oE '"status"[[:space:]]*:[[:space:]]*"(error|failed)"' >/dev/null 2>&1 \
+     && ! printf '%s' "$POLL_BODY" | grep -oE '"status"[[:space:]]*:[[:space:]]*"(running|pending|accepted)"' >/dev/null 2>&1; then
+    SUMMARY_MSG=$(printf '%s' "$POLL_BODY" | grep -o '"summary":"[^"]*"' | head -1 | cut -d'"' -f4 || true)
+    echo "SN_ERROR Aiden workflow failed trace_id=${TRACE_ID} summary=${SUMMARY_MSG}"
+    exit 1
+  fi
+
+  # Looks finished but the number has not landed yet — keep waiting, bounded.
+  if printf '%s' "$POLL_BODY" | grep -q '"chat_turn_completed"'; then
+    SETTLE_COUNT=$((SETTLE_COUNT + 1))
+    if (( SETTLE_COUNT >= SETTLE_MAX )); then
+      echo "COMPLETED trace_id=${TRACE_ID} chg=unknown correlation_id=${correlation_id}"
+      exit 0
+    fi
+  fi
+
+  POLL_COUNT=$((POLL_COUNT + 1))
+done
+
+echo "SN_ERROR timed out after $((AIDEN_MAX_POLLS * 5))s trace_id=${TRACE_ID} last_status=${STATUS}"
+exit 1

--- a/stackgen/scripts/check-change-record-setup.sh
+++ b/stackgen/scripts/check-change-record-setup.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# =============================================================================
+# check-change-record-setup.sh — Is the ServiceNow change record step usable?
+#
+# The change record is OPTIONAL. Exit 1 here does NOT block a deploy — it only
+# means no CHG record will be created for this run.
+#
+# Exit 0 → READY        (AIDEN_TOKEN + AIDEN_ORG_ID present)
+# Exit 1 → NOT_CONFIGURED
+# =============================================================================
+
+echo "StackGen power — ServiceNow change record configuration"
+echo ""
+
+ok=1
+
+check() {
+  local var="$1" hint="$2"
+  if [[ -n "${!var:-}" ]]; then
+    printf "  [ok]      %s\n" "$var"
+  else
+    printf "  [missing] %-16s  %s\n" "$var" "$hint"
+    ok=0
+  fi
+}
+
+check AIDEN_TOKEN    "StackGen PAT with GUILD access (stackgen_...)"
+check AIDEN_ORG_ID   "Aiden workspace UUID"
+check AIDEN_BASE_URL "base URL of the Aiden API — no default"
+check AIDEN_WORKFLOW "GUILD workflow name — no default"
+
+
+echo ""
+echo "Optional overrides:"
+for _var in AIDEN_MAX_POLLS; do
+  if [[ -n "${!_var:-}" ]]; then
+    printf "  [set]     %-16s  %s\n" "$_var" "${!_var}"
+  else
+    printf "  [default] %s\n" "$_var"
+  fi
+done
+
+echo ""
+if (( ok )); then
+  echo "READY — successful Apply runs will produce a ServiceNow CHG record."
+  exit 0
+else
+  cat <<'EOF'
+NOT_CONFIGURED — deploys still work, but no CHG record will be created.
+
+  export AIDEN_TOKEN="stackgen_..."
+  export AIDEN_ORG_ID="<your-workspace-uuid>"
+  export AIDEN_BASE_URL="https://<your-aiden-host>"   # e.g. https://ai.stackgen.com
+  export AIDEN_WORKFLOW="post-stackgen-servicenow-change-request"
+EOF
+  exit 1
+fi

--- a/stackgen/steering/change-record.md
+++ b/stackgen/steering/change-record.md
@@ -1,0 +1,170 @@
+# Change Record — ServiceNow CHG via Aiden 2.0
+
+Optional post-Apply step. A successful Apply produces an auditable ServiceNow
+change request carrying the full plan diff, so a reviewer can see exactly what
+happened and against which run.
+
+**This step never blocks a deploy.** If credentials are missing, say so in one
+line and finish normally. The deploy succeeded; only the record is missing.
+
+## When to run it
+
+| Situation | Action |
+|---|---|
+| Apply completed, health check passed | Run it |
+| Plan completed, no Apply yet | Skip — no infrastructure changed |
+| Apply failed, or health check failed | Skip — never record a failed run |
+| Any of the four required variables unset | Skip — report "no CHG record created" |
+| User says "no change record" / "skip ServiceNow" | Skip |
+
+## Locating the script
+
+The relative path depends on which folder is open in Kiro — the repo root and an
+app subfolder are both valid workspaces. Resolve it first, never assume:
+
+```bash
+SG_SCRIPT=""
+for p in powers/stackgen/scripts/aiden-workflow.sh \
+         ../powers/stackgen/scripts/aiden-workflow.sh \
+         ../../powers/stackgen/scripts/aiden-workflow.sh \
+         ../../../powers/stackgen/scripts/aiden-workflow.sh; do
+  [ -f "$p" ] && { SG_SCRIPT="$p"; break; }
+done
+[ -z "$SG_SCRIPT" ] && SG_SCRIPT=$(find "$HOME/.kiro/powers" -maxdepth 4 -name aiden-workflow.sh 2>/dev/null | head -1)
+```
+
+No bare globs: on zsh an unmatched glob aborts the whole command.
+
+If nothing is found, skip the change record and say so in one line. NEVER
+recreate the script inline and NEVER call the Aiden API directly instead.
+
+## Credentials
+
+| Variable | Required | Notes |
+|---|---|---|
+| `AIDEN_TOKEN` | yes | StackGen PAT with GUILD access (`stackgen_…`) |
+| `AIDEN_ORG_ID` | yes | Aiden workspace UUID |
+| `AIDEN_BASE_URL` | **yes** | Base URL of the Aiden API, e.g. `https://ai.stackgen.com`. Must be the Aiden instance where `AIDEN_WORKFLOW` is published. **No default on purpose** — a guessed endpoint fails right after a successful Apply. Unset is treated as `NOT_CONFIGURED`, which skips safely |
+| `AIDEN_WORKFLOW` | **yes** | The GUILD workflow to invoke, e.g. `post-stackgen-servicenow-change-request`. **No default on purpose** — a workflow is published into a specific Aiden workspace, so a name that is correct in one is a 404 in another |
+| `AIDEN_MAX_POLLS` | no | Default `30` (× 5 s = 150 s) |
+
+Check silently before running:
+
+```bash
+bash "$(dirname "$SG_SCRIPT")/check-change-record-setup.sh"
+```
+
+Exit 1 → skip the step. Do not ask the user for tokens mid-deploy.
+
+## Gathering the inputs
+
+Everything comes from the Apply run — never invent a value.
+
+| Input | Source |
+|---|---|
+| `appStack` | The appStack name from `create_appstack` |
+| `environment` | The env profile name used for the run |
+| `provider` | `aws` (or `azure` / `gcp`) |
+| `region` | Region from the env profile |
+| `run_type` | `Apply` |
+| `created` `changed` `replaced` `removed` | Parsed from the captured run output — see the per-path table below |
+| `correlation_id` | The run ID — differs per path, see below. The idempotency key |
+| `cli_run_url` | The run URL — differs per path, see below |
+| `plan_stdout` | **The plan text captured at deploy-flow step 11.** Not fetched now: by this point the diff no longer exists anywhere |
+| `executed_via` | `saas-runner` or `local-cli` — how the Apply actually ran |
+| `justification` | The user's stated reason, or the deploy intent in one sentence |
+
+### Three inputs differ by execution path
+
+`POWER.md` offers the SaaS runner and the local CLI, and falls back from the
+first to the second after two failures — so both paths occur in practice.
+
+| Input | SaaS runner | Local CLI (`stackgen provision`) |
+|---|---|---|
+| `correlation_id` | the Apply `action_run_id` | the CLI Run ID (`sg-clirun-<uuid>`) |
+| `cli_run_url` | run URL from `get_action_run` | the CLI run URL |
+| counts source | `get_action_run_logs` (`apply_stdout`) | the captured stdout of the provision run |
+| `executed_via` | `saas-runner` | `local-cli` |
+
+`executed_via` is not bookkeeping. An Apply run by StackGen's governed runner
+and one run from a laptop with personal AWS credentials are different events to
+whoever reviews the record, so the record has to say which happened.
+
+The plan text itself is NOT in this table on purpose: capturing it is the same
+action on both paths, and a branch there is one more thing to get wrong.
+
+Optional: `backout_plan`, `test_plan`, `impact` (default `3`), `risk` (default
+`Low`), `start_date`, `end_date`.
+
+## Running it
+
+Single `execute_bash` call, env vars only — never positional args, because
+`plan_stdout` is multi-line. Requires bash: macOS and Linux natively, Windows
+via WSL or Git Bash.
+
+```bash
+appStack="<name>" environment="<env>" provider=aws region="<region>" \
+run_type=Apply \
+created=<N> changed=<N> replaced=<N> removed=<N> \
+correlation_id="<APPLY_RUN_ID>" \
+cli_run_url="<APPLY_RUN_URL>" \
+justification="<one sentence>" \
+plan_stdout="<PLAN_OUTPUT>" \
+bash "$SG_SCRIPT"
+```
+
+The script polls to completion itself (150 s default). Do not wrap it in your
+own retry loop.
+
+## Reading the output
+
+One line on stdout:
+
+| Output | Meaning | What to do |
+|---|---|---|
+| `COMPLETED trace_id=… chg=CHG0030002 correlation_id=…` | Record created | Show the **CHG number** to the user — this is the one ID that is always surfaced |
+| `COMPLETED … chg=unknown` | Workflow finished, number not parseable | Tell the user the record was created but the number could not be read; give them the Aiden execution link |
+| `NOT_CONFIGURED` | Aiden credentials missing | One line: "No CHG record created — Aiden credentials not configured." Stop. Do not retry |
+| `BAD_ARGS` | An input was empty | Fix the missing input from the run data and retry **once** |
+| `SN_ERROR …` | Aiden/ServiceNow rejected or timed out | Report it in one line with the trace ID. Do not retry blindly |
+
+Re-checking an execution later (e.g. the user asks for the CHG number of an
+earlier run):
+
+```bash
+curl -sS "${AIDEN_BASE_URL}/guild/api/v1/executions/<trace_id>?orgId=${AIDEN_ORG_ID}" \
+  -H "Authorization: Bearer ${AIDEN_TOKEN}"
+```
+
+`status` → `completed` (extract `CHG[0-9]*`) · `running`/`pending`/`accepted`
+(wait 5 s, max 3 retries) · `error`/`failed` (report `summary`, stop).
+
+Human-readable view: `${AIDEN_BASE_URL}/guild/executions/<trace_id>`.
+
+## Reporting to the user
+
+Append one line to the final deploy result — no extra message, no narration
+while the script runs:
+
+```
+Change record: CHG0030002
+```
+
+or, when skipped:
+
+```
+Change record: not created (Aiden credentials not configured)
+```
+
+## Never
+
+- Never create a change record for a failed Plan or a failed Apply.
+- Never invent `correlation_id`, `cli_run_url`, a CHG number, or resource counts.
+- Never rebuild the plan text with `terraform show`, `tofu show`, or the `.tfplan`
+  file. Those give current state, not the diff. If the plan output was not
+  captured at step 11, skip the record and say so.
+- Never call the ServiceNow API directly, and never use ServiceNow basic-auth
+  credentials (`SN_USER` / `SN_PASSWORD`) — Aiden is the only supported path.
+- Never modify or close an existing change record.
+- Never echo `AIDEN_TOKEN` or write it into a file in this repository.
+- Never let a change-record failure change the reported deploy outcome.

--- a/stackgen/steering/deploy-setup.md
+++ b/stackgen/steering/deploy-setup.md
@@ -1,0 +1,170 @@
+# Deploy Setup — Runner Config & Prerequisites
+
+All agent-driven. User only approves browser for SSO.
+
+## Cross-Platform Notes
+
+Commands in this file default to bash (macOS/Linux). On Windows, use these substitutions:
+
+| Unix Command | Windows (PowerShell) Equivalent |
+|---|---|
+| `grep '^token:' ~/.stackgen/config.yaml \| sed 's/^token: *//'` | `(Select-String -Pattern '^token: (.+)' "$env:USERPROFILE\.stackgen\config.yaml").Matches[0].Groups[1].Value.Trim()` |
+| `curl -s -H "Authorization: Bearer $TOKEN" "$URL"` | `Invoke-RestMethod -Uri $URL -Headers @{Authorization="Bearer $TOKEN"}` |
+| `curl -s -X POST -H "..." -d '...' "$URL"` | `Invoke-RestMethod -Method Post -Uri $URL -Headers @{...} -Body $json` |
+| `echo "$VAR" \| grep -o '"id":"[^"]*"' \| head -1 \| cut -d'"' -f4` | `($resp.id)` (PowerShell auto-parses JSON from Invoke-RestMethod) |
+| `aws sts get-caller-identity` | Same (AWS CLI is cross-platform) |
+| `~/.stackgen/config.yaml` | `$env:USERPROFILE\.stackgen\config.yaml` |
+
+**Shell requirement:** The bash blocks below require bash or a POSIX shell. On Windows, these run automatically via Git Bash (bundled with Git for Windows) or WSL. Kiro's execute_bash uses the system's configured shell.
+
+## Runner Configuration (before Plan)
+
+**The StackGen SaaS runner needs project-level environment config. If `GET /iac-gen/v1/environment-config?orgId={PID}` returns empty items, CREATE it first.**
+
+### 0. Create Environment Config (if doesn't exist)
+```bash
+RESPONSE=$(curl -s -H "Authorization: Bearer $TOKEN" "$STACKGEN_URL/iac-gen/v1/environment-config?orgId=$PROJECT_ID")
+# If items array is empty → create:
+CONFIG=$(curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  "$STACKGEN_URL/iac-gen/v1/environment-config?orgId=$PROJECT_ID" \
+  -d '{"name":"default","environmentTemplates":[{"name":"dev","color":"green"}]}')
+# Extract: CONFIG_ID and ENV_TEMPLATE_ID from response
+```
+
+### 1. AWS session
+```bash
+aws sts get-caller-identity || aws sso login
+```
+
+### 2. Integration config
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" "$STACKGEN_URL/api/vault/v1/integration/aws/config?orgId=$PROJECT_ID"
+```
+Returns: `roleArn`, `externalId`, `trustPolicy`
+
+### 3. IAM role (if not exists)
+
+**CRITICAL: Trust policy MUST have TWO statements — AssumeRole AND TagSession (separate statements, NOT combined)**
+
+```bash
+# Get integration config first
+INTEGRATION=$(curl -s -H "Authorization: Bearer $TOKEN" "$STACKGEN_URL/api/vault/v1/integration/aws/config?orgId=$PROJECT_ID")
+BASTION_ROLE=$(echo "$INTEGRATION" | grep -o '"roleArn":"[^"]*"' | cut -d'"' -f4)
+EXTERNAL_ID=$(echo "$INTEGRATION" | grep -o '"externalId":"[^"]*"' | cut -d'"' -f4)
+
+# Create role with CORRECT trust policy (both AssumeRole + TagSession)
+TRUST_POLICY='{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": { "AWS": "'$BASTION_ROLE'" },
+      "Action": "sts:AssumeRole",
+      "Condition": { "StringEquals": { "sts:ExternalId": "'$EXTERNAL_ID'" } }
+    },
+    {
+      "Effect": "Allow",
+      "Principal": { "AWS": "'$BASTION_ROLE'" },
+      "Action": "sts:TagSession"
+    }
+  ]
+}'
+
+aws iam get-role --role-name stackgen-aws-integration 2>/dev/null || \
+aws iam create-role --role-name stackgen-aws-integration --assume-role-policy-document "$TRUST_POLICY"
+
+# NOTE: AdministratorAccess is used here for demo/dev simplicity.
+# For production, scope down to only the permissions your infrastructure requires.
+# At minimum: EC2, ECS, ECR, RDS, S3, VPC, ELB, IAM (for service roles), CloudWatch, Route53.
+aws iam attach-role-policy --role-name stackgen-aws-integration --policy-arn arn:aws:iam::aws:policy/AdministratorAccess
+ROLE_ARN=$(aws iam get-role --role-name stackgen-aws-integration --query 'Role.Arn' --output text)
+```
+
+**If role already exists** → update trust policy: `aws iam update-assume-role-policy --role-name stackgen-aws-integration --policy-document "$TRUST_POLICY"`
+
+### 4. Vault secret
+```bash
+curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  "$STACKGEN_URL/api/vault/v1/secrets?orgId=$PROJECT_ID" \
+  -d '{"name":"aws-deploy-credentials","description":"AWS assume role","category":"Cloud","subcategory":"aws","value":[{"key":"auth_method","value":"assume_role"},{"key":"aws_role_arn","value":"'"$ROLE_ARN"'"}],"shareWithTenant":true}'
+```
+
+### 5. Env config + runner attach
+```bash
+# Get config ID
+CONFIG_ID=$(curl -s -H "Authorization: Bearer $TOKEN" "$STACKGEN_URL/iac-gen/v1/environment-config?orgId=$PROJECT_ID" \
+  | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+ENV_TEMPLATE_ID=$(curl -s -H "Authorization: Bearer $TOKEN" "$STACKGEN_URL/iac-gen/v1/environment-config?orgId=$PROJECT_ID" \
+  | grep -o '"environmentTemplates":\[{"id":"[^"]*"' | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+
+# Attach secret
+curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  "$STACKGEN_URL/iac-gen/v1/environment-config/$CONFIG_ID/runner/secrets?orgId=$PROJECT_ID" \
+  -d '[{"provider":"aws","values":[{"environmentTemplateId":"'"$ENV_TEMPLATE_ID"'","value":"'"$SECRET_ID"'"}]}]'
+
+# Add region
+curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  "$STACKGEN_URL/iac-gen/v1/environment-config/$CONFIG_ID/runner/variables?orgId=$PROJECT_ID" \
+  -d '[{"key":"AWS_DEFAULT_REGION","values":[{"environmentTemplateId":"'"$ENV_TEMPLATE_ID"'","value":"us-east-1"}]}]'
+```
+
+### 6. State bucket
+```bash
+BUCKET="<appstack-name>-state"
+aws s3api head-bucket --bucket "$BUCKET" 2>/dev/null || {
+  aws s3api create-bucket --bucket "$BUCKET" --region us-east-1
+  aws s3api put-bucket-versioning --bucket "$BUCKET" --versioning-configuration Status=Enabled
+}
+```
+
+### 7. State backend (MCP)
+```
+update_env_profile: profile_name="dev"
+  variables: {"region":"us-east-1","AWS_DEFAULT_REGION":"us-east-1"}
+  state_backend_raw_hcl: terraform { backend "s3" { bucket="<bucket>" key="<appstack>/terraform.tfstate" region="us-east-1" encrypt=true } }
+```
+
+## CLI Fallback: stackgen provision
+
+If SaaS runner fails 2+ times (credential/signing errors), use local CLI:
+```bash
+# MUST set project context first
+stackgen login --url="{STACKGEN_URL}" --project="<PROJECT_ID>"
+# Then provision (uses local AWS creds)
+stackgen provision --appstack <APPSTACK_ID> -e dev
+# For apply:
+stackgen provision --appstack <APPSTACK_ID> -e dev --apply
+```
+
+## GitHub Module Access (if Plan fails: module not found)
+
+Custom modules from private repos need a GitHub PAT as runner secret.
+
+Ask user with clear explanation:
+> **GitHub token needed for deployment.** StackGen's cloud runner pulls your Terraform modules from GitHub during Plan/Apply. Without a token, it can't access private module repositories and the plan will fail with "module not found".
+>
+> Please create a GitHub Personal Access Token:
+> 1. Go to [https://github.com/settings/tokens?type=beta](https://github.com/settings/tokens?type=beta)
+> 2. Click **"Generate new token"**
+> 3. Name it something like "stackgen-runner"
+> 4. Under **Repository access**, select "All repositories" (or specific repos containing your Terraform modules)
+> 5. Under **Permissions → Repository permissions**, grant **Contents: Read-only**
+> 6. Click **Generate token** and paste it here
+>
+> This token is stored securely in StackGen's vault and only used by the runner during Plan/Apply.
+
+Then:
+1. Vault secret: `{"name":"github-modules","category":"SCM","subcategory":"github","value":[{"key":"token","value":"<PAT>"}],"shareWithTenant":true}`
+2. Attach: `[{"provider":"github","values":[{"environmentTemplateId":"<id>","value":"<secret_id>"}]}]`
+3. Retry Plan
+
+## UI Deep Links
+
+| Page | URL |
+|---|---|
+| AppStack | `{URL}/project/{name}/appstacks/{id}` |
+| Secret Store | `{URL}/project/{name}/secret-store` |
+| Env Config | `{URL}/project/{name}/project-settings?tab=environment-configuration` |
+| Runner Secrets | `{URL}/project/{name}/project-settings?tab=environment-configuration&env-tab=secrets` |
+| CLI Runs | `{URL}/project/{name}/cli-runs` |
+| PAT Tokens | `{URL}/enterprise/account-settings/pat` |

--- a/stackgen/steering/intent-to-deploy.md
+++ b/stackgen/steering/intent-to-deploy.md
@@ -1,0 +1,102 @@
+# Intent to Deploy — End-to-End Flow
+
+User sees MAX 4 messages: (1) setup confirm, (2) plan summary, (3) approval, (4) final result.
+
+## Cross-Platform Awareness
+
+Before executing ANY command in this flow, check the user's OS from the Kiro system prompt (`Operating System`, `Platform`, `Shell` fields). Apply the correct variant:
+
+| Operation | macOS | Linux | Windows |
+|---|---|---|---|
+| Install stackgen | `brew install stackgenhq/stackgen/stackgen` | Prefer `brew install`; or `download-stackgen.sh <version> <arch>` (no `latest`) | WSL/Docker, or versioned `.exe` zip from docs/releases |
+| Check command exists | `command -v stackgen` | `command -v stackgen` | `Get-Command stackgen -EA 0` |
+| Read config file | `grep '^token:' ~/.stackgen/config.yaml` | Same | `Select-String '^token:' "$env:USERPROFILE\.stackgen\config.yaml"` |
+| sed in-place | `sed -i '' 's/…/…/'` | `sed -i 's/…/…/'` | `(Get-Content file) -replace '…','…' \| Set-Content file` |
+| Unix timestamp | `date +%s` | `date +%s` | `[DateTimeOffset]::Now.ToUnixTimeSeconds()` |
+| Heredoc + curl | `bash << 'SCRIPT' ... curl -d @- << 'JSON'` | Same | PowerShell here-string: `$body = @'…'@; Invoke-RestMethod …` |
+| Cleanup temp files | `rm -rf /tmp/env_config*` | Same | `Remove-Item "$env:TEMP\env_config*" -Recurse -Force` |
+
+## Step 1: Understand App
+Read Dockerfile + package.json. Map: Dockerfile → ECS+ECR, pg/prisma → RDS, HTTP → ALB, Lambda → Lambda+FunctionURL.
+
+## Step 2: Auth
+1. `stackgen version` → upgrade if needed (use OS-appropriate install method)
+2. MCP `me` → if works, skip to Step 3
+3. If fails: `stackgen login --url="{STACKGEN_URL}"` (NO timeout) → create PAT → set in `~/.kiro/settings/mcp.json` (or `$env:USERPROFILE\.kiro\settings\mcp.json` on Windows) → wait 5s → retry
+4. `aws sts get-caller-identity` → if no creds: `aws sso login`
+5. **Do NOT proceed until MCP + AWS both confirmed**
+
+## Step 3: Confirm
+> Ready to deploy. Project **X**, region **us-east-1**, env **dev**. Say "go".
+
+## Step 4: Create AppStack
+`create_appstack: name="<app>-infra-<timestamp>", cloud_provider="aws", project_name="<project>"`
+
+## Step 5: Create Custom Modules (bash+curl, parallel)
+See `module-authoring` steering. All modules created in one `execute_bash` with `&` + `wait`.
+On Windows without WSL/Git Bash, use sequential PowerShell with `Invoke-RestMethod` instead of heredocs.
+If 403 on publish → catalog fallback within 5s.
+
+## Step 6: Add + Configure Resources
+```
+get_supported_resource_types → get template IDs
+bulk_add_resources_to_appstack → all in ONE call
+update_resource × N → configure silently
+get_possible_resource_connections → if empty, skip
+```
+
+## Step 7: Deploy Prerequisites (silent)
+1. `create_env_profile` + `update_env_profile` (state backend + variables)
+2. `list-available-secrets` → find/create AWS secret
+3. Attach secret + region to runner (API)
+4. Create state bucket
+
+## Step 8: Plan
+`create_appstack_action_run: action_type="Plan"` — save the run ID from response.
+
+**Polling (same as UI — every 5s):**
+After triggering Plan/Apply, poll `get_action_run` every 5 seconds until terminal state:
+```
+Loop:
+  sleep 5s
+  get_action_run(action_run_id=<id>, project_name=<project>)
+  Check status field:
+    "pending" or "running" → continue polling
+    "completed" → SUCCESS — stop polling
+    "failed" → FAILED — call get_action_run_logs to get error
+    "cancelled" → CANCELLED — stop polling
+```
+- Never poll more frequently than 5s
+- On "failed": `get_action_run_logs(action_run_id, log_type="plan_stderr")` or `"init_stderr"`
+- Fix once, retry once. MCP 400 → API fallback with `{"operationType":"Plan"}`
+
+## Step 9: Plan Summary (to user)
+> **Plan ready.** Will create: Network, Container service, Load balancer, Database. **Apply?**
+
+## Step 10: Apply
+`create_appstack_action_run: action_type="Apply"` — pass planRunId if via API.
+
+## Step 11: Health Check (before telling user)
+Wait 60s → `aws ecs describe-services` → `runningCount > 0`.
+If 0: check events. Common: CannotPullContainer (no route), Essential container exited (bad env vars).
+Fix via StackGen only.
+
+## Step 11b: Change Record (optional)
+Only if the health check passed. Resolve the script path first (workspace may be the
+repo root or an app subfolder), then check setup silently:
+resolve `SG_SCRIPT` with the glob-free loop in the `change-record` steering (zsh aborts on unmatched globs).
+Not found, or `check-change-record-setup.sh` exits 1 → skip, no message mid-flow.
+If READY: run `"$SG_SCRIPT"` with the Apply run data (`correlation_id` = Apply run ID,
+`plan_stdout` = plan log). See `change-record` steering.
+Never blocks: any failure here → deploy still reported as successful.
+
+## Step 12: Result
+> **Done!** App live at: `http://<alb-dns>` | [View topology]({url})
+> Change record: `CHG0030002`   ← only if created; omit the line if skipped
+
+## Step 13: Docker (if needed)
+Build → `ecr get-login-password` → push → `ecs update-service --force-new-deployment` → wait healthy.
+
+## Step 14: Cleanup
+- macOS/Linux: `rm -rf /tmp/env_config* ./{uuid-dirs}/`
+- Windows: `Remove-Item "$env:TEMP\env_config*" -Recurse -Force -EA 0; Get-ChildItem -Directory | Where-Object { $_.Name -match '^[0-9a-f]{8}-' } | Remove-Item -Recurse -Force`

--- a/stackgen/steering/module-authoring.md
+++ b/stackgen/steering/module-authoring.md
@@ -1,0 +1,153 @@
+# Module Authoring — Custom Modules at AppStack Scope
+
+## When to Create
+
+Always. Default path — create appstack-scoped custom modules. Fall back to catalog only if user requests or publish returns 403.
+
+## Philosophy
+
+1. **Hide complexity, expose intent.** 3-8 variables max.
+2. **Bake best practices inside.** Encryption, IAM, tagging hardcoded — not exposed.
+3. **Side panel friendly.** >15 variables = too complex.
+4. **Plan all upfront.** Decide all modules BEFORE creating any. Then parallel.
+
+## Quality Rules
+
+From `config/module-rules.yaml`:
+- **V01–V09:** Variables (types, descriptions, sensitivity, count, naming)
+- **O01–O03:** Outputs (descriptions, sensitive, connectable)
+- **S01–S08:** stackgen.yaml (representation, variable_groups, connections)
+- **T01–T10:** Structure (no providers, for_each>count, tags, formatting)
+- **SEC01–SEC07:** Security (encryption default, no public access, least privilege)
+- **X01–X04:** Cross-cutting (abstraction, no dead code)
+
+## Required Files
+
+`main.tf`, `variables.tf`, `outputs.tf`, `.stackgen/stackgen.yaml`
+
+## Creation Flow (single execute_bash, no file writes)
+
+**Problem:** HCL has `${...}` which zsh expands. `jq --arg` mishandles `\n` as literal chars. File writes need approvals.
+
+**Solution:** `curl -d @- << 'JSON'` — pipe pre-formatted JSON body directly into curl via heredoc. No jq, no variables, no escaping issues. Single-quoted heredoc delimiter prevents all shell expansion.
+
+**Cross-platform note:** This heredoc pattern requires bash (available on macOS and Linux natively). On Windows, Kiro executes commands via the system shell. If the user is on Windows:
+- **Git Bash** (bundled with Git for Windows): heredocs work as-is
+- **WSL**: heredocs work as-is
+- **PowerShell fallback**: Use `Invoke-RestMethod` with splatting instead of curl heredocs. The JSON body should be stored in a PowerShell variable and passed with `-Body`
+
+The agent MUST detect the user's OS (from the Kiro system prompt `Operating System` field) and use the appropriate shell syntax. On Windows without WSL/Git Bash, convert the curl heredoc pattern to:
+```powershell
+$body = @'
+{"files":{"main.tf":"...","variables.tf":"...","outputs.tf":"...",".stackgen/stackgen.yaml":"..."}}
+'@
+Invoke-RestMethod -Method Put -Uri "$URL/tf-module/v1/modules/$MOD_ID/files" -Headers @{Authorization="Bearer $TOKEN";"Content-Type"="application/json"} -Body $body
+```
+
+```bash
+bash << 'SCRIPT'
+TOKEN=$(grep '^token:' ~/.stackgen/config.yaml | sed 's/^token: *//')
+URL="https://cloud.stackgen.com"
+APPSTACK_ID="<uuid>"
+PID="<project-id>"
+
+# Step 1: Create module (~1s)
+MOD_ID=$(curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  "$URL/tf-module/v1/modules" \
+  -d "{\"name\":\"<name>\",\"cloudProvider\":\"aws\",\"resourceType\":\"<type>\"}" \
+  | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+
+# Step 2: Upload files via stdin heredoc (~1s) — NO jq needed
+curl -s -o /dev/null -X PUT -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  "$URL/tf-module/v1/modules/$MOD_ID/files" \
+  -d @- << 'JSON'
+{"files":{"main.tf":"resource \"aws_vpc\" \"main\" {\n  cidr_block = var.cidr\n  tags = { Name = \"${var.name}-vpc\" }\n}","variables.tf":"variable \"name\" {\n  type = string\n}","outputs.tf":"output \"vpc_id\" {\n  value = aws_vpc.main.id\n}",".stackgen/stackgen.yaml":"version: \"1.0\"\nrepresentation:\n  icon: aws-vpc"}}
+JSON
+
+# Step 3: Publish (~1s)
+curl -s -o /dev/null -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  "$URL/tf-module/v1/modules/$MOD_ID/publish?overwriteVersion=true&orgId=$PID" \
+  -d '{"version":"0.0.1","scope":{"type":"appstack","appstackId":"'"$APPSTACK_ID"'"}}'
+
+echo "DONE:$MOD_ID"
+SCRIPT
+```
+
+**Rules:**
+- `curl -d @- << 'JSON'` — body is the heredoc itself, piped to stdin. Zero overhead.
+- In the JSON heredoc: `\n` = literal two chars (what JSON wants for newlines). `\"` = escaped quote.
+- Single-quoted delimiter `'JSON'` prevents bash from touching `${var.name}` inside.
+- **Total time per module: ~3s** (create 1s + upload 1s + publish 1s). If slower → something is wrong.
+- For multiple modules: repeat the 3-step block for each module within the same `bash << 'SCRIPT'`.
+- **NO jq, NO printf, NO intermediate variables for file content.**
+
+## API Reference
+
+| Step | Method | Path | Body |
+|---|---|---|---|
+| Create | POST | `/tf-module/v1/modules` | `{"name":"..","cloudProvider":"aws","resourceType":".."}` |
+| Upload | PUT | `/tf-module/v1/modules/{id}/files` | `{"files":{"main.tf":"..","variables.tf":"..","outputs.tf":"..",".stackgen/stackgen.yaml":".."}}` |
+| Publish | POST | `/tf-module/v1/modules/{id}/publish?overwriteVersion=true&orgId={PID}` | `{"version":"0.0.1","scope":{"type":"appstack","appstackId":"<id>"}}` |
+
+- Files body is MAP (not array). All 4 required. Non-empty content.
+- `scope.type` = `"appstack"` (lowercase). `overwriteVersion=true` for re-publish.
+- After publish: `get_supported_resource_types` (retry 3x, 500ms) → get `templateId` → `bulk_add_resources_to_appstack`
+
+## stackgen.yaml Template
+
+```yaml
+version: "1.0"
+representation:
+  description: "Brief description"
+  icon: aws-<resource>
+  side_panel:
+    label: Human Name
+    icon: aws-<resource>
+  node:
+    label:
+      static: Default Label
+      template: Label - ${name}
+    label_attribute: name
+variables:
+  name:
+    label: Name
+    type: string
+    validation:
+      required: true
+variable_groups:
+  - label: Basic
+    variables: [name]
+```
+
+## Self-Contained Module Rule
+
+Each module includes ALL its resources internally:
+- **VPC:** VPC + subnets + IGW + NAT + route tables + associations + routes
+- **ECS:** cluster + task def + service + ALB + target group + listener + SGs + IAM roles
+- **RDS:** DB instance + subnet group + security group
+
+Cross-module deps → accept as variable. Never dynamic `count` from module refs.
+
+## Troubleshooting
+
+| Error | Fix |
+|---|---|
+| 403 on publish | Catalog fallback immediately (<5s) |
+| Files 400 | MAP format `{"files":{"main.tf":"..."}}` not array |
+| Not in catalog after publish | `get_supported_resource_types` retry 3x/500ms |
+| 409 name conflict | Append timestamp |
+| resourceType empty | Ensure name is valid terraform slug |
+
+## Pre-Module Validation
+
+Before writing HCL:
+- **RDS versions:** `aws rds describe-db-engine-versions --engine postgres` — never guess
+- **Instance types:** confirm exists in target region
+- **CIDR:** don't overlap existing VPCs
+- **SG rules:** ALB allows 80/443 in. ECS allows from ALB SG only.
+- **Routes:** Public RT → IGW. Private RT → NAT.
+
+## Registries (research)
+
+Use web search: `terraform {provider} {resource_type} module best practice`
+URLs in `config/module-rules.yaml` → `registries` section.


### PR DESCRIPTION
## Summary

- Switch the stackgen MCP server from the hosted HTTPS SSE endpoint to the local `stackgen` CLI over stdio, and update the README MCP line to match
- Expand `POWER.md` with the deploy flow, pre-flight validation, failure-recovery guidance, and an optional post-Apply ServiceNow change record; bump the power to 1.1.0
- Add steering docs (`intent-to-deploy`, `deploy-setup`, `module-authoring`, `change-record`), module/app-code authoring config, and the Aiden change-record helper scripts

## Why

The hosted SSE endpoint doesn't expose the full tool set the deploy workflow depends on, and PAT-based auth is handled cleanly by the CLI. Moving to `stackgen mcp` over stdio makes the documented Plan/Apply flow actually reachable, and the new steering files keep that guidance out of the always-loaded `POWER.md` context.

## Changes

| File | Change |
|---|---|
| `stackgen/mcp.json` | HTTPS SSE -> local CLI stdio with `STACKGEN_URL` / `STACKGEN_TOKEN`, plus `autoApprove` for read and deploy tools |
| `stackgen/POWER.md` | Deploy flow, hard rules, pre-flight checks, API reference, troubleshooting; version 1.1.0 |
| `stackgen/steering/*.md` | New: deploy setup, intent-to-deploy, module authoring, change record |
| `stackgen/config/*` | Module and app-code authoring rules |
| `stackgen/scripts/*.sh` | Aiden workflow + change-record setup check |
| `README.md` | stackgen MCP entry now reads `CLI stdio` |

The change-record integration is entirely optional and never blocks a deploy: if the Aiden environment variables are unset, the step is skipped and the deploy result is unchanged.

## Test plan

- [x] Install the power locally and confirm the MCP server connects via `stackgen mcp`
- [x] Confirm activation keywords load the power and that steering files load only when needed
- [x] Run an end-to-end appstack create -> Plan -> Apply and verify the documented flow matches behavior
- [x] Run `stackgen/scripts/check-change-record-setup.sh` and confirm both `READY` and `NOT_CONFIGURED` paths report correctly
- [x] Verify the README stackgen entry shows `CLI stdio`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
