### PR TITLE
chore(stackgen): retitle listing to Aiden for InfraOps

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Documentation is available at https://kiro.dev/docs/powers/
 ---
 
 ### stackgen
-**Aiden for Infrastructure** - Design, manage, and deploy cloud infrastructure with StackGen - create appstacks, manage resources, configure environments, and push IaC to Git. Supports AWS, Azure, and GCP.
+**Aiden for InfraOps** - Design, manage, and deploy cloud infrastructure with StackGen - create appstacks, manage resources, configure environments, and push IaC to Git. Supports AWS, Azure, and GCP.
 
 **MCP Servers:** stackgen (CLI stdio)
 

--- a/stackgen/POWER.md
+++ b/stackgen/POWER.md
@@ -1,6 +1,6 @@
 ---
 name: "stackgen"
-displayName: "Aiden for Infrastructure"
+displayName: "Aiden for InfraOps"
 description: "Build, Operate, Observe, and Remediate with Aiden — Aiden for Infrastructure Kiro power specifically to create appstacks, manage resources, configure environments, and push IaC to Git. Deploy to AWS, Azure, and GCP. Deployment Runners. ServiceNow integration."
 keywords: ["infrastructure", "iac", "cloud", "terraform", "opentofu", "aws", "azure", "gcp", "devops", "deployment", "stackgen", "appstack", "deploy", "servicenow", "change request", "chg", "aiden", "audit", "compliance"]
 author: "StackGen"


### PR DESCRIPTION
## Summary
- Rename the marketplace/UI listing from **Aiden for Infrastructure** to **Aiden for InfraOps**
- Power id stays `stackgen` (folder, MCP namespace `power-stackgen-stackgen` unchanged)

## Changes
- `stackgen/POWER.md`: `displayName` only
- `README.md`: listing title only
