### PR TITLE
[kiro-support] Add Kiro Support power (Agent Plugins format)

### DIFF
--- a/kiro-support/mcp.json
+++ b/kiro-support/mcp.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "awslabs.aws-support-mcp-server": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["awslabs.aws-support-mcp-server@latest"],
+      "env": {
+        "AWS_PROFILE": "<your-aws-profile>",
+        "AWS_REGION": "us-east-1",
+        "FASTMCP_LOG_LEVEL": "ERROR"
+      }
+    },
+    "aws-mcp": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "mcp-proxy-for-aws@latest",
+        "https://aws-mcp.us-east-1.api.aws/mcp",
+        "--metadata",
+        "AWS_REGION=us-east-1",
+        "--disable-telemetry"
+      ],
+      "env": {
+        "AWS_PROFILE": "<your-aws-profile>"
+      }
+    }
+  }
+}

--- a/kiro-support/plugin.json
+++ b/kiro-support/plugin.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "kiro-support",
+  "version": "1.0.0",
+  "description": "File and manage AWS Support cases for Kiro issues directly from the IDE. Collects diagnostics and verifies Support API access first — with a ready-to-send admin request when permissions are missing.",
+  "author": {
+    "name": "Kiro AWS team"
+  },
+  "keywords": ["kiro support case", "aws support case", "create support case", "report kiro issue", "kiro diagnostics", "aws support api"],
+  "license": "Apache-2.0",
+  "repository": "https://github.com/kirodotdev/powers"
+}

--- a/kiro-support/plugin.json
+++ b/kiro-support/plugin.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "kiro-support",
+  "displayName": "Kiro Support",
   "version": "1.0.0",
   "description": "File and manage AWS Support cases for Kiro issues directly from the IDE. Collects diagnostics and verifies Support API access first — with a ready-to-send admin request when permissions are missing.",
   "author": {

--- a/kiro-support/skills/kiro-support/SKILL.md
+++ b/kiro-support/skills/kiro-support/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: "kiro-support"
+description: "File and track AWS Support cases for Kiro issues without leaving the IDE. Use when creating, tracking, replying to, or resolving AWS Support cases, or when checking Support API access."
+license: "Apache-2.0"
+metadata:
+  author: "Kiro AWS team"
+  version: "1.0.0"
+---
+
+# Kiro Support Cases
+
+File and track AWS Support cases for Kiro without leaving the IDE. Two backends:
+[AWS Support MCP Server](https://awslabs.github.io/mcp/servers/aws-support-mcp-server) (primary) and
+[Agent Toolkit](https://aws.amazon.com/products/developer-tools/agent-toolkit-for-aws/) (`aws-mcp`, fallback).
+
+## On activation
+
+If intent is clear (e.g. "file a case for X"), go straight to the matching workflow.
+Otherwise reply with just this menu — no preamble, no capability tour:
+
+> What do you need?
+> 1. Raise a case  2. Track a case  3. Read history  4. Reply  5. Resolve  6. Check access / setup
+
+For "get started" / "check access" / "setup": run the read-only `describe_support_cases`
+probe and report the result in one line (e.g. "Access confirmed — no open cases. What next?").
+Do not explain what the power does, list its features, or show example code unless asked.
+
+## First-run onboarding
+
+Before the first case in a session, confirm the environment is ready — silently, in this order.
+Surface a step only if it fails; if all pass, continue to the task without narrating the checks.
+
+1. **`uvx` present** — the MCP server launches via `uvx`. If `uvx --version` fails, point to the
+   [install guide](https://docs.astral.sh/uv/getting-started/installation/).
+2. **`AWS_PROFILE` set** — confirm `mcp.json` has a real profile, not the `<your-aws-profile>`
+   placeholder. If it's still the placeholder, ask the user to set it and reconnect the server.
+3. **Access probe** — run `describe_support_cases` once. Success → proceed. `AccessDenied` or
+   `SubscriptionRequiredException` → [setup](references/setup.md). Server won't start → fall back to `aws-mcp`.
+
+## Available MCP servers
+
+Configured in [`mcp.json`](../../mcp.json). Both backends reach the same AWS Support API with the same
+IAM permissions (`support:*`) and require a Business+ support plan.
+
+**Primary — `awslabs.aws-support-mcp-server`** (typed tools; all arguments use `snake_case`):
+
+| Tool | Purpose |
+| --- | --- |
+| `describe_support_cases` | List/search cases — also the read-only access probe |
+| `describe_communications` | Full communication history for a case |
+| `add_communication_to_case` | Reply to a case (optional attachments) |
+| `create_support_case` | File a new case |
+| `resolve_support_case` | Close a case (reopenable within 7 days) |
+| `describe_services` | List services + category codes |
+| `describe_severity_levels` | List severity levels + SLAs |
+| `describe_create_case_options` | Valid categories/severities for a service |
+| `describe_supported_languages` | List supported languages |
+| `add_attachments_to_set` | Upload files → returns `attachmentSetId` |
+| `describe_attachment` | Download an attachment by ID |
+
+**Fallback — `aws-mcp`** (Agent Toolkit): runs `aws support …` CLI commands (kebab-case flags,
+`--region us-east-1`) when the primary server can't start. CLI equivalents for each tool above are
+in [filing-and-tracking-cases](references/filing-and-tracking-cases.md#toolkit-fallback-cli).
+
+## Output contract (applies to EVERY response)
+
+- **No narration.** Never write "Let me…", "Now I understand…", "Now I'll…". Just act, then report.
+- **No unsolicited overviews.** Don't explain what the power does, list capabilities, or show
+  example workflows/code unless the user asks. They activated it; they know what it's for.
+- **No multi-section essays.** No "1. What this does / 2. Setup / 3. Example" structures.
+- **No behind-the-scenes.** Don't narrate which tools run internally, IAM/plan requirements, or
+  fallback servers unless the user asks or something fails.
+- **Lead with the result.** Tool ran → one-line outcome → at most one short next-step question.
+- **Batch questions.** All missing info in one message. Never drip questions across turns.
+- **Skip what you know.** OS is in system context. Don't re-ask for anything already provided.
+- **Confirm once.** Show the case body a single time for approval, then file. No recaps after.
+
+### Formatting
+
+Brevity and polish aren't opposites — format for scannability, not length.
+
+- **Bold the lead.** Start with the outcome in bold (e.g. **Access confirmed**), then a short clause.
+- **Bullets for capabilities.** When listing what the power does, use a tight bulleted list with
+  the verb bolded (**Raise**, **Track**, …) — one line each, no sentences.
+- **Inline code for examples.** Put example prompts and identifiers in backticks
+  (`file a normal case: Kiro chat keeps disconnecting on macOS`), not fenced code blocks.
+- **Label the closer.** End with a bolded lead-in for the next step (e.g. **Next up:** …).
+- **No headers, no tables, no emojis** in chat replies — they add height without adding signal.
+- Keep the whole thing scannable in one glance: bold anchors, short lines, ≤10 lines total.
+
+### When asked for an overview / walkthrough / example (e.g. the install "try it out" prompt)
+
+Comply, but stay bounded — a request for an overview is not license for an essay:
+
+- **Overview:** one short sentence, or one line per capability. No section headers.
+- **Setup/verify:** run `describe_support_cases`, report the one-line result. Don't recount the
+  guide's steps or explain what you're about to do.
+- **Example:** one sentence describing the most common flow (filing a case). No code block, no
+  step-by-step internals, unless the user asks.
+- **Total:** aim for ≤10 lines. End with one next-step question.
+
+<example>
+<scenario>User: "help me get started"</scenario>
+<bad>A three-part essay: what the power does, a walkthrough of the setup guide, a code
+example, and a menu of six next steps.</bad>
+<good>[runs describe_support_cases] "Access confirmed — no open cases yet. Want to file one,
+or check something else?"</good>
+</example>
+
+<example>
+<scenario>Overview + example, formatted for scannability (still ≤10 lines).</scenario>
+<good>
+**Access confirmed** — no open cases, you're set up.
+
+**kiro-support** files and tracks AWS Support cases without leaving Kiro:
+
+- **Raise** a new case
+- **Track** case status
+- **Read** a case's history
+- **Reply** to support
+- **Resolve** a case
+
+**Typical flow:** tell me an issue — e.g. `file a normal case: Kiro chat keeps disconnecting on
+macOS` — and I'll draft it, show you the body once for approval, then file on your OK.
+
+**Next up:** file one, or check something else?
+</good>
+</example>
+
+<example>
+<scenario>Prompt asks for a brief overview + step-by-step setup + a simple example.</scenario>
+<bad>Runs the probe, then writes "1. What this power does" (capability list), "2. Setup status"
+(recaps the guide + IAM/plan notes), "3. A simple example" (code block + behind-the-scenes
+tool sequence), then a six-option menu.</bad>
+<good>[runs describe_support_cases] "Access confirmed — no open cases, you're set up.
+This power files and tracks AWS Support cases from Kiro: raise, track, reply to, or resolve
+cases. Typical use: tell me an issue like 'file a normal case: Kiro chat keeps disconnecting on
+macOS' and I'll draft it, show you the body, and file on your OK. Want to try one?"</good>
+</example>
+
+## Steering guides — MUST read before acting
+
+These files contain the detailed workflows, templates, and procedures for this skill. They are
+located in the `references/` directory alongside this SKILL.md file.
+
+**You MUST use `read_file` to load the matching file from this skill's `references/` directory
+BEFORE executing any intent.** The files are located at:
+`skills/kiro-support/references/<filename>` relative to the power root.
+
+Do not attempt to file, track, reply, resolve, or troubleshoot without first reading the relevant
+guide. Load only what the current intent requires; don't read them all up front.
+
+| Intent | File to read | When to load |
+| --- | --- | --- |
+| Filing, tracking, replying, resolving a case | `references/filing-and-tracking-cases.md` | **Always** before filing, replying, tracking, or resolving. Contains the required 4-step workflow, case body template, severity mapping, tool arguments, and attachment rules. |
+| Backend selection, onboarding, IAM/permissions, troubleshooting | `references/setup.md` | **Always** before handling access errors, `AccessDenied`, `SubscriptionRequiredException`, server connection failures, or when user asks about setup/configuration. Contains backend fallback logic and the admin email template. |
+| Capturing diagnostics, secrets reminder, attaching logs | `references/case-safety-and-diagnostics.md` | **Always** when filing a case. Contains the auto-capture workflow, session lookup, debug log location, attachment size rules, and secrets reminder. |
+
+**Filing a case requires reading TWO files:**
+1. Read `references/filing-and-tracking-cases.md` for the workflow and template.
+2. Read `references/case-safety-and-diagnostics.md` for diagnostics collection.
+
+Follow both fully. In particular: always offer `capture these` to auto-gather session data and
+debug logs before drafting the case body. Do not skip diagnostics gathering.
+
+---
+
+## Licenses
+
+This power integrates with the [AWS Support MCP Server](https://github.com/awslabs/mcp) (`awslabs.aws-support-mcp-server`, Apache-2.0 license).
+
+This power integrates with [MCP Proxy for AWS](https://github.com/aws/mcp-proxy-for-aws) (`mcp-proxy-for-aws`, the `aws-mcp` / Agent Toolkit backend, Apache-2.0 license).
+
+The reference files and `SKILL.md` are original content authored by the power author and are distributed as part of this power.
+
+## Telemetry
+
+- **Primary backend** (`awslabs.aws-support-mcp-server`): no client-side telemetry is documented or collected by the server.
+- **Fallback backend** (`mcp-proxy-for-aws`): collects telemetry by default. This power ships with
+  `--disable-telemetry` set in [`mcp.json`](../../mcp.json), so telemetry is off out of the box. To re-enable it,
+  remove that flag from the `aws-mcp` args and reconnect the server.
+- This power itself adds no additional telemetry, analytics, or usage tracking.
+
+## Privacy
+
+- **What leaves your machine:** only the AWS Support case content you approve — subject, severity,
+  category, body, and any attachment you explicitly add — sent to the AWS Support API using your own
+  AWS credentials. Nothing is filed, replied to, or resolved without your confirmation.
+- **Local reads are opt-in:** the power reads local Kiro session data (`~/.kiro/sessions/…`) and
+  workspace debug logs (`.kiro/debug/`) only when you say `capture these`. It announces the read
+  before touching the filesystem.
+- **Secrets:** the power reminds you to strip secrets (passwords, tokens, keys) from logs before
+  they're included in a case. Review case content before approving.
+- **No third parties:** the power sends data only to the AWS Support API via your credentials; it
+  does not transmit your code, logs, or session data to any other endpoint.

--- a/kiro-support/skills/kiro-support/references/case-safety-and-diagnostics.md
+++ b/kiro-support/skills/kiro-support/references/case-safety-and-diagnostics.md
@@ -1,0 +1,192 @@
+# Case Safety and Diagnostics
+
+What to gather, how to attach, and the one rule about secrets.
+
+---
+
+## Secrets reminder
+
+When the user shares logs or a debug zip, remind them **once**:
+
+> If there are secrets in the logs (passwords, tokens, API keys, private keys), remove them before shipping.
+
+Safe to include: AWS Account IDs, ARNs, Conversation IDs, error messages, stack traces, Kiro version, OS, timestamps, regions.
+
+---
+
+## Diagnostics to collect
+
+You know the OS from system context — don't ask. Batch all asks into one message.
+
+| Item | How | Required |
+| --- | --- | --- |
+| Conversation ID | From local session data (see auto-capture) or user pastes it | Always |
+| Kiro version | Help → About (not in session data) | Always |
+| Debug logs | `.kiro/debug/debug.log` (plain text, preferred) or the zip (Cmd+Shift+P → "Create Debug Log Zip") | Recommended for crashes/errors |
+| Repro steps | Steps → expected → actual → frequency | Always (if reproducible) |
+| Error messages | Verbatim | If any |
+
+When you list these for the user, always offer the shortcut: **"…or just say `capture these` and
+I'll pull them from your local Kiro session data and debug logs."**
+
+---
+
+## Auto-capture (opt-in): "capture these"
+
+When the user says `capture these` (or asks you to gather the diagnostics), **announce it first**,
+then read the local filesystem — this is opt-in, so don't scan files until the user opts in:
+
+> I'll read your local Kiro session data and debug logs to capture the conversation ID, session
+> type, and version, and locate a debug zip. Nothing leaves your machine until you approve the case.
+
+### Which session? (don't assume the current one)
+
+The user may be filing from a **different conversation than the one the issue happened in**, so
+never hard-code "the current session." Read session metadata and let the user pick:
+
+1. List `~/.kiro/sessions/<workspace-hash>/sess_*/session.json`. Each file holds:
+   - `id` — the **Conversation ID** (e.g. `sess_5cebf1c0-…`)
+   - `title` — human-readable label
+   - `agentMode` — `vibe` / `spec` → **Session Type** (Vibe/Spec)
+   - `autopilot` — `true`/`false` → **Autonomy** (Autopilot/Supervised)
+   - `modelId`, `workspacePaths`, `createdAt`, `lastModifiedAt`
+2. Show the most recent few (title + last-modified + workspace) and ask which one the issue
+   occurred in — unless the user already named it. Match by title/time/workspace.
+3. Pull `id`, `agentMode`, `autopilot`, `modelId` from the chosen `session.json`.
+
+### Locate debug logs
+
+Search the chosen session's `workspacePaths` for `.kiro/debug/`. Two artifacts usually live there
+(e.g. `<workspace>/.kiro/debug/debug.log`):
+
+- **`debug.log`** (plain text) — **prefer this.** Read the relevant tail (~200 lines, or the lines
+  around the error) and include it **inline** in the case body's Logs/Error section. No base64, no
+  size-limit worries.
+- **`kiroDebugLogs.zip`** — the full bundle. Only attach it when the plain log isn't enough, and
+  check the 5 MB limit in the attachment flow below first.
+
+On macOS, raw logs also live at `~/Library/Application Support/Kiro/logs/`. If neither exists, tell
+the user how to make the zip (Cmd+Shift+P → "Create Debug Log Zip") or proceed without.
+
+### Multiple errors found → confirm which one (don't guess)
+
+A `debug.log` or zip often contains **several unrelated errors** from a long session. Never assume
+which one the case is about. When you find more than one distinct error (different messages, stack
+traces, or timeframes):
+
+1. Show a short numbered list — one line each: timestamp + a one-line summary of the error.
+2. Ask the user to confirm **which specific error** they want to report.
+3. Put only the confirmed error's log lines in the case body. Ignore the rest.
+
+> I found a few distinct errors in the log — which one is this case about?
+> 1. `18:42` — MCP server `awslabs.aws-support-mcp-server` failed to connect (timeout)
+> 2. `19:03` — Uncaught TypeError in chat renderer
+> 3. `19:15` — Spec task execution aborted: tool call rejected
+>
+> Reply with the number, or tell me if it's something else.
+
+If the errors are genuinely separate problems the user wants tracked, follow **one issue per
+case** — file the confirmed one now and offer to file the others as their own cases.
+
+### What you still can't auto-capture
+
+- **Kiro version** — not in `session.json`; get it from the debug zip metadata or ask (Help → About).
+- **Repro steps / error text / impact** — always from the user.
+
+Report what you captured in a compact list, then continue to the remaining questions (version,
+severity, repro) in one message.
+
+### Crash type clarification (ask inline if user says "crash"/"freeze"/"hang")
+
+| Type | Key diagnostic |
+| --- | --- |
+| IDE crash (process closes) | Debug Log Zip essential |
+| Freeze/hang (IDE open, stuck) | Debug Log Zip + Conversation ID |
+| Agent hang (IDE fine) | Output panel logs + Conversation ID |
+| Feature broken | Conversation ID + repro steps |
+
+### Debug zip handling
+
+| User says | Action |
+| --- | --- |
+| Gives a path | Note it. Don't read/encode until filing time. |
+| "Done" / "generated it" (no path) | Search `.kiro/debug/` for recent zip. Confirm with user. |
+| "Skip" / "no zip" | Proceed without. Note in body: "Debug Log Zip: not attached." |
+
+---
+
+## Attachment flow
+
+### Prefer inline logs over attachments
+
+`add_attachments_to_set` only accepts files **under 5 MB** and requires base64 encoding — usually
+overkill. **Default to pasting the relevant slice of `debug.log` inline** in the case body. Attach
+a file only when it's genuinely needed (a binary, or a full zip support explicitly asks for) **and**
+it's under 5 MB. If `kiroDebugLogs.zip` exceeds 5 MB, don't attach it — extract the relevant
+`debug.log` lines inline instead, or wait for support to request specific logs.
+
+**If attachment fails or is unavailable for any reason**, always fall back to reading the logs
+directly and including the relevant lines inline. This is the primary diagnostic delivery method —
+attachments are a convenience, not a requirement.
+
+### Log extraction strategy (use this FIRST, before attempting full-file attachment)
+
+Full debug zips and large log files are almost always too large for the `add_attachments_to_set`
+tool argument limit (~30KB of base64 in a single tool call). **Do not attempt to attach full zips
+or large files directly.** Instead:
+
+1. **Extract relevant lines first.** Use `grep` with error-related patterns against the log file:
+   ```
+   grep -B2 -A2 "error\|abort\|failed\|ECONNRESET\|Stream error" <logfile> > /tmp/extract.log
+   ```
+2. **Check the extract size.** If `/tmp/extract.log` is under ~50KB, base64 it and attach as a
+   small `.log` file via `add_attachments_to_set`. This usually succeeds.
+3. **If still too large**, trim further (last 100 relevant lines) or paste the key lines directly
+   into the case body's Error Messages section.
+4. **Only attempt full zip attachment** if the extract is insufficient AND the zip is under 200KB
+   AND the user explicitly requests attaching the full file.
+
+This approach avoids the common failure mode where the agent tries to base64-encode a 275KB+ zip,
+hits tool argument limits, gets stuck retrying, and wastes multiple turns.
+
+### When you do attach (non-negotiable order)
+
+**ATTACH FIRST, THEN FILE.** One uninterrupted sequence (file must be < 5 MB):
+
+1. `add_attachments_to_set(attachments=[{"fileName": "kiroDebugLogs.zip", "data": "<base64>"}])` — encode inside this call.
+2. Get `attachmentSetId` from response.
+3. **Immediately** call `create_support_case(..., attachment_set_id=<id>)`.
+
+### What NOT to do
+
+- Pre-encode the file in an earlier step.
+- Upload early, do other work, then file later (set expires ~1 hour).
+- File first intending to attach later (impossible).
+
+### Attachment failure or timeout fallback
+
+If `add_attachments_to_set` fails, times out, or gets stuck (no response within ~30 seconds):
+
+1. **Try the fallback server.** If using the primary (`awslabs.aws-support-mcp-server`), retry the
+   upload via `aws-mcp` using the CLI equivalent:
+   `aws support add-attachments-to-set --attachments fileName=kiroDebugLogs.zip,data=<base64> --region us-east-1`
+2. **If fallback also fails or is unavailable**, abandon the attachment and collect logs inline:
+   - Read the tail of `.kiro/debug/debug.log` (~200 lines) or `~/Library/Application Support/Kiro/logs/`
+   - Search for lines matching the user's reported error (timestamps, stack traces, error messages)
+   - If multiple errors exist, show a numbered list and confirm which one to include
+   - Paste the relevant log lines directly into the case body's Diagnostics section
+3. **File the case without the attachment.** Add a note in the body:
+   `"Debug Log Zip: attachment upload failed — relevant log lines included inline below."`
+4. **Tell the user.** Let them know the attachment didn't go through, the relevant logs were
+   included inline, and they can manually attach the zip later via the AWS Support Console if needed.
+
+Never block case filing on a stuck attachment. The inline log is always sufficient for initial triage.
+
+---
+
+## What NOT to include in cases
+
+- Full log dumps (trim `debug.log` to ~200 relevant lines and paste inline)
+- Entire workspace trees or source code
+- `.env` files or secrets
+- Other users' session data

--- a/kiro-support/skills/kiro-support/references/filing-and-tracking-cases.md
+++ b/kiro-support/skills/kiro-support/references/filing-and-tracking-cases.md
@@ -1,0 +1,197 @@
+# Filing and Tracking Support Cases
+
+Workflow for filing, tracking, replying to, and resolving cases. For backend/IAM/setup, see
+[setup](setup.md). For diagnostics/secrets, see
+[case-safety-and-diagnostics](case-safety-and-diagnostics.md).
+
+## Routing
+
+| Intent | Action |
+| --- | --- |
+| Raise a case | [File a Case](#file-a-case) |
+| Track / status | `describe_support_cases` |
+| Read history | `describe_communications` |
+| Reply | `add_communication_to_case` |
+| Resolve | `resolve_support_case` (confirm first) |
+| Check access | Step 1 probe; if denied → [Admin Setup](setup.md#admin-setup) |
+
+## MCP Tools
+
+Server: `awslabs.aws-support-mcp-server`. All arguments use **`snake_case`** (not camelCase).
+
+| Tool | Purpose |
+| --- | --- |
+| `describe_support_cases` | List/search cases — also the read-only access probe |
+| `describe_services` | List services + category codes |
+| `describe_create_case_options` | Valid categories/severities for a service |
+| `describe_severity_levels` | List severity levels + SLAs |
+| `create_support_case` | File a case |
+| `describe_communications` | Case communication history |
+| `add_communication_to_case` | Reply to a case |
+| `resolve_support_case` | Close a case |
+| `add_attachments_to_set` | Upload files → returns `attachmentSetId` |
+
+### `create_support_case` arguments
+
+| Arg | Required | Notes |
+| --- | --- | --- |
+| `subject` | Yes | Short, specific |
+| `service_code` | Yes | From `describe_services` |
+| `category_code` | Yes | From `describe_create_case_options` |
+| `severity_code` | Yes | `low`/`normal`/`high`/`urgent`/`critical` |
+| `communication_body` | Yes | Structured body (template below) |
+| `issue_type` | No | `technical` (default) or `customer-service` |
+| `attachment_set_id` | No | From `add_attachments_to_set` |
+
+### Toolkit fallback (CLI)
+
+When using `aws-mcp`, issue `aws support <command> --region us-east-1`. Use `kebab-case` flags.
+
+| Dedicated tool | CLI equivalent |
+| --- | --- |
+| `describe_severity_levels` | `aws support describe-severity-levels --region us-east-1` |
+| `describe_services` | `aws support describe-services --region us-east-1` |
+| `create_support_case` | `aws support create-case --subject .. --service-code .. --category-code .. --severity-code .. --communication-body .. --region us-east-1` |
+| `describe_support_cases` | `aws support describe-cases --region us-east-1` |
+| `describe_communications` | `aws support describe-communications --case-id .. --region us-east-1` |
+| `add_communication_to_case` | `aws support add-communication-to-case --case-id .. --communication-body .. --region us-east-1` |
+| `resolve_support_case` | `aws support resolve-case --case-id .. --region us-east-1` |
+
+---
+
+## File a Case
+
+**Target: 3 turns max** (user describes → agent asks one follow-up → user confirms → filed).
+
+### Step 1 — Verify access (silent, fast)
+
+1. Check `mcp.json` has a real `AWS_PROFILE` (not the placeholder). If missing, ask user to set it.
+2. Call `describe_support_cases` as a probe (same read-only probe used on activation).
+   - Succeeds → continue.
+   - Server unavailable → fall back to toolkit (see [setup](setup.md)).
+   - `AccessDenied` → route to [Admin Setup](setup.md#admin-setup). Stop.
+   - `SubscriptionRequiredException` → tell user account needs Business+ plan. Stop.
+
+### Step 2 — Gather info (ONE batched message)
+
+From the user's initial description, identify what you already have and what's missing. Ask for everything missing in **one message**, and close with the capture shortcut:
+
+> I need a few things to file this:
+> 1. **Conversation ID** — the session where the issue happened
+> 2. **Kiro version** — Help → About
+> 3. **Severity** — Low (24h) / Normal (12h) / High (4h) / Urgent (1h)?
+> 4. **Steps to reproduce** — and the exact error text if you have it
+> 5. **Debug logs** *(optional)* — path to `.kiro/debug/debug.log` or a zip
+>
+> Or just say **`capture these`** and I'll collect them from your machine.
+
+Skip any item the user already provided. Don't ask for OS (you know it).
+
+If they mention "crash"/"freeze"/"hang" — clarify which type in the same message (IDE crash vs freeze vs agent hang).
+
+### Step 3 — Discover codes + build case (no user interaction needed)
+
+1. Call `describe_services` → find the Kiro service code.
+2. Call `describe_create_case_options` → get valid category/severity.
+3. Map issue to category:
+
+   | Issue type | Category |
+   | --- | --- |
+   | Completions, chat, inline suggestions | Chat / IDE |
+   | Install, auth, login, config | Setup |
+   | CLI issues | CLI |
+   | Steering not loading | Steering |
+   | Powers / MCP in a power | Powers |
+   | Hooks | Hooks / Extensions |
+   | MCP connections/tools | MCP |
+   | Specs / task execution | Specs |
+   | Feature requests | Feature Request |
+   | Other | General Guidance |
+
+   This table is a mapping *hint* only. The valid codes returned by `describe_create_case_options`
+   are authoritative — if they conflict with this table, use the API's codes.
+
+4. If user's stated severity doesn't match their described impact, flag it in one line and let them decide.
+5. If captured logs surfaced **more than one distinct error**, confirm which one the case is about
+   before building the body — see [multiple errors found](case-safety-and-diagnostics.md#multiple-errors-found--confirm-which-one-dont-guess).
+   One issue per case.
+
+### Step 4 — Confirm and file (one message)
+
+Present the case summary for approval:
+
+> **Subject:** `<subject>`
+> **Severity:** `<severity>` (SLA: Xh)
+> **Category:** `<service/category>`
+>
+> **Body:**
+> ```
+> <formatted body>
+> ```
+>
+> File this? (If you have a debug zip, remind me of the path.)
+
+On "yes":
+- **With attachment:** `add_attachments_to_set` → get `attachmentSetId` → immediately `create_support_case` with that ID. No other calls between.
+- **Without attachment:** `create_support_case` directly.
+
+Return the case ID. Done.
+
+### Attachment rules (non-negotiable)
+
+- Upload → file in one uninterrupted sequence.
+- Encode the file inside `add_attachments_to_set` — never pre-encode in a separate step.
+- Never file first intending to attach later.
+- If user said "done" without a path, search `.kiro/debug/` for a recent zip before asking.
+- Remind user once to strip secrets from logs before shipping.
+
+---
+
+## Severity mapping
+
+| Impact | Code | SLA (Business) |
+| --- | --- | --- |
+| General question / feature request | `low` | 24h |
+| Non-critical, workaround exists | `normal` | 12h |
+| Something isn't working right | `high` | 4h |
+| Blocked / production impact | `urgent` | 1h |
+| Critical system down (Enterprise only) | `critical` | 15 min |
+
+---
+
+## Case body template
+
+```
+## Issue Description
+<what happened, what was expected>
+
+## Environment
+- Kiro Version: <version>
+- OS: <platform>
+- Session Type: <Vibe/Spec>
+- Conversation ID: <id>
+
+## Steps to Reproduce
+1. <step>
+2. <step>
+
+Expected: <expected>
+Actual: <actual>
+Frequency: <always / intermittent / one-time>
+
+## Error Messages
+<exact text>
+
+## Diagnostics Attached
+- Debug Log Zip: <attached / not attached>
+
+## Additional Context
+<patterns, recent changes, workarounds tried; "None." if none>
+```
+
+## Tracking and follow-up
+
+- **List cases:** `describe_support_cases`
+- **Read history:** `describe_communications` — show chronologically.
+- **Reply:** `add_communication_to_case` — remind to strip secrets from new logs. Attach with same two-step flow.
+- **Resolve:** `resolve_support_case` — confirm with user first. Cases can be reopened within 7 days.

--- a/kiro-support/skills/kiro-support/references/setup.md
+++ b/kiro-support/skills/kiro-support/references/setup.md
@@ -1,0 +1,121 @@
+# Setup
+
+How this power reaches the AWS Support API, onboarding, and fixing common failures.
+
+---
+
+## Backends
+
+| Backend | Server key | How it works | Default |
+| --- | --- | --- | --- |
+| **Primary** | `awslabs.aws-support-mcp-server` | Typed MCP tools | enabled |
+| **Fallback** | `aws-mcp` | `aws support …` CLI via toolkit | disabled |
+
+Both use the **same IAM permissions** (`support:*`) and require Business+ support plan.
+
+### When to fall back
+
+| Failure | Action |
+| --- | --- |
+| Server won't start / not connected / blocked | **Fall back** to toolkit |
+| `AccessDenied` | **Don't fall back** → Admin Setup below |
+| `SubscriptionRequiredException` | **Don't fall back** → account needs Business+ |
+
+To enable fallback: set `"disabled": false` on `aws-mcp` in `mcp.json`, set same `AWS_PROFILE`, reconnect.
+
+---
+
+## Prerequisites
+
+- **Support plan:** Business, Enterprise On-Ramp, or Enterprise.
+- **IAM:** `support:*` via `AWSSupportAccess` managed policy or custom policy below.
+- **`uvx`** installed ([install guide](https://docs.astral.sh/uv/getting-started/installation/)).
+- **Python 3.10+** for the dedicated server.
+
+---
+
+## Onboarding
+
+### Admin (one-time, ~15 min)
+
+1. Create SSO Permission Set with Support API access (Option A or B below).
+2. Assign to Kiro developer group on the account with the Kiro subscription.
+3. Confirm account is on Business+ support.
+4. Share: SSO start URL, account ID, permission set name.
+
+### Developer
+
+**One-time setup:**
+
+1. `aws configure sso` — use SSO URL and account from admin.
+2. Set `AWS_PROFILE` and `AWS_REGION` in this power's `mcp.json`, reconnect server.
+
+**Per-session (recurs):**
+
+3. `aws sso login --profile <profile>` — SSO tokens expire, so re-run when the session lapses (typically daily).
+4. Verify: "List my open Kiro support cases." Empty list = success.
+
+---
+
+## Admin Setup
+
+When probe returns `AccessDenied`, the user needs this grant. Offer to draft the admin request.
+
+### Option A — Managed policy (simple)
+
+Attach `AWSSupportAccess` (`arn:aws:iam::aws:policy/AWSSupportAccess`). Grants `support:*` + `support-console:*`.
+
+### Option B — Custom least-privilege (recommended)
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Sid": "AllowKiroSupportCaseManagement",
+    "Effect": "Allow",
+    "Action": [
+      "support:CreateCase",
+      "support:DescribeCases",
+      "support:DescribeCommunications",
+      "support:AddCommunicationToCase",
+      "support:AddAttachmentsToSet",
+      "support:DescribeAttachment",
+      "support:DescribeServices",
+      "support:DescribeSeverityLevels",
+      "support:DescribeCreateCaseOptions",
+      "support:DescribeSupportedLanguages",
+      "support:ResolveCase"
+    ],
+    "Resource": "*"
+  }]
+}
+```
+
+`Resource: "*"` is expected — Support actions don't support resource-level scoping.
+
+---
+
+## MCP Config
+
+Both servers ship with `AWS_PROFILE` placeholder — **no default**. User must set it before filing.
+
+- Set `AWS_PROFILE` to their profile name in `mcp.json`.
+- `AWS_REGION` should be `us-east-1` (Support API global endpoint).
+- Reconnect server after editing.
+
+---
+
+## Troubleshooting
+
+| Symptom | Fix |
+| --- | --- |
+| `SubscriptionRequiredException` | Account not on Business+. Route to admin. |
+| `AccessDenied` | Missing `support:*`. Use Admin Setup above. |
+| Server won't start | Check `uvx --version`, `uv python install 3.10`, valid `AWS_PROFILE`. |
+| "Server not connected" | Retry once (init delay). If persistent: `aws sso login`, reconnect. |
+| `InvalidParameterValueException` | Invalid code combo. Re-run `describe_create_case_options`. |
+| "unexpected keyword argument" | Using camelCase. Switch to `snake_case`. |
+| `ExpiredTokenException` | `aws sso login --profile <profile>`, reconnect. |
+| `CaseIdNotFound` | Wrong account or invalid ID. Run `describe_support_cases` to list valid IDs. |
+| Toolkit `AccessDenied` | Profile lacks `support:*`. Same fix as dedicated server. |
+| Toolkit wrong region | Pass `--region us-east-1` on every command. |


### PR DESCRIPTION
## Summary

Add the kiro-support power using the Agent Plugins v1.0.0 specification format. This is the same power as #189 but migrated from the legacy POWER.md format to the portable agent-plugins standard (`plugin.json` + `skills/` + `mcp.json`).

## What this power does

File and manage AWS Support cases for Kiro issues directly from the IDE. Collects diagnostics and verifies Support API access with a read-only probe before any write, and never files, replies to, or resolves a case without explicit user approval.

Backends: `awslabs.aws-support-mcp-server` (primary) and `mcp-proxy-for-aws` / Agent Toolkit (fallback, telemetry disabled).

## Structure

```
kiro-support/
├── plugin.json
├── mcp.json
└── skills/
    └── kiro-support/
        ├── SKILL.md
        └── references/
            ├── filing-and-tracking-cases.md
            ├── setup.md
            └── case-safety-and-diagnostics.md
```

## Key differences from #189

- Uses `plugin.json` manifest instead of POWER.md frontmatter
- `mcp.json` has `$schema` and `type: stdio` per the Agent Plugins spec
- Removed Kiro-specific `disabled`/`autoApprove` fields from mcp.json
- Steering files moved to `skills/kiro-support/references/`
- All content preserved verbatim — only structural migration + improved attachment fallback instructions

## Testing

- Installed locally via Kiro Powers UI
- Verified skill activation on keyword match
- Verified reference file loading
- Tested case filing end-to-end with diagnostics auto-capture
- Tested attachment fallback (extract → small file attach)

## Related

Supersedes #189